### PR TITLE
feat: add board and folder tool groups (ULT-1617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-03-19
+
+### Added
+
+- **board** tool group (13 tools): full CRUD for boards, board sections, and board items
+  - `list_boards`, `get_board`, `create_board`, `update_board`, `delete_board`
+  - `get_board_section`, `create_board_section`, `update_board_section`, `delete_board_section`
+  - `get_board_item`, `create_board_item`, `update_board_item`, `delete_board_item`
+  - Input validation on `create_board_item` enforcing exactly one of `dashboard_id`, `look_id`, or `url`
+- **folder** tool group (9 tools): folder navigation, CRUD, and content listing
+  - `list_folders`, `get_folder`, `create_folder`, `update_folder`, `delete_folder`
+  - `get_folder_children`, `get_folder_ancestors`
+  - `get_folder_looks`, `get_folder_dashboards`
+- Total tool count: 56 → 78 across 10 groups
+
 ## [0.1.2] - 2026-03-17
 
 ### Fixed
@@ -52,7 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
-[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ultrathink-solutions/looker-mcp-server/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **56 tools** across 8 groups covering the full Looker API surface
+- **78 tools** across 10 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -103,6 +103,8 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **query**\* | `query`, `query_sql`, `run_look`, `run_dashboard`, `query_url`, `search_content` | Run queries through the semantic layer |
 | **schema**\* | `list_databases`, `list_schemas`, `list_tables`, `list_columns` | Inspect underlying database schema |
 | **content**\* | `list_looks`, `create_look`, `update_look`, `delete_look`, `list_dashboards`, `create_dashboard`, `update_dashboard`, `delete_dashboard`, `add_dashboard_element`, `add_dashboard_filter`, `generate_embed_url` | Manage Looks and dashboards |
+| **board** | `list_boards`, `get_board`, `create_board`, `update_board`, `delete_board`, `get_board_section`, `create_board_section`, `update_board_section`, `delete_board_section`, `get_board_item`, `create_board_item`, `update_board_item`, `delete_board_item` | Curate content with boards, sections, and items |
+| **folder** | `list_folders`, `get_folder`, `create_folder`, `update_folder`, `delete_folder`, `get_folder_children`, `get_folder_ancestors`, `get_folder_looks`, `get_folder_dashboards` | Navigate and manage the folder hierarchy |
 | **health**\* | `health_pulse`, `health_analyze`, `health_vacuum` | Instance health checks and usage analysis |
 | **modeling** | `list_projects`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project` | Edit LookML files and validate syntax |
 | **git** | `get_git_branch`, `list_git_branches`, `create_git_branch`, `switch_git_branch`, `deploy_to_production`, `reset_to_production` | Git operations and production deployment |
@@ -117,7 +119,7 @@ looker-mcp-server
 # Specific groups
 looker-mcp-server --groups explore,query
 
-# All groups (including modeling, git, admin)
+# All groups (including board, folder, modeling, git, admin)
 looker-mcp-server --groups all
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.1.2"
+version = "0.2.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -15,6 +15,8 @@ ALL_GROUPS = frozenset(
         "query",
         "schema",
         "content",
+        "board",
+        "folder",
         "modeling",
         "git",
         "admin",

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -78,8 +78,10 @@ def create_server(
     groups = enabled_groups or DEFAULT_GROUPS
 
     from .tools.admin import register_admin_tools
+    from .tools.board import register_board_tools
     from .tools.content import register_content_tools
     from .tools.explore import register_explore_tools
+    from .tools.folder import register_folder_tools
     from .tools.git import register_git_tools
     from .tools.health import register_health_tools
     from .tools.modeling import register_modeling_tools
@@ -91,6 +93,8 @@ def create_server(
         "query": register_query_tools,
         "schema": register_schema_tools,
         "content": register_content_tools,
+        "board": register_board_tools,
+        "folder": register_folder_tools,
         "modeling": register_modeling_tools,
         "git": register_git_tools,
         "admin": register_admin_tools,

--- a/src/looker_mcp_server/tools/board.py
+++ b/src/looker_mcp_server/tools/board.py
@@ -1,0 +1,318 @@
+"""Board tool group — Board, board section, and board item CRUD.
+
+Boards are Looker's content curation surface (replacing the legacy Homepage
+API).  A board contains *sections*, and each section contains *items* that
+reference dashboards, Looks, or other content.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+
+
+def register_board_tools(server: FastMCP, client: LookerClient) -> None:
+    # ── Boards ────────────────────────────────────────────────────────
+
+    @server.tool(
+        description="Search for boards by title or other criteria.",
+    )
+    async def list_boards(
+        title: Annotated[str | None, "Filter by title (partial match)"] = None,
+        limit: Annotated[int, "Maximum results"] = 50,
+    ) -> str:
+        ctx = client.build_context("list_boards", "board")
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] = {"limit": limit}
+                if title:
+                    params["title"] = title
+                boards = await session.get("/boards/search", params=params)
+                result = [
+                    {
+                        "id": b.get("id"),
+                        "title": b.get("title"),
+                        "description": b.get("description"),
+                        "created_at": b.get("created_at"),
+                        "section_order": b.get("section_order"),
+                    }
+                    for b in (boards or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_boards", e)
+
+    @server.tool(
+        description=(
+            "Get a board by ID, including its sections and items. Returns the full board structure."
+        ),
+    )
+    async def get_board(
+        board_id: Annotated[str, "ID of the board to retrieve"],
+    ) -> str:
+        ctx = client.build_context("get_board", "board", {"board_id": board_id})
+        try:
+            async with client.session(ctx) as session:
+                board = await session.get(f"/boards/{board_id}")
+                return json.dumps(board, indent=2)
+        except Exception as e:
+            return format_api_error("get_board", e)
+
+    @server.tool(
+        description="Create a new board with a title and optional description.",
+    )
+    async def create_board(
+        title: Annotated[str, "Title for the new board"],
+        description: Annotated[str | None, "Description of the board"] = None,
+    ) -> str:
+        ctx = client.build_context("create_board", "board")
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {"title": title}
+                if description:
+                    body["description"] = description
+                board = await session.post("/boards", body=body)
+                return json.dumps(
+                    {
+                        "id": board.get("id"),
+                        "title": board.get("title"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_board", e)
+
+    @server.tool(description="Update a board's title or description.")
+    async def update_board(
+        board_id: Annotated[str, "ID of the board to update"],
+        title: Annotated[str | None, "New title"] = None,
+        description: Annotated[str | None, "New description"] = None,
+    ) -> str:
+        ctx = client.build_context("update_board", "board", {"board_id": board_id})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                if title is not None:
+                    body["title"] = title
+                if description is not None:
+                    body["description"] = description
+                board = await session.patch(f"/boards/{board_id}", body=body)
+                return json.dumps(
+                    {"id": board.get("id"), "title": board.get("title")},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_board", e)
+
+    @server.tool(description="Delete a board. This action cannot be undone.")
+    async def delete_board(
+        board_id: Annotated[str, "ID of the board to delete"],
+    ) -> str:
+        ctx = client.build_context("delete_board", "board", {"board_id": board_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/boards/{board_id}")
+                return json.dumps({"deleted": True, "board_id": board_id}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_board", e)
+
+    # ── Board sections ────────────────────────────────────────────────
+
+    @server.tool(
+        description="Get a board section by ID, including its items.",
+    )
+    async def get_board_section(
+        board_section_id: Annotated[str, "ID of the board section"],
+    ) -> str:
+        ctx = client.build_context(
+            "get_board_section", "board", {"board_section_id": board_section_id}
+        )
+        try:
+            async with client.session(ctx) as session:
+                section = await session.get(f"/board_sections/{board_section_id}")
+                return json.dumps(section, indent=2)
+        except Exception as e:
+            return format_api_error("get_board_section", e)
+
+    @server.tool(
+        description="Create a new section within a board.",
+    )
+    async def create_board_section(
+        board_id: Annotated[str, "ID of the parent board"],
+        title: Annotated[str | None, "Section title"] = None,
+        description: Annotated[str | None, "Section description"] = None,
+    ) -> str:
+        ctx = client.build_context("create_board_section", "board", {"board_id": board_id})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {"board_id": board_id}
+                if title:
+                    body["title"] = title
+                if description:
+                    body["description"] = description
+                section = await session.post("/board_sections", body=body)
+                return json.dumps(
+                    {
+                        "id": section.get("id"),
+                        "title": section.get("title"),
+                        "board_id": section.get("board_id"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_board_section", e)
+
+    @server.tool(description="Update a board section's title or description.")
+    async def update_board_section(
+        board_section_id: Annotated[str, "ID of the section to update"],
+        title: Annotated[str | None, "New title"] = None,
+        description: Annotated[str | None, "New description"] = None,
+    ) -> str:
+        ctx = client.build_context(
+            "update_board_section", "board", {"board_section_id": board_section_id}
+        )
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                if title is not None:
+                    body["title"] = title
+                if description is not None:
+                    body["description"] = description
+                section = await session.patch(f"/board_sections/{board_section_id}", body=body)
+                return json.dumps(
+                    {"id": section.get("id"), "title": section.get("title")},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_board_section", e)
+
+    @server.tool(description="Delete a board section and all its items.")
+    async def delete_board_section(
+        board_section_id: Annotated[str, "ID of the section to delete"],
+    ) -> str:
+        ctx = client.build_context(
+            "delete_board_section", "board", {"board_section_id": board_section_id}
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/board_sections/{board_section_id}")
+                return json.dumps(
+                    {"deleted": True, "board_section_id": board_section_id},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_board_section", e)
+
+    # ── Board items ───────────────────────────────────────────────────
+
+    @server.tool(
+        description="Get a board item by ID.",
+    )
+    async def get_board_item(
+        board_item_id: Annotated[str, "ID of the board item"],
+    ) -> str:
+        ctx = client.build_context("get_board_item", "board", {"board_item_id": board_item_id})
+        try:
+            async with client.session(ctx) as session:
+                item = await session.get(f"/board_items/{board_item_id}")
+                return json.dumps(item, indent=2)
+        except Exception as e:
+            return format_api_error("get_board_item", e)
+
+    @server.tool(
+        description=(
+            "Add an item (dashboard, Look, or URL) to a board section. "
+            "Provide exactly one of dashboard_id, look_id, or url."
+        ),
+    )
+    async def create_board_item(
+        board_section_id: Annotated[str, "ID of the board section to add the item to"],
+        dashboard_id: Annotated[str | None, "ID of a dashboard to add"] = None,
+        look_id: Annotated[str | None, "ID of a Look to add"] = None,
+        url: Annotated[str | None, "URL to add as a link item"] = None,
+        title: Annotated[str | None, "Custom title for the item"] = None,
+        description: Annotated[str | None, "Custom description for the item"] = None,
+    ) -> str:
+        ctx = client.build_context(
+            "create_board_item", "board", {"board_section_id": board_section_id}
+        )
+        try:
+            targets = [v for v in (dashboard_id, look_id, url) if v is not None]
+            if len(targets) != 1:
+                return json.dumps(
+                    {
+                        "error": "Provide exactly one of dashboard_id, look_id, or url.",
+                        "status": 400,
+                    },
+                    indent=2,
+                )
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {"board_section_id": board_section_id}
+                if dashboard_id:
+                    body["dashboard_id"] = int(dashboard_id)
+                if look_id:
+                    body["look_id"] = int(look_id)
+                if url:
+                    body["url"] = url
+                if title:
+                    body["title"] = title
+                if description:
+                    body["description"] = description
+                item = await session.post("/board_items", body=body)
+                return json.dumps(
+                    {
+                        "id": item.get("id"),
+                        "title": item.get("title"),
+                        "board_section_id": item.get("board_section_id"),
+                        "dashboard_id": item.get("dashboard_id"),
+                        "look_id": item.get("look_id"),
+                        "url": item.get("url"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_board_item", e)
+
+    @server.tool(description="Update a board item's properties.")
+    async def update_board_item(
+        board_item_id: Annotated[str, "ID of the board item to update"],
+        title: Annotated[str | None, "New title"] = None,
+        description: Annotated[str | None, "New description"] = None,
+        board_section_id: Annotated[str | None, "Move to a different board section"] = None,
+    ) -> str:
+        ctx = client.build_context("update_board_item", "board", {"board_item_id": board_item_id})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                if title is not None:
+                    body["title"] = title
+                if description is not None:
+                    body["description"] = description
+                if board_section_id is not None:
+                    body["board_section_id"] = board_section_id
+                item = await session.patch(f"/board_items/{board_item_id}", body=body)
+                return json.dumps(
+                    {"id": item.get("id"), "title": item.get("title")},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_board_item", e)
+
+    @server.tool(description="Remove an item from a board section.")
+    async def delete_board_item(
+        board_item_id: Annotated[str, "ID of the board item to delete"],
+    ) -> str:
+        ctx = client.build_context("delete_board_item", "board", {"board_item_id": board_item_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/board_items/{board_item_id}")
+                return json.dumps(
+                    {"deleted": True, "board_item_id": board_item_id},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_board_item", e)

--- a/src/looker_mcp_server/tools/folder.py
+++ b/src/looker_mcp_server/tools/folder.py
@@ -1,0 +1,230 @@
+"""Folder tool group — Folder navigation and management.
+
+Folders organise Looker content (dashboards, Looks) into a hierarchical tree.
+These tools allow browsing, creating, updating, and deleting folders, as well
+as inspecting a folder's children and ancestry.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+
+
+def register_folder_tools(server: FastMCP, client: LookerClient) -> None:
+    # ── Folder listing & search ───────────────────────────────────────
+
+    @server.tool(
+        description="Search for folders by name or parent folder.",
+    )
+    async def list_folders(
+        name: Annotated[str | None, "Filter by folder name (partial match)"] = None,
+        parent_id: Annotated[str | None, "Filter by parent folder ID"] = None,
+        limit: Annotated[int, "Maximum results"] = 50,
+    ) -> str:
+        ctx = client.build_context("list_folders", "folder")
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] = {"limit": limit}
+                if name:
+                    params["name"] = name
+                if parent_id:
+                    params["parent_id"] = parent_id
+                folders = await session.get("/folders/search", params=params)
+                result = [
+                    {
+                        "id": f.get("id"),
+                        "name": f.get("name"),
+                        "parent_id": f.get("parent_id"),
+                        "child_count": f.get("child_count"),
+                        "dashboards_count": len(f.get("dashboards", [])),
+                        "looks_count": len(f.get("looks", [])),
+                    }
+                    for f in (folders or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_folders", e)
+
+    @server.tool(
+        description="Get a folder by ID, including metadata and content counts.",
+    )
+    async def get_folder(
+        folder_id: Annotated[str, "ID of the folder to retrieve"],
+    ) -> str:
+        ctx = client.build_context("get_folder", "folder", {"folder_id": folder_id})
+        try:
+            async with client.session(ctx) as session:
+                folder = await session.get(f"/folders/{folder_id}")
+                return json.dumps(folder, indent=2)
+        except Exception as e:
+            return format_api_error("get_folder", e)
+
+    @server.tool(
+        description="Create a new folder inside a parent folder.",
+    )
+    async def create_folder(
+        name: Annotated[str, "Name for the new folder"],
+        parent_id: Annotated[str, "ID of the parent folder"],
+    ) -> str:
+        ctx = client.build_context("create_folder", "folder")
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {"name": name, "parent_id": parent_id}
+                folder = await session.post("/folders", body=body)
+                return json.dumps(
+                    {
+                        "id": folder.get("id"),
+                        "name": folder.get("name"),
+                        "parent_id": folder.get("parent_id"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_folder", e)
+
+    @server.tool(description="Update a folder's name or move it to a different parent.")
+    async def update_folder(
+        folder_id: Annotated[str, "ID of the folder to update"],
+        name: Annotated[str | None, "New folder name"] = None,
+        parent_id: Annotated[str | None, "Move to a different parent folder"] = None,
+    ) -> str:
+        ctx = client.build_context("update_folder", "folder", {"folder_id": folder_id})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                if name is not None:
+                    body["name"] = name
+                if parent_id is not None:
+                    body["parent_id"] = parent_id
+                folder = await session.patch(f"/folders/{folder_id}", body=body)
+                return json.dumps(
+                    {
+                        "id": folder.get("id"),
+                        "name": folder.get("name"),
+                        "parent_id": folder.get("parent_id"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_folder", e)
+
+    @server.tool(
+        description=(
+            "Delete a folder. The folder must be empty (no child folders, "
+            "dashboards, or Looks). This action cannot be undone."
+        ),
+    )
+    async def delete_folder(
+        folder_id: Annotated[str, "ID of the folder to delete"],
+    ) -> str:
+        ctx = client.build_context("delete_folder", "folder", {"folder_id": folder_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/folders/{folder_id}")
+                return json.dumps({"deleted": True, "folder_id": folder_id}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_folder", e)
+
+    # ── Folder tree navigation ────────────────────────────────────────
+
+    @server.tool(
+        description=("List a folder's direct child folders. Useful for browsing the folder tree."),
+    )
+    async def get_folder_children(
+        folder_id: Annotated[str, "ID of the parent folder"],
+        limit: Annotated[int, "Maximum child folders to return"] = 50,
+    ) -> str:
+        ctx = client.build_context("get_folder_children", "folder", {"folder_id": folder_id})
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] = {"limit": limit}
+                children = await session.get(f"/folders/{folder_id}/children", params=params)
+                result = [
+                    {
+                        "id": c.get("id"),
+                        "name": c.get("name"),
+                        "parent_id": c.get("parent_id"),
+                        "child_count": c.get("child_count"),
+                    }
+                    for c in (children or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("get_folder_children", e)
+
+    @server.tool(
+        description=(
+            "Get the full ancestry chain of a folder (from root to its parent). "
+            "Useful for building breadcrumb navigation or understanding the "
+            "folder hierarchy."
+        ),
+    )
+    async def get_folder_ancestors(
+        folder_id: Annotated[str, "ID of the folder"],
+    ) -> str:
+        ctx = client.build_context("get_folder_ancestors", "folder", {"folder_id": folder_id})
+        try:
+            async with client.session(ctx) as session:
+                ancestors = await session.get(f"/folders/{folder_id}/ancestors")
+                result = [
+                    {
+                        "id": a.get("id"),
+                        "name": a.get("name"),
+                        "parent_id": a.get("parent_id"),
+                    }
+                    for a in (ancestors or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("get_folder_ancestors", e)
+
+    # ── Folder content listing ────────────────────────────────────────
+
+    @server.tool(
+        description="List all Looks saved in a specific folder.",
+    )
+    async def get_folder_looks(
+        folder_id: Annotated[str, "ID of the folder"],
+    ) -> str:
+        ctx = client.build_context("get_folder_looks", "folder", {"folder_id": folder_id})
+        try:
+            async with client.session(ctx) as session:
+                looks = await session.get(f"/folders/{folder_id}/looks")
+                result = [
+                    {
+                        "id": lk.get("id"),
+                        "title": lk.get("title"),
+                        "description": lk.get("description"),
+                    }
+                    for lk in (looks or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("get_folder_looks", e)
+
+    @server.tool(
+        description="List all dashboards saved in a specific folder.",
+    )
+    async def get_folder_dashboards(
+        folder_id: Annotated[str, "ID of the folder"],
+    ) -> str:
+        ctx = client.build_context("get_folder_dashboards", "folder", {"folder_id": folder_id})
+        try:
+            async with client.session(ctx) as session:
+                dashboards = await session.get(f"/folders/{folder_id}/dashboards")
+                result = [
+                    {
+                        "id": d.get("id"),
+                        "title": d.get("title"),
+                        "description": d.get("description"),
+                    }
+                    for d in (dashboards or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("get_folder_dashboards", e)

--- a/tests/test_board_tools.py
+++ b/tests/test_board_tools.py
@@ -1,0 +1,234 @@
+"""Tests for board tool group — boards, sections, and items."""
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerClient
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+def server_and_client(config):
+    mcp, client = create_server(config, enabled_groups={"board"})
+    return mcp, client
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    """Set up login/logout mocks for API-key auth sessions."""
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestListBoards:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_boards(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/boards/search").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "1",
+                        "title": "My Board",
+                        "description": "desc",
+                        "created_at": "2025-01-01",
+                    },
+                    {
+                        "id": "2",
+                        "title": "Board 2",
+                        "description": None,
+                        "created_at": "2025-02-01",
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_boards", "board")
+
+        try:
+            async with client.session(ctx) as session:
+                boards = await session.get("/boards/search", params={"limit": 50})
+                assert len(boards) == 2
+                assert boards[0]["title"] == "My Board"
+        finally:
+            await client.close()
+
+
+class TestCreateBoard:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_creates_board(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/boards").mock(
+            return_value=httpx.Response(200, json={"id": "10", "title": "New Board"})
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_board", "board")
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.post("/boards", body={"title": "New Board"})
+                assert result["id"] == "10"
+                assert result["title"] == "New Board"
+        finally:
+            await client.close()
+
+
+class TestDeleteBoard:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deletes_board(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/boards/5").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_board", "board", {"board_id": "5"})
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.delete("/boards/5")
+                assert result is None  # DELETE returns None
+        finally:
+            await client.close()
+
+
+class TestBoardSections:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_section(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/board_sections").mock(
+            return_value=httpx.Response(
+                200, json={"id": "20", "title": "Section 1", "board_id": "1"}
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_board_section", "board", {"board_id": "1"})
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.post(
+                    "/board_sections", body={"board_id": "1", "title": "Section 1"}
+                )
+                assert result["id"] == "20"
+                assert result["board_id"] == "1"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_section(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/board_sections/20").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_board_section", "board", {"board_section_id": "20"})
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.delete("/board_sections/20")
+                assert result is None
+        finally:
+            await client.close()
+
+
+class TestBoardItems:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_item_with_dashboard(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/board_items").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "30",
+                    "title": "Sales Dashboard",
+                    "board_section_id": "20",
+                    "dashboard_id": 42,
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_board_item", "board", {"board_section_id": "20"})
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.post(
+                    "/board_items",
+                    body={"board_section_id": "20", "dashboard_id": 42, "title": "Sales Dashboard"},
+                )
+                assert result["id"] == "30"
+                assert result["dashboard_id"] == 42
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_item(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/board_items/30").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_board_item", "board", {"board_item_id": "30"})
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.delete("/board_items/30")
+                assert result is None
+        finally:
+            await client.close()
+
+
+class TestBoardToolRegistration:
+    """Verify that board tools are registered when the group is enabled."""
+
+    def test_board_tools_registered(self, server_and_client):
+        mcp, _client = server_and_client
+        tool_names = {t.name for t in mcp._tool_manager._tools.values()}
+        expected = {
+            "list_boards",
+            "get_board",
+            "create_board",
+            "update_board",
+            "delete_board",
+            "get_board_section",
+            "create_board_section",
+            "update_board_section",
+            "delete_board_section",
+            "get_board_item",
+            "create_board_item",
+            "update_board_item",
+            "delete_board_item",
+        }
+        assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,7 +86,18 @@ class TestGroupConstants:
         assert DEFAULT_GROUPS.issubset(ALL_GROUPS)
 
     def test_all_groups_includes_expected(self):
-        expected = {"explore", "query", "schema", "content", "modeling", "git", "admin", "health"}
+        expected = {
+            "explore",
+            "query",
+            "schema",
+            "content",
+            "board",
+            "folder",
+            "modeling",
+            "git",
+            "admin",
+            "health",
+        }
         assert ALL_GROUPS == expected
 
     def test_admin_and_git_not_in_defaults(self):

--- a/tests/test_folder_tools.py
+++ b/tests/test_folder_tools.py
@@ -1,0 +1,250 @@
+"""Tests for folder tool group — folder navigation and management."""
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerClient
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+def server_and_client(config):
+    mcp, client = create_server(config, enabled_groups={"folder"})
+    return mcp, client
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    """Set up login/logout mocks for API-key auth sessions."""
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestListFolders:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_folders(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/folders/search").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "1",
+                        "name": "Shared",
+                        "parent_id": None,
+                        "child_count": 3,
+                        "dashboards": [{"id": "d1"}],
+                        "looks": [],
+                    },
+                    {
+                        "id": "2",
+                        "name": "Users",
+                        "parent_id": None,
+                        "child_count": 10,
+                        "dashboards": [],
+                        "looks": [{"id": "l1"}, {"id": "l2"}],
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_folders", "folder")
+
+        try:
+            async with client.session(ctx) as session:
+                folders = await session.get("/folders/search", params={"limit": 50})
+                assert len(folders) == 2
+                assert folders[0]["name"] == "Shared"
+                assert folders[0]["child_count"] == 3
+        finally:
+            await client.close()
+
+
+class TestCreateFolder:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_creates_folder(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/folders").mock(
+            return_value=httpx.Response(
+                200, json={"id": "5", "name": "New Folder", "parent_id": "1"}
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_folder", "folder")
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.post(
+                    "/folders", body={"name": "New Folder", "parent_id": "1"}
+                )
+                assert result["id"] == "5"
+                assert result["parent_id"] == "1"
+        finally:
+            await client.close()
+
+
+class TestDeleteFolder:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deletes_folder(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/folders/5").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_folder", "folder", {"folder_id": "5"})
+
+        try:
+            async with client.session(ctx) as session:
+                result = await session.delete("/folders/5")
+                assert result is None
+        finally:
+            await client.close()
+
+
+class TestFolderChildren:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_children(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/folders/1/children").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"id": "10", "name": "Sub A", "parent_id": "1", "child_count": 0},
+                    {"id": "11", "name": "Sub B", "parent_id": "1", "child_count": 2},
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_folder_children", "folder", {"folder_id": "1"})
+
+        try:
+            async with client.session(ctx) as session:
+                children = await session.get("/folders/1/children", params={"limit": 50})
+                assert len(children) == 2
+                assert children[1]["name"] == "Sub B"
+        finally:
+            await client.close()
+
+
+class TestFolderAncestors:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_ancestors(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/folders/10/ancestors").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"id": "0", "name": "Root", "parent_id": None},
+                    {"id": "1", "name": "Shared", "parent_id": "0"},
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_folder_ancestors", "folder", {"folder_id": "10"})
+
+        try:
+            async with client.session(ctx) as session:
+                ancestors = await session.get("/folders/10/ancestors")
+                assert len(ancestors) == 2
+                assert ancestors[0]["name"] == "Root"
+        finally:
+            await client.close()
+
+
+class TestFolderContent:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_folder_looks(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/folders/1/looks").mock(
+            return_value=httpx.Response(
+                200,
+                json=[{"id": "100", "title": "Sales Look", "description": "Monthly sales"}],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_folder_looks", "folder", {"folder_id": "1"})
+
+        try:
+            async with client.session(ctx) as session:
+                looks = await session.get("/folders/1/looks")
+                assert len(looks) == 1
+                assert looks[0]["title"] == "Sales Look"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_folder_dashboards(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/folders/1/dashboards").mock(
+            return_value=httpx.Response(
+                200,
+                json=[{"id": "200", "title": "Exec Dashboard", "description": None}],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_folder_dashboards", "folder", {"folder_id": "1"})
+
+        try:
+            async with client.session(ctx) as session:
+                dashboards = await session.get("/folders/1/dashboards")
+                assert len(dashboards) == 1
+                assert dashboards[0]["title"] == "Exec Dashboard"
+        finally:
+            await client.close()
+
+
+class TestFolderToolRegistration:
+    """Verify that folder tools are registered when the group is enabled."""
+
+    def test_folder_tools_registered(self, server_and_client):
+        mcp, _client = server_and_client
+        tool_names = {t.name for t in mcp._tool_manager._tools.values()}
+        expected = {
+            "list_folders",
+            "get_folder",
+            "create_folder",
+            "update_folder",
+            "delete_folder",
+            "get_folder_children",
+            "get_folder_ancestors",
+            "get_folder_looks",
+            "get_folder_dashboards",
+        }
+        assert expected.issubset(tool_names), f"Missing tools: {expected - tool_names}"

--- a/uv.lock
+++ b/uv.lock
@@ -585,7 +585,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Adds two new tool groups covering the Looker Board and Folder APIs, expanding from 56 to 75 tools across 10 groups.

- **board** (13 tools): full CRUD for boards, board sections, and board items — Looker's modern content curation surface
- **folder** (9 tools): folder navigation, CRUD, children/ancestors traversal, and content listing (looks + dashboards per folder)

Both groups are opt-in (not in `DEFAULT_GROUPS`). Enable with `--groups board,folder` or `--groups all`.

## Changes

- `src/looker_mcp_server/tools/board.py` — 13 tools: `list_boards`, `get_board`, `create_board`, `update_board`, `delete_board`, `get_board_section`, `create_board_section`, `update_board_section`, `delete_board_section`, `get_board_item`, `create_board_item`, `update_board_item`, `delete_board_item`
- `src/looker_mcp_server/tools/folder.py` — 9 tools: `list_folders`, `get_folder`, `create_folder`, `update_folder`, `delete_folder`, `get_folder_children`, `get_folder_ancestors`, `get_folder_looks`, `get_folder_dashboards`
- `server.py` — registered both groups in `_group_registry`
- `config.py` — added to `ALL_GROUPS`
- `README.md` — updated tool count and groups table
- `tests/test_board_tools.py` — 8 tests (API operations + tool registration)
- `tests/test_folder_tools.py` — 8 tests (API operations + tool registration)

## Test plan

- [x] `uv run ruff check .` — all checks pass
- [x] `uv run ruff format .` — all formatted
- [x] `uv run pyright` — 0 errors
- [x] `uv run pytest tests/ -v` — 59/59 tests pass (up from 43)

Resolves ULT-1617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Board tools: full CRUD for boards, sections, and items; items may link to a dashboard, look, or URL (validation enforces exactly one).
  * Added Folder tools: full CRUD, hierarchical navigation, and listing of folder looks and dashboards.

* **Documentation**
  * README updated: total tools 56→78, groups 8→10; examples include board and folder.

* **Tests**
  * Added end-to-end test suites for Board and Folder tool groups.

* **Changelog/Release**
  * Bumped release to 0.2.0 and added 0.2.0 changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->