### PR TITLE
fix: pass workspace_id=dev on file operations, remove toggle_dev_mode (ULT-1596)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: uv run pyright
 
   test:
-    name: Test (Python ${{ matrix.python-version }})
+    name: Test (${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-03-17
+
+### Fixed
+
+- File operations (`list_project_files`, `get_file`, `create_file`, `update_file`,
+  `delete_file`) now pass `workspace_id=dev` query parameter, fixing 404 errors on
+  dev-mode endpoints.
+- Added `params` argument to `LookerSession.post()`, `.patch()`, `.put()`, and
+  `.delete()` methods (`.get()` already had it).
+
+### Removed
+
+- `toggle_dev_mode` tool — sessions are ephemeral (per tool call), so `PATCH /session`
+  had no lasting effect. File operations now handle workspace context automatically.
+
 ## [0.1.1] - 2026-03-01
 
 ### Fixed
@@ -37,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
-[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ultrathink-solutions/looker-mcp-server/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **schema**\* | `list_databases`, `list_schemas`, `list_tables`, `list_columns` | Inspect underlying database schema |
 | **content**\* | `list_looks`, `create_look`, `update_look`, `delete_look`, `list_dashboards`, `create_dashboard`, `update_dashboard`, `delete_dashboard`, `add_dashboard_element`, `add_dashboard_filter`, `generate_embed_url` | Manage Looks and dashboards |
 | **health**\* | `health_pulse`, `health_analyze`, `health_vacuum` | Instance health checks and usage analysis |
-| **modeling** | `list_projects`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `toggle_dev_mode`, `validate_project` | Edit LookML files and validate syntax |
+| **modeling** | `list_projects`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project` | Edit LookML files and validate syntax |
 | **git** | `get_git_branch`, `list_git_branches`, `create_git_branch`, `switch_git_branch`, `deploy_to_production`, `reset_to_production` | Git operations and production deployment |
 | **admin** | `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`, `list_roles`, `create_role`, `list_groups`, `add_group_user`, `remove_group_user`, `list_schedules`, `create_schedule`, `delete_schedule` | User, role, group, and schedule management |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.1.1"
+version = "0.1.2"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -54,25 +54,32 @@ class LookerSession:
         self,
         path: str,
         body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> Any:
-        return await self._request("POST", path, json=body)
+        return await self._request("POST", path, params=params, json=body)
 
     async def patch(
         self,
         path: str,
         body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> Any:
-        return await self._request("PATCH", path, json=body)
+        return await self._request("PATCH", path, params=params, json=body)
 
     async def put(
         self,
         path: str,
         body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
     ) -> Any:
-        return await self._request("PUT", path, json=body)
+        return await self._request("PUT", path, params=params, json=body)
 
-    async def delete(self, path: str) -> None:
-        await self._request("DELETE", path)
+    async def delete(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> None:
+        await self._request("DELETE", path, params=params)
 
     async def _request(
         self,

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -1,8 +1,9 @@
 """Modeling tool group — LookML development.
 
-Tools for browsing and editing LookML files, toggling dev mode,
-and validating LookML syntax.  Does NOT include Git operations or
-deployment — those are in the ``git`` tool group.
+Tools for browsing and editing LookML files and validating LookML syntax.
+File operations automatically use dev-mode workspace context.
+Does NOT include Git operations or deployment — those are in the ``git``
+tool group.
 """
 
 from __future__ import annotations
@@ -13,6 +14,11 @@ from typing import Annotated
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
+
+# Looker's file endpoints are dev-mode-only and require an explicit
+# workspace_id query parameter.  Sessions are ephemeral (per tool call),
+# so PATCH /session workspace state does not persist across calls.
+_DEV_PARAMS: dict[str, str] = {"workspace_id": "dev"}
 
 
 def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
@@ -36,14 +42,14 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         except Exception as e:
             return format_api_error("list_projects", e)
 
-    @server.tool(description="List all LookML files in a project.")
+    @server.tool(description="List all LookML files in a project (dev workspace).")
     async def list_project_files(
         project_id: Annotated[str, "LookML project ID"],
     ) -> str:
         ctx = client.build_context("list_project_files", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                files = await session.get(f"/projects/{project_id}/files")
+                files = await session.get(f"/projects/{project_id}/files", params=_DEV_PARAMS)
                 result = [
                     {
                         "id": f.get("id"),
@@ -59,7 +65,9 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
             return format_api_error("list_project_files", e)
 
     @server.tool(
-        description="Read the contents of a LookML file. Returns the full source code.",
+        description=(
+            "Read the contents of a LookML file (dev workspace). Returns the full source code."
+        ),
     )
     async def get_file(
         project_id: Annotated[str, "LookML project ID"],
@@ -70,16 +78,15 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("get_file", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                file_info = await session.get(f"/projects/{project_id}/files/{file_id}")
+                file_info = await session.get(
+                    f"/projects/{project_id}/files/{file_id}", params=_DEV_PARAMS
+                )
                 return json.dumps(file_info, indent=2)
         except Exception as e:
             return format_api_error("get_file", e)
 
     @server.tool(
-        description=(
-            "Create a new LookML file in a project. Requires dev mode to be "
-            "enabled first (use toggle_dev_mode)."
-        ),
+        description="Create a new LookML file in a project (dev workspace).",
     )
     async def create_file(
         project_id: Annotated[str, "LookML project ID"],
@@ -89,10 +96,10 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("create_file", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                # The Looker API uses the file_id in the path and content in the body.
                 file_info = await session.post(
                     f"/projects/{project_id}/files/{file_id}",
                     body={"id": file_id, "content": content},
+                    params=_DEV_PARAMS,
                 )
                 return json.dumps(
                     {"created": True, "id": file_info.get("id") if file_info else file_id},
@@ -102,9 +109,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
             return format_api_error("create_file", e)
 
     @server.tool(
-        description=(
-            "Update the content of an existing LookML file. Requires dev mode to be enabled first."
-        ),
+        description="Update the content of an existing LookML file (dev workspace).",
     )
     async def update_file(
         project_id: Annotated[str, "LookML project ID"],
@@ -117,6 +122,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
                 file_info = await session.patch(
                     f"/projects/{project_id}/files/{file_id}",
                     body={"content": content},
+                    params=_DEV_PARAMS,
                 )
                 return json.dumps(
                     {"updated": True, "id": file_info.get("id") if file_info else file_id},
@@ -126,7 +132,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
             return format_api_error("update_file", e)
 
     @server.tool(
-        description="Delete a LookML file from a project. Requires dev mode.",
+        description="Delete a LookML file from a project (dev workspace).",
     )
     async def delete_file(
         project_id: Annotated[str, "LookML project ID"],
@@ -135,36 +141,10 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("delete_file", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/projects/{project_id}/files/{file_id}")
+                await session.delete(f"/projects/{project_id}/files/{file_id}", params=_DEV_PARAMS)
                 return json.dumps({"deleted": True, "file_id": file_id}, indent=2)
         except Exception as e:
             return format_api_error("delete_file", e)
-
-    @server.tool(
-        description=(
-            "Toggle the current session into or out of LookML dev mode. "
-            "Dev mode is required for creating, editing, or deleting LookML files. "
-            "Changes in dev mode are not visible to other users until deployed."
-        ),
-    )
-    async def toggle_dev_mode(
-        enable: Annotated[bool, "True to enter dev mode, False to exit"] = True,
-    ) -> str:
-        ctx = client.build_context("toggle_dev_mode", "modeling")
-        try:
-            async with client.session(ctx) as session:
-                result = await session.patch(
-                    "/session",
-                    body={"workspace_id": "dev" if enable else "production"},
-                )
-                workspace = (
-                    result.get("workspace_id") if result else ("dev" if enable else "production")
-                )
-                return json.dumps(
-                    {"dev_mode": workspace == "dev", "workspace": workspace}, indent=2
-                )
-        except Exception as e:
-            return format_api_error("toggle_dev_mode", e)
 
     @server.tool(
         description=(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -72,6 +72,82 @@ class TestLookerSession:
             result = await session.delete("/resource/1")
             assert result is None
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_with_params(self):
+        api_url = "https://test.looker.com/api/4.0"
+        route = respx.get(f"{api_url}/projects/myproj/files").mock(
+            return_value=httpx.Response(200, json=[{"id": "test.lkml"}])
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            result = await session.get("/projects/myproj/files", params={"workspace_id": "dev"})
+            assert result == [{"id": "test.lkml"}]
+            assert "workspace_id=dev" in str(route.calls[0].request.url)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_post_with_params(self):
+        api_url = "https://test.looker.com/api/4.0"
+        route = respx.post(f"{api_url}/projects/myproj/files/new.lkml").mock(
+            return_value=httpx.Response(200, json={"id": "new.lkml"})
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            result = await session.post(
+                "/projects/myproj/files/new.lkml",
+                body={"content": "view: test {}"},
+                params={"workspace_id": "dev"},
+            )
+            assert result["id"] == "new.lkml"
+            assert "workspace_id=dev" in str(route.calls[0].request.url)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_patch_with_params(self):
+        api_url = "https://test.looker.com/api/4.0"
+        route = respx.patch(f"{api_url}/projects/myproj/files/test.lkml").mock(
+            return_value=httpx.Response(200, json={"id": "test.lkml"})
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            result = await session.patch(
+                "/projects/myproj/files/test.lkml",
+                body={"content": "updated"},
+                params={"workspace_id": "dev"},
+            )
+            assert result["id"] == "test.lkml"
+            assert "workspace_id=dev" in str(route.calls[0].request.url)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_put_with_params(self):
+        api_url = "https://test.looker.com/api/4.0"
+        route = respx.put(f"{api_url}/projects/myproj/files/test.lkml").mock(
+            return_value=httpx.Response(200, json={"id": "test.lkml"})
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            result = await session.put(
+                "/projects/myproj/files/test.lkml",
+                body={"content": "updated"},
+                params={"workspace_id": "dev"},
+            )
+            assert result["id"] == "test.lkml"
+            assert "workspace_id=dev" in str(route.calls[0].request.url)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_with_params(self):
+        api_url = "https://test.looker.com/api/4.0"
+        route = respx.delete(f"{api_url}/projects/myproj/files/old.lkml").mock(
+            return_value=httpx.Response(204)
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            await session.delete("/projects/myproj/files/old.lkml", params={"workspace_id": "dev"})
+            assert "workspace_id=dev" in str(route.calls[0].request.url)
+
 
 class TestLookerClientApiKey:
     @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

- File operations (`list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`) returned HTTP 404 because they lacked the required `workspace_id=dev` query parameter on Looker's dev-mode endpoints
- `toggle_dev_mode` was a no-op — sessions are ephemeral (created/destroyed per tool call), so `PATCH /session` workspace state never persisted across invocations. Removed the tool; file operations now handle workspace context automatically via `_DEV_PARAMS`
- Added `params` argument to `LookerSession.post()`, `.patch()`, `.put()`, and `.delete()` — previously only `.get()` supported query parameters

## Test plan

- [x] All 42 existing tests pass
- [x] 4 new tests verify `workspace_id=dev` is sent as query param on GET, POST, PATCH, DELETE
- [x] Ruff lint + format clean
- [ ] Manual verification against a Looker instance (list_project_files, create_file, get_file)

Closes ULT-1596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File operations now use the development workspace by default, preventing 404s in dev mode.
* **Removed**
  * Dev-mode toggle removed; workspace context is applied automatically per operation.
* **Tests**
  * Added tests validating query-parameter propagation for file-related HTTP requests.
* **Chores**
  * Project version, changelog, and README formatting updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->