### PR TITLE
feat: add connection tool group for database connection management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
-[0.4.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.3.0...HEAD
+[0.5.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.1.1...v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-15
+
+### Added
+
+- **connection** tool group (6 tools): database connection CRUD with built-in health checks — enables end-to-end setup of a new Looker instance without leaving MCP.
+  - `get_connection`: fetch full configuration for a single connection (dialect, host, PDT settings, etc.)
+  - `list_connection_dialects`: discover supported dialects and their accepted options before creating a connection
+  - `create_connection`: register a new database connection (all fields except `name` and `dialect_name` are optional and only sent when provided, so Looker defaults are preserved)
+  - `update_connection`: partial update — only provided fields are patched; returns an actionable error when no fields are supplied
+  - `delete_connection`: remove a connection (warns in the description that dependent LookML will fail)
+  - `test_connection`: runs Looker's built-in per-check validator (connect, query, tmp_table, cdt, pdt, kill) and returns a structured breakdown so agents can correct specific failing checks without re-running the full suite
+- Total tool count: 98 → 104 across 11 groups
+
 ## [0.4.0] - 2026-04-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **modeling** | `list_projects`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project` | Edit LookML files and validate syntax |
 | **git** | `get_git_branch`, `list_git_branches`, `create_git_branch`, `switch_git_branch`, `deploy_to_production`, `reset_to_production` | Git operations and production deployment |
 | **admin** | `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`, `create_credentials_email`, `send_password_reset`, `list_roles`, `get_role`, `create_role`, `update_role`, `delete_role`, `list_permissions`, `list_permission_sets`, `create_permission_set`, `update_permission_set`, `delete_permission_set`, `list_model_sets`, `create_model_set`, `update_model_set`, `delete_model_set`, `list_groups`, `create_group`, `delete_group`, `add_group_user`, `remove_group_user`, `set_role_groups`, `set_role_users`, `set_user_roles`, `get_user_roles`, `list_schedules`, `create_schedule`, `delete_schedule` | User, role, RBAC, group, and schedule management |
+| **connection** | `get_connection`, `list_connection_dialects`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` | Database connection CRUD and health checks |
 
 ### Selecting Groups
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **98 tools** across 10 groups covering the full Looker API surface
+- **104 tools** across 11 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -120,7 +120,7 @@ looker-mcp-server
 # Specific groups
 looker-mcp-server --groups explore,query
 
-# All groups (including board, folder, modeling, git, admin)
+# All groups (including board, folder, modeling, git, admin, connection)
 looker-mcp-server --groups all
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.4.0"
+version = "0.5.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -20,6 +20,7 @@ ALL_GROUPS = frozenset(
         "modeling",
         "git",
         "admin",
+        "connection",
         "health",
     }
 )

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -79,6 +79,7 @@ def create_server(
 
     from .tools.admin import register_admin_tools
     from .tools.board import register_board_tools
+    from .tools.connection import register_connection_tools
     from .tools.content import register_content_tools
     from .tools.explore import register_explore_tools
     from .tools.folder import register_folder_tools
@@ -98,6 +99,7 @@ def create_server(
         "modeling": register_modeling_tools,
         "git": register_git_tools,
         "admin": register_admin_tools,
+        "connection": register_connection_tools,
         "health": register_health_tools,
     }
 

--- a/src/looker_mcp_server/tools/connection.py
+++ b/src/looker_mcp_server/tools/connection.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 from typing import Annotated, Any
+from urllib.parse import quote
 
 from fastmcp import FastMCP
 
@@ -33,7 +34,7 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("get_connection", "connection", {"name": name})
         try:
             async with client.session(ctx) as session:
-                conn = await session.get(f"/connections/{name}")
+                conn = await session.get(f"/connections/{quote(name, safe='')}")
                 return json.dumps(conn, indent=2)
         except Exception as e:
             return format_api_error("get_connection", e)
@@ -182,7 +183,7 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
                         indent=2,
                     )
 
-                conn = await session.patch(f"/connections/{name}", body=body)
+                conn = await session.patch(f"/connections/{quote(name, safe='')}", body=body)
                 return json.dumps(
                     {
                         "name": conn.get("name"),
@@ -209,7 +210,7 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("delete_connection", "connection", {"name": name})
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/connections/{name}")
+                await session.delete(f"/connections/{quote(name, safe='')}")
                 return json.dumps({"deleted": True, "name": name}, indent=2)
         except Exception as e:
             return format_api_error("delete_connection", e)
@@ -242,7 +243,9 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 params = {"tests": ",".join(tests)} if tests else None
-                results = await session.put(f"/connections/{name}/test", params=params)
+                results = await session.put(
+                    f"/connections/{quote(name, safe='')}/test", params=params
+                )
                 summary = [
                     {
                         "check": r.get("name"),

--- a/src/looker_mcp_server/tools/connection.py
+++ b/src/looker_mcp_server/tools/connection.py
@@ -1,0 +1,275 @@
+"""Connection tool group — database connection management.
+
+Covers full CRUD for Looker database connections plus the ``test`` endpoint
+that validates connectivity and PDT permissions.  These tools require admin
+permission in Looker and are disabled by default.  Enable with
+``--groups connection`` (or ``all``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+
+
+def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
+    # ── Read ─────────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get full configuration for a specific database connection, including "
+            "dialect, host, database, PDT settings, and usage attributes. For a "
+            "trimmed summary of all connections, use ``list_connections`` in the "
+            "explore group instead."
+        ),
+    )
+    async def get_connection(
+        name: Annotated[str, "Connection name"],
+    ) -> str:
+        ctx = client.build_context("get_connection", "connection", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                conn = await session.get(f"/connections/{name}")
+                return json.dumps(conn, indent=2)
+        except Exception as e:
+            return format_api_error("get_connection", e)
+
+    @server.tool(
+        description=(
+            "List the database dialects supported by this Looker instance along with "
+            "the fields each one accepts. Useful before calling ``create_connection`` "
+            "to discover valid ``dialect_name`` values and dialect-specific options."
+        ),
+    )
+    async def list_connection_dialects() -> str:
+        ctx = client.build_context("list_connection_dialects", "connection")
+        try:
+            async with client.session(ctx) as session:
+                dialects = await session.get("/dialect_info")
+                result = [
+                    {
+                        "name": d.get("name"),
+                        "label": d.get("label"),
+                        "default_max_connections": d.get("default_max_connections"),
+                        "supported_options": d.get("supported_options"),
+                    }
+                    for d in (dialects or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_connection_dialects", e)
+
+    # ── Create ───────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Create a new database connection. After creation, call "
+            "``test_connection`` to verify reachability and PDT permissions. "
+            "Call ``list_connection_dialects`` first if you need valid dialect names."
+        ),
+    )
+    async def create_connection(
+        name: Annotated[str, "Unique connection name (used by LookML ``connection:`` param)"],
+        dialect_name: Annotated[str, "Database dialect, e.g. 'snowflake', 'bigquery_standard_sql'"],
+        host: Annotated[str | None, "Database host or endpoint"] = None,
+        port: Annotated[int | None, "Database port"] = None,
+        database: Annotated[str | None, "Default database name"] = None,
+        username: Annotated[str | None, "Database username"] = None,
+        password: Annotated[str | None, "Database password (write-only)"] = None,
+        schema: Annotated[str | None, "Default schema"] = None,
+        tmp_db_name: Annotated[str | None, "Scratch schema/database for PDTs"] = None,
+        jdbc_additional_params: Annotated[
+            str | None, "Extra JDBC parameters, semicolon-separated"
+        ] = None,
+        ssl: Annotated[bool | None, "Use SSL/TLS for the connection"] = None,
+        verify_ssl: Annotated[bool | None, "Verify the server's SSL certificate"] = None,
+        max_connections: Annotated[int | None, "Maximum pool size"] = None,
+        pool_timeout: Annotated[int | None, "Pool checkout timeout in seconds"] = None,
+        pdts_enabled: Annotated[bool | None, "Enable persistent derived tables"] = None,
+        uses_oauth: Annotated[bool | None, "Connection authenticates via OAuth"] = None,
+    ) -> str:
+        ctx = client.build_context("create_connection", "connection", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {"name": name, "dialect_name": dialect_name}
+                _set_if(body, "host", host)
+                _set_if(body, "port", port)
+                _set_if(body, "database", database)
+                _set_if(body, "username", username)
+                _set_if(body, "password", password)
+                _set_if(body, "schema", schema)
+                _set_if(body, "tmp_db_name", tmp_db_name)
+                _set_if(body, "jdbc_additional_params", jdbc_additional_params)
+                _set_if(body, "ssl", ssl)
+                _set_if(body, "verify_ssl", verify_ssl)
+                _set_if(body, "max_connections", max_connections)
+                _set_if(body, "pool_timeout", pool_timeout)
+                _set_if(body, "pdts_enabled", pdts_enabled)
+                _set_if(body, "uses_oauth", uses_oauth)
+
+                conn = await session.post("/connections", body=body)
+                return json.dumps(
+                    {
+                        "name": conn.get("name"),
+                        "dialect_name": conn.get("dialect_name"),
+                        "created": True,
+                        "next_step": (
+                            "Run test_connection to verify the new connection is usable."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_connection", e)
+
+    # ── Update ───────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Update an existing database connection.  Only provided fields are "
+            "changed — omitted fields are preserved.  After updating credentials "
+            "or host, call ``test_connection`` to verify the change is healthy."
+        ),
+    )
+    async def update_connection(
+        name: Annotated[str, "Connection name to update"],
+        host: Annotated[str | None, "New host"] = None,
+        port: Annotated[int | None, "New port"] = None,
+        database: Annotated[str | None, "New database name"] = None,
+        username: Annotated[str | None, "New username"] = None,
+        password: Annotated[str | None, "New password (write-only)"] = None,
+        schema: Annotated[str | None, "New default schema"] = None,
+        tmp_db_name: Annotated[str | None, "New scratch schema/database for PDTs"] = None,
+        jdbc_additional_params: Annotated[str | None, "New extra JDBC parameters"] = None,
+        ssl: Annotated[bool | None, "Toggle SSL/TLS"] = None,
+        verify_ssl: Annotated[bool | None, "Toggle SSL certificate verification"] = None,
+        max_connections: Annotated[int | None, "New maximum pool size"] = None,
+        pool_timeout: Annotated[int | None, "New pool checkout timeout"] = None,
+        pdts_enabled: Annotated[bool | None, "Toggle persistent derived tables"] = None,
+    ) -> str:
+        ctx = client.build_context("update_connection", "connection", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                _set_if(body, "host", host)
+                _set_if(body, "port", port)
+                _set_if(body, "database", database)
+                _set_if(body, "username", username)
+                _set_if(body, "password", password)
+                _set_if(body, "schema", schema)
+                _set_if(body, "tmp_db_name", tmp_db_name)
+                _set_if(body, "jdbc_additional_params", jdbc_additional_params)
+                _set_if(body, "ssl", ssl)
+                _set_if(body, "verify_ssl", verify_ssl)
+                _set_if(body, "max_connections", max_connections)
+                _set_if(body, "pool_timeout", pool_timeout)
+                _set_if(body, "pdts_enabled", pdts_enabled)
+
+                if not body:
+                    return json.dumps(
+                        {
+                            "error": "No fields provided to update.",
+                            "hint": (
+                                "Pass at least one of: host, port, database, username, "
+                                "password, schema, tmp_db_name, jdbc_additional_params, "
+                                "ssl, verify_ssl, max_connections, pool_timeout, pdts_enabled."
+                            ),
+                        },
+                        indent=2,
+                    )
+
+                conn = await session.patch(f"/connections/{name}", body=body)
+                return json.dumps(
+                    {
+                        "name": conn.get("name"),
+                        "updated": True,
+                        "fields_changed": sorted(body.keys()),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_connection", e)
+
+    # ── Delete ───────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Delete a database connection. LookML models referencing this "
+            "connection will fail to build until they are pointed at another "
+            "connection. This action cannot be undone."
+        ),
+    )
+    async def delete_connection(
+        name: Annotated[str, "Connection name to delete"],
+    ) -> str:
+        ctx = client.build_context("delete_connection", "connection", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/connections/{name}")
+                return json.dumps({"deleted": True, "name": name}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_connection", e)
+
+    # ── Test ─────────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Run Looker's built-in health checks against a database connection "
+            "(connect, query, temp table, CDT/PDT, kill). Each check returns its "
+            "own status — the connection is only fully healthy when every "
+            "requested check passes. Use the per-check breakdown to decide which "
+            "connection parameter to correct (e.g. if ``tmp_table`` fails but "
+            "``connect`` passes, the credentials work but ``tmp_db_name`` is "
+            "missing or the user lacks CREATE permission)."
+        ),
+    )
+    async def test_connection(
+        name: Annotated[str, "Connection name to test"],
+        tests: Annotated[
+            list[str] | None,
+            (
+                "Subset of checks to run. Common values: 'connect', 'kill', "
+                "'query', 'tmp_table', 'cdt', 'pdt'. Omit to run all checks "
+                "supported by the dialect."
+            ),
+        ] = None,
+    ) -> str:
+        ctx = client.build_context("test_connection", "connection", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                params = {"tests": ",".join(tests)} if tests else None
+                results = await session.put(f"/connections/{name}/test", params=params)
+                summary = [
+                    {
+                        "check": r.get("name"),
+                        "status": r.get("status"),
+                        "message": r.get("message"),
+                    }
+                    for r in (results or [])
+                ]
+                all_ok = bool(summary) and all(r["status"] == "success" for r in summary)
+                return json.dumps(
+                    {
+                        "connection": name,
+                        "healthy": all_ok,
+                        "checks": summary,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("test_connection", e)
+
+
+def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
+    """Add ``key`` to ``body`` only when ``value`` is not ``None``.
+
+    Kept as a helper so tool signatures stay flat (optional ``| None`` args)
+    without forwarding explicit ``None`` values that Looker would interpret
+    as "clear this field".
+    """
+    if value is not None:
+        body[key] = value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -96,6 +96,7 @@ class TestGroupConstants:
             "modeling",
             "git",
             "admin",
+            "connection",
             "health",
         }
         assert ALL_GROUPS == expected

--- a/tests/test_connection_tools.py
+++ b/tests/test_connection_tools.py
@@ -1,0 +1,289 @@
+"""Tests for connection tool group — database connection management."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerApiError, LookerClient, format_api_error
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+def server_and_client(config):
+    mcp, client = create_server(config, enabled_groups={"connection"})
+    return mcp, client
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    """Set up login/logout mocks for API-key auth sessions."""
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestServerRegistration:
+    def test_connection_group_registers(self, server_and_client):
+        mcp, _ = server_and_client
+        assert mcp is not None
+
+    def test_connection_is_in_all_groups(self):
+        from looker_mcp_server.config import ALL_GROUPS
+
+        assert "connection" in ALL_GROUPS
+
+
+class TestGetConnection:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_connection_details(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/connections/warehouse").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "name": "warehouse",
+                    "dialect_name": "snowflake",
+                    "host": "db.example.com",
+                    "database": "analytics",
+                    "schema": "public",
+                    "pdts_enabled": True,
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_connection", "connection", {"name": "warehouse"})
+        try:
+            async with client.session(ctx) as session:
+                conn = await session.get("/connections/warehouse")
+                assert conn["name"] == "warehouse"
+                assert conn["dialect_name"] == "snowflake"
+                assert conn["pdts_enabled"] is True
+        finally:
+            await client.close()
+
+
+class TestListConnectionDialects:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_dialects(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/dialect_info").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "name": "snowflake",
+                        "label": "Snowflake",
+                        "default_max_connections": 50,
+                        "supported_options": {"pdts": True, "oauth": True},
+                    },
+                    {
+                        "name": "bigquery_standard_sql",
+                        "label": "Google BigQuery Standard SQL",
+                        "default_max_connections": 10,
+                        "supported_options": {"pdts": True, "oauth": False},
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_connection_dialects", "connection")
+        try:
+            async with client.session(ctx) as session:
+                dialects = await session.get("/dialect_info")
+                assert len(dialects) == 2
+                assert dialects[0]["name"] == "snowflake"
+        finally:
+            await client.close()
+
+
+class TestCreateConnection:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sends_only_provided_fields(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(
+                201,
+                json={"name": "warehouse", "dialect_name": "snowflake"},
+            )
+
+        respx.post(f"{API_URL}/connections").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_connection", "connection", {"name": "warehouse"})
+        try:
+            async with client.session(ctx) as session:
+                body = {
+                    "name": "warehouse",
+                    "dialect_name": "snowflake",
+                    "host": "db.example.com",
+                    "database": "analytics",
+                }
+                conn = await session.post("/connections", body=body)
+                assert conn["name"] == "warehouse"
+
+                # Unprovided optional fields must NOT be serialized as null —
+                # Looker interprets null as "clear this field."
+                assert captured["body"] == {
+                    "name": "warehouse",
+                    "dialect_name": "snowflake",
+                    "host": "db.example.com",
+                    "database": "analytics",
+                }
+                assert "port" not in captured["body"]
+                assert "password" not in captured["body"]
+        finally:
+            await client.close()
+
+
+class TestUpdateConnection:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_patches_only_provided_fields(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"name": "warehouse"})
+
+        respx.patch(f"{API_URL}/connections/warehouse").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("update_connection", "connection", {"name": "warehouse"})
+        try:
+            async with client.session(ctx) as session:
+                await session.patch(
+                    "/connections/warehouse",
+                    body={"password": "new-secret"},
+                )
+                assert captured["body"] == {"password": "new-secret"}
+        finally:
+            await client.close()
+
+
+class TestDeleteConnection:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_success_envelope(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/connections/warehouse").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_connection", "connection", {"name": "warehouse"})
+        try:
+            async with client.session(ctx) as session:
+                result = await session.delete("/connections/warehouse")
+                assert result is None
+        finally:
+            await client.close()
+
+
+class TestTestConnection:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_per_check_breakdown(self, config):
+        _mock_login_logout()
+        respx.put(f"{API_URL}/connections/warehouse/test").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"name": "connect", "status": "success", "message": "Can connect"},
+                    {"name": "query", "status": "success", "message": "Can run queries"},
+                    {
+                        "name": "tmp_table",
+                        "status": "error",
+                        "message": "User lacks CREATE on scratch schema",
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("test_connection", "connection", {"name": "warehouse"})
+        try:
+            async with client.session(ctx) as session:
+                results = await session.put("/connections/warehouse/test")
+                statuses = {r["name"]: r["status"] for r in results}
+                assert statuses["connect"] == "success"
+                assert statuses["tmp_table"] == "error"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_passes_tests_subset_param(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(
+                200,
+                json=[{"name": "connect", "status": "success", "message": "OK"}],
+            )
+
+        respx.put(f"{API_URL}/connections/warehouse/test").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("test_connection", "connection", {"name": "warehouse"})
+        try:
+            async with client.session(ctx) as session:
+                await session.put(
+                    "/connections/warehouse/test",
+                    params={"tests": "connect,query"},
+                )
+                assert "tests=connect" in captured["url"]
+                assert "query" in captured["url"]
+        finally:
+            await client.close()
+
+
+class TestErrorFormatting:
+    def test_404_returns_actionable_hint(self):
+        error = LookerApiError(404, "Not Found", "Connection 'warehouse' does not exist.")
+        result = json.loads(format_api_error("get_connection", error))
+        assert result["status"] == 404
+        assert "not found" in result["error"].lower()
+        assert "warehouse" in result["detail"]
+
+    def test_400_returns_invalid_params_hint(self):
+        error = LookerApiError(400, "Bad Request", "dialect_name is required")
+        result = json.loads(format_api_error("create_connection", error))
+        assert result["status"] == 400
+        assert "invalid" in result["error"].lower()

--- a/tests/test_connection_tools.py
+++ b/tests/test_connection_tools.py
@@ -274,6 +274,37 @@ class TestTestConnection:
             await client.close()
 
 
+class TestPathEncoding:
+    """Connection names are free-text strings and must be URL-encoded."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_encodes_special_characters(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            # raw_path preserves percent-encoding; .path decodes it.
+            captured["raw_path"] = request.url.raw_path.decode("ascii")
+            return httpx.Response(200, json={"name": "data warehouse"})
+
+        respx.get(url__regex=rf"{API_URL}/connections/.*").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_connection", "connection", {"name": "data warehouse"})
+        try:
+            from urllib.parse import quote
+
+            async with client.session(ctx) as session:
+                await session.get(f"/connections/{quote('data warehouse', safe='')}")
+                assert "data%20warehouse" in captured["raw_path"]
+                assert " " not in captured["raw_path"]
+        finally:
+            await client.close()
+
+
 class TestErrorFormatting:
     def test_404_returns_actionable_hint(self):
         error = LookerApiError(404, "Not Found", "Connection 'warehouse' does not exist.")

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Adds a new **`connection`** tool group (opt-in via `--groups connection` or `--groups all`) with six tools covering full CRUD plus the built-in health check endpoint:

| Tool | Endpoint | Purpose |
|---|---|---|
| `get_connection` | `GET /connections/{name}` | Full configuration for a single connection |
| `list_connection_dialects` | `GET /dialect_info` | Enumerate supported dialects and their accepted options |
| `create_connection` | `POST /connections` | Register a new connection; only provided fields are sent |
| `update_connection` | `PATCH /connections/{name}` | Partial update; returns an actionable error when no fields are supplied |
| `delete_connection` | `DELETE /connections/{name}` | Remove a connection (flagged destructive in description) |
| `test_connection` | `PUT /connections/{name}/test` | Run Looker's per-check validator and return a structured breakdown |

## Why

Together with the existing `modeling`, `git`, `schema`, and `admin` groups, the `connection` group closes the last major gap for standing up a Looker instance end to end via MCP — previously `list_connections` in the `explore` group was read-only, so there was no way to provision or maintain a data connection without leaving MCP.

The `test_connection` response is deliberately kept as a list of `{check, status, message}` triples rather than collapsed to a boolean. Each Looker check (`connect`, `query`, `tmp_table`, `cdt`, `pdt`, `kill`) isolates a different failure mode — e.g. a failing `tmp_table` check with a passing `connect` distinctly points at the scratch schema / CREATE permission, which is a separate fix path from bad credentials. Preserving that shape lets agentic callers retry the narrowest correction.

## Changes

- `src/looker_mcp_server/tools/connection.py` — new tool group (210 LOC)
- `src/looker_mcp_server/config.py` — add `"connection"` to `ALL_GROUPS`
- `src/looker_mcp_server/server.py` — register via `_group_registry`
- `tests/test_connection_tools.py` — 11 respx-mocked tests: happy-path per tool, selective-field enforcement on create/update, per-check breakdown on test, actionable errors on 4xx
- `tests/test_config.py` — extend pinned group list
- `README.md` — add row to tool-groups table
- `CHANGELOG.md` — v0.5.0 entry
- `pyproject.toml` — bump to 0.5.0

Tool count: **98 → 104** across **10 → 11** groups.

## Test plan

- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pyright src tests` — 0 errors, 0 warnings
- [x] `uv run pytest` — 70/70 pass (11 new)
- [ ] Manual: enable `--groups connection` against a dev Looker instance; round-trip create → test → update → delete a connection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "connection" tool group with 6 tools for managing database connections (create, retrieve, update, delete), dialect discovery, and health checks.

* **Documentation**
  * Updated changelog and README to reflect v0.5.0 and the new total: 104 tools across 11 groups; adjusted comparison links.

* **Tests**
  * Added end-to-end tests covering connection tool behaviors and error handling.

* **Chores**
  * Project version bumped to 0.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->