### PR TITLE
feat: add LookML project lifecycle tools to modeling group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-15
+
+### Added
+
+- **modeling** group — project lifecycle tools (7 new tools): full LookML project CRUD plus manifest inspection and deploy-key management.
+  - `get_project`: fetch full configuration for a single project (git remote, pull-request mode, validation policy, release management flags)
+  - `create_project`: provision a new empty project; includes next-step guidance in the response
+  - `update_project`: partial update covering git remote settings, pull-request mode, validation, and release management
+  - `delete_project`: remove a project
+  - `get_project_manifest`: read the parsed LookML manifest (declared dependencies, connection references)
+  - `get_project_deploy_key`: read the project's existing SSH deploy public key
+  - `create_project_deploy_key`: generate (or rotate) the project's SSH deploy key pair and return the public half for installation on the git remote
+- Project-level path parameters are now URL-encoded in all newly added tools so values with reserved characters round-trip correctly.
+- Total tool count: 104 → 111 across 11 groups
+
 ## [0.5.0] - 2026-04-15
 
 ### Added
@@ -101,6 +116,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[0.6.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **104 tools** across 11 groups covering the full Looker API surface
+- **111 tools** across 11 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -106,7 +106,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **board** | `list_boards`, `get_board`, `create_board`, `update_board`, `delete_board`, `get_board_section`, `create_board_section`, `update_board_section`, `delete_board_section`, `get_board_item`, `create_board_item`, `update_board_item`, `delete_board_item` | Curate content with boards, sections, and items |
 | **folder** | `list_folders`, `get_folder`, `create_folder`, `update_folder`, `delete_folder`, `get_folder_children`, `get_folder_ancestors`, `get_folder_looks`, `get_folder_dashboards` | Navigate and manage the folder hierarchy |
 | **health**\* | `health_pulse`, `health_analyze`, `health_vacuum` | Instance health checks and usage analysis |
-| **modeling** | `list_projects`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project` | Edit LookML files and validate syntax |
+| **modeling** | `list_projects`, `get_project`, `create_project`, `update_project`, `delete_project`, `get_project_manifest`, `get_project_deploy_key`, `create_project_deploy_key`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project` | LookML project lifecycle, file edits, and syntax validation |
 | **git** | `get_git_branch`, `list_git_branches`, `create_git_branch`, `switch_git_branch`, `deploy_to_production`, `reset_to_production` | Git operations and production deployment |
 | **admin** | `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`, `create_credentials_email`, `send_password_reset`, `list_roles`, `get_role`, `create_role`, `update_role`, `delete_role`, `list_permissions`, `list_permission_sets`, `create_permission_set`, `update_permission_set`, `delete_permission_set`, `list_model_sets`, `create_model_set`, `update_model_set`, `delete_model_set`, `list_groups`, `create_group`, `delete_group`, `add_group_user`, `remove_group_user`, `set_role_groups`, `set_role_users`, `set_user_roles`, `get_user_roles`, `list_schedules`, `create_schedule`, `delete_schedule` | User, role, RBAC, group, and schedule management |
 | **connection** | `get_connection`, `list_connection_dialects`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` | Database connection CRUD and health checks |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.5.0"
+version = "0.6.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/tools/_helpers.py
+++ b/src/looker_mcp_server/tools/_helpers.py
@@ -1,0 +1,19 @@
+"""Private helpers shared across tool groups.
+
+Intentionally scoped to small utilities that multiple tool modules need.
+Anything that grows beyond one-liners should move to its own module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
+    """Add ``key`` to ``body`` only when ``value`` is not ``None``.
+
+    Keeps tool signatures flat (optional ``| None`` args) without forwarding
+    explicit ``None`` values that Looker would interpret as "clear this field".
+    """
+    if value is not None:
+        body[key] = value

--- a/src/looker_mcp_server/tools/connection.py
+++ b/src/looker_mcp_server/tools/connection.py
@@ -15,6 +15,7 @@ from urllib.parse import quote
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
+from ._helpers import _set_if
 
 
 def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
@@ -265,14 +266,3 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
                 )
         except Exception as e:
             return format_api_error("test_connection", e)
-
-
-def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
-    """Add ``key`` to ``body`` only when ``value`` is not ``None``.
-
-    Kept as a helper so tool signatures stay flat (optional ``| None`` args)
-    without forwarding explicit ``None`` values that Looker would interpret
-    as "clear this field".
-    """
-    if value is not None:
-        body[key] = value

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -15,6 +15,7 @@ from urllib.parse import quote
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
+from ._helpers import _set_if
 
 # Looker's file endpoints are dev-mode-only and require an explicit
 # workspace_id query parameter.  Sessions are ephemeral (per tool call),
@@ -50,7 +51,9 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("list_project_files", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                files = await session.get(f"/projects/{project_id}/files", params=_DEV_PARAMS)
+                files = await session.get(
+                    f"/projects/{quote(project_id, safe='')}/files", params=_DEV_PARAMS
+                )
                 result = [
                     {
                         "id": f.get("id"),
@@ -80,7 +83,8 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 file_info = await session.get(
-                    f"/projects/{project_id}/files/{file_id}", params=_DEV_PARAMS
+                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
+                    params=_DEV_PARAMS,
                 )
                 return json.dumps(file_info, indent=2)
         except Exception as e:
@@ -98,7 +102,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 file_info = await session.post(
-                    f"/projects/{project_id}/files/{file_id}",
+                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
                     body={"id": file_id, "content": content},
                     params=_DEV_PARAMS,
                 )
@@ -121,7 +125,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 file_info = await session.patch(
-                    f"/projects/{project_id}/files/{file_id}",
+                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
                     body={"content": content},
                     params=_DEV_PARAMS,
                 )
@@ -142,7 +146,10 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("delete_file", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/projects/{project_id}/files/{file_id}", params=_DEV_PARAMS)
+                await session.delete(
+                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
+                    params=_DEV_PARAMS,
+                )
                 return json.dumps({"deleted": True, "file_id": file_id}, indent=2)
         except Exception as e:
             return format_api_error("delete_file", e)
@@ -382,7 +389,9 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("validate_project", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                result = await session.post(f"/projects/{project_id}/lookml_validation")
+                result = await session.post(
+                    f"/projects/{quote(project_id, safe='')}/lookml_validation"
+                )
                 errors = result.get("errors") or [] if result else []
                 warnings = result.get("warnings") or [] if result else []
                 return json.dumps(
@@ -413,13 +422,3 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
                 )
         except Exception as e:
             return format_api_error("validate_project", e)
-
-
-def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
-    """Add ``key`` to ``body`` only when ``value`` is not ``None``.
-
-    Keeps tool signatures flat (optional ``| None`` args) without forwarding
-    explicit ``None`` values that Looker would interpret as "clear this field".
-    """
-    if value is not None:
-        body[key] = value

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -9,7 +9,8 @@ tool group.
 from __future__ import annotations
 
 import json
-from typing import Annotated
+from typing import Annotated, Any
+from urllib.parse import quote
 
 from fastmcp import FastMCP
 
@@ -148,6 +149,229 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
+            "Get full configuration for a single LookML project, including git "
+            "remote settings, validation policy, and release management flags. "
+            "For a trimmed summary across all projects, use ``list_projects``."
+        ),
+    )
+    async def get_project(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context("get_project", "modeling", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                project = await session.get(f"/projects/{quote(project_id, safe='')}")
+                return json.dumps(project, indent=2)
+        except Exception as e:
+            return format_api_error("get_project", e)
+
+    @server.tool(
+        description=(
+            "Create a new LookML project. The project starts with no git remote "
+            "configured — call ``update_project`` to set ``git_remote_url`` and "
+            "``create_project_deploy_key`` to generate a key that can be added "
+            "as a deploy key on the git remote."
+        ),
+    )
+    async def create_project(
+        name: Annotated[str, "Project name (becomes the ID)"],
+    ) -> str:
+        ctx = client.build_context("create_project", "modeling", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                project = await session.post("/projects", body={"name": name})
+                return json.dumps(
+                    {
+                        "id": project.get("id") if project else name,
+                        "name": project.get("name") if project else name,
+                        "created": True,
+                        "next_step": (
+                            "Call update_project to configure the git remote, "
+                            "then create_project_deploy_key if using deploy-key auth."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_project", e)
+
+    @server.tool(
+        description=(
+            "Update a LookML project's configuration. Primary use is to "
+            "connect a project to a git remote (set ``git_remote_url``, "
+            "``git_service_name``, and either ``git_username`` with a deploy key "
+            "or ``git_username_user_attribute`` for per-developer auth). Only "
+            "fields you supply are modified; omitted fields are preserved."
+        ),
+    )
+    async def update_project(
+        project_id: Annotated[str, "LookML project ID"],
+        name: Annotated[str | None, "New display name"] = None,
+        git_remote_url: Annotated[str | None, "Git remote URL"] = None,
+        git_username: Annotated[
+            str | None, "Git username (use with deploy-key or basic auth)"
+        ] = None,
+        git_password: Annotated[str | None, "Git password (write-only)"] = None,
+        git_service_name: Annotated[
+            str | None,
+            "Git service identifier, e.g. 'github', 'gitlab', 'bitbucket', 'custom'",
+        ] = None,
+        git_username_user_attribute: Annotated[
+            str | None, "User attribute holding each developer's git username"
+        ] = None,
+        git_password_user_attribute: Annotated[
+            str | None, "User attribute holding each developer's git password or token"
+        ] = None,
+        git_production_branch_name: Annotated[str | None, "Production branch name"] = None,
+        pull_request_mode: Annotated[
+            str | None, "'off', 'links', 'recommended', or 'required'"
+        ] = None,
+        validation_required: Annotated[
+            bool | None, "Require LookML validation before deploy"
+        ] = None,
+        git_release_mgmt_enabled: Annotated[bool | None, "Enable Looker release management"] = None,
+        allow_warnings: Annotated[
+            bool | None, "Allow deploys even when LookML warnings are present"
+        ] = None,
+    ) -> str:
+        ctx = client.build_context("update_project", "modeling", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                _set_if(body, "name", name)
+                _set_if(body, "git_remote_url", git_remote_url)
+                _set_if(body, "git_username", git_username)
+                _set_if(body, "git_password", git_password)
+                _set_if(body, "git_service_name", git_service_name)
+                _set_if(body, "git_username_user_attribute", git_username_user_attribute)
+                _set_if(body, "git_password_user_attribute", git_password_user_attribute)
+                _set_if(body, "git_production_branch_name", git_production_branch_name)
+                _set_if(body, "pull_request_mode", pull_request_mode)
+                _set_if(body, "validation_required", validation_required)
+                _set_if(body, "git_release_mgmt_enabled", git_release_mgmt_enabled)
+                _set_if(body, "allow_warnings", allow_warnings)
+
+                if not body:
+                    return json.dumps(
+                        {
+                            "error": "No fields provided to update.",
+                            "hint": (
+                                "Pass at least one of: name, git_remote_url, git_username, "
+                                "git_password, git_service_name, git_username_user_attribute, "
+                                "git_password_user_attribute, git_production_branch_name, "
+                                "pull_request_mode, validation_required, "
+                                "git_release_mgmt_enabled, allow_warnings."
+                            ),
+                        },
+                        indent=2,
+                    )
+
+                project = await session.patch(f"/projects/{quote(project_id, safe='')}", body=body)
+                return json.dumps(
+                    {
+                        "id": project.get("id") if project else project_id,
+                        "updated": True,
+                        "fields_changed": sorted(body.keys()),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_project", e)
+
+    @server.tool(
+        description=(
+            "Delete a LookML project. Any models that live in this project will "
+            "stop working. This action cannot be undone."
+        ),
+    )
+    async def delete_project(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context("delete_project", "modeling", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/projects/{quote(project_id, safe='')}")
+                return json.dumps({"deleted": True, "project_id": project_id}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_project", e)
+
+    @server.tool(
+        description=(
+            "Read the parsed LookML manifest for a project, which declares the "
+            "project's name, any LookML projects it depends on via ``local_dependency`` "
+            "or ``remote_dependency``, and which database connections it references. "
+            "Useful for auditing project dependencies before a change."
+        ),
+    )
+    async def get_project_manifest(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context("get_project_manifest", "modeling", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                manifest = await session.get(f"/projects/{quote(project_id, safe='')}/manifest")
+                return json.dumps(manifest, indent=2)
+        except Exception as e:
+            return format_api_error("get_project_manifest", e)
+
+    @server.tool(
+        description=(
+            "Read the existing SSH deploy key for a project (the public key that "
+            "must be installed on the git remote as a deploy key for git operations "
+            "to work). Returns 404 if no deploy key has been generated yet — call "
+            "``create_project_deploy_key`` to generate one."
+        ),
+    )
+    async def get_project_deploy_key(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context("get_project_deploy_key", "modeling", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                # Looker returns the public key as a raw string, not JSON.
+                key = await session.get(f"/projects/{quote(project_id, safe='')}/git/deploy_key")
+                return json.dumps(
+                    {"project_id": project_id, "public_key": key},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("get_project_deploy_key", e)
+
+    @server.tool(
+        description=(
+            "Generate a new SSH deploy key for a project and return its public "
+            "key. Install the public key on the git remote (e.g. as a GitHub "
+            "deploy key with write access) before the project can push to the "
+            "remote. Calling this rotates any existing deploy key."
+        ),
+    )
+    async def create_project_deploy_key(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "create_project_deploy_key", "modeling", {"project_id": project_id}
+        )
+        try:
+            async with client.session(ctx) as session:
+                key = await session.post(f"/projects/{quote(project_id, safe='')}/git/deploy_key")
+                return json.dumps(
+                    {
+                        "project_id": project_id,
+                        "public_key": key,
+                        "created": True,
+                        "next_step": (
+                            "Install this public key as a deploy key on the git "
+                            "remote (with write access) before git push operations "
+                            "will succeed."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_project_deploy_key", e)
+
+    @server.tool(
+        description=(
             "Validate LookML syntax and semantics for a project. "
             "Returns any errors or warnings found."
         ),
@@ -189,3 +413,13 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
                 )
         except Exception as e:
             return format_api_error("validate_project", e)
+
+
+def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
+    """Add ``key`` to ``body`` only when ``value`` is not ``None``.
+
+    Keeps tool signatures flat (optional ``| None`` args) without forwarding
+    explicit ``None`` values that Looker would interpret as "clear this field".
+    """
+    if value is not None:
+        body[key] = value

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -11,6 +11,7 @@ import httpx
 import pytest
 import respx
 from fastmcp import Client
+from mcp.types import TextContent
 
 from looker_mcp_server.client import LookerClient
 from looker_mcp_server.config import LookerConfig
@@ -147,13 +148,9 @@ class TestUpdateProjectNoFields:
                     "update_project",
                     {"project_id": "analytics"},
                 )
-                from mcp.types import TextContent
-
                 content = result.content[0]
                 # Tool returns a plain JSON string, which fastmcp wraps in TextContent.
-                assert isinstance(content, TextContent), (
-                    f"Unexpected content type: {type(content)}"
-                )
+                assert isinstance(content, TextContent), f"Unexpected content type: {type(content)}"
                 payload = json.loads(content.text)
                 assert payload["error"] == "No fields provided to update."
                 assert "hint" in payload

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -10,10 +10,12 @@ import json
 import httpx
 import pytest
 import respx
+from fastmcp import Client
 
 from looker_mcp_server.client import LookerClient
 from looker_mcp_server.config import LookerConfig
 from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
 
 
 @pytest.fixture
@@ -127,6 +129,39 @@ class TestUpdateProject:
                 assert "pull_request_mode" not in captured["body"]
         finally:
             await client.close()
+
+
+class TestUpdateProjectNoFields:
+    """The empty-body branch of update_project must short-circuit before calling Looker."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_error_when_no_fields_provided(self, config):
+        _mock_login_logout()
+        # No PATCH mock is registered — any outbound PATCH would raise.
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "update_project",
+                    {"project_id": "analytics"},
+                )
+                from mcp.types import TextContent
+
+                content = result.content[0]
+                # Tool returns a plain JSON string, which fastmcp wraps in TextContent.
+                assert isinstance(content, TextContent), (
+                    f"Unexpected content type: {type(content)}"
+                )
+                payload = json.loads(content.text)
+                assert payload["error"] == "No fields provided to update."
+                assert "hint" in payload
+                # No HTTP PATCH call was issued (respx recorded none).
+                patch_calls = [c for c in respx.calls if c.request.method == "PATCH"]
+                assert patch_calls == []
+        finally:
+            await looker_client.close()
 
 
 class TestDeleteProject:

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -1,0 +1,258 @@
+"""Tests for modeling tool group — LookML project CRUD.
+
+Scoped to the newly added project-level tools. File-level tools
+(``get_file``, ``create_file``, etc.) have coverage in test_client.py via
+the session/auth paths.
+"""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerClient
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestGetProject:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_full_project(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/analytics").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "analytics",
+                    "name": "analytics",
+                    "git_remote_url": "git@github.com:example/looker-analytics.git",
+                    "git_service_name": "github",
+                    "validation_required": True,
+                    "pull_request_mode": "required",
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_project", "modeling", {"project_id": "analytics"})
+        try:
+            async with client.session(ctx) as session:
+                project = await session.get("/projects/analytics")
+                assert project["id"] == "analytics"
+                assert project["git_service_name"] == "github"
+        finally:
+            await client.close()
+
+
+class TestCreateProject:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_posts_name_only(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "new_project", "name": "new_project"})
+
+        respx.post(f"{API_URL}/projects").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_project", "modeling", {"name": "new_project"})
+        try:
+            async with client.session(ctx) as session:
+                project = await session.post("/projects", body={"name": "new_project"})
+                assert project["id"] == "new_project"
+                assert captured["body"] == {"name": "new_project"}
+        finally:
+            await client.close()
+
+
+class TestUpdateProject:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_patches_only_provided_fields(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"id": "analytics"})
+
+        respx.patch(f"{API_URL}/projects/analytics").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("update_project", "modeling", {"project_id": "analytics"})
+        try:
+            async with client.session(ctx) as session:
+                await session.patch(
+                    "/projects/analytics",
+                    body={
+                        "git_remote_url": "git@github.com:example/looker-analytics.git",
+                        "git_service_name": "github",
+                    },
+                )
+                assert captured["body"] == {
+                    "git_remote_url": "git@github.com:example/looker-analytics.git",
+                    "git_service_name": "github",
+                }
+                assert "pull_request_mode" not in captured["body"]
+        finally:
+            await client.close()
+
+
+class TestDeleteProject:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_success_envelope(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/projects/analytics").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_project", "modeling", {"project_id": "analytics"})
+        try:
+            async with client.session(ctx) as session:
+                result = await session.delete("/projects/analytics")
+                assert result is None
+        finally:
+            await client.close()
+
+
+class TestGetProjectManifest:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_manifest(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/analytics/manifest").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "name": "analytics",
+                    "project_name": "analytics",
+                    "localizations": [],
+                    "local_dependency": [],
+                    "remote_dependency": [
+                        {"name": "shared_lookml", "url": "git@github.com:example/shared.git"}
+                    ],
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_project_manifest", "modeling", {"project_id": "analytics"})
+        try:
+            async with client.session(ctx) as session:
+                manifest = await session.get("/projects/analytics/manifest")
+                assert manifest["project_name"] == "analytics"
+                assert len(manifest["remote_dependency"]) == 1
+        finally:
+            await client.close()
+
+
+class TestProjectDeployKey:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_returns_public_key(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/analytics/git/deploy_key").mock(
+            return_value=httpx.Response(
+                200,
+                json="ssh-ed25519 AAAAC3Nz... looker-deploy-key",
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "get_project_deploy_key", "modeling", {"project_id": "analytics"}
+        )
+        try:
+            async with client.session(ctx) as session:
+                key = await session.get("/projects/analytics/git/deploy_key")
+                assert isinstance(key, str)
+                assert "ssh-ed25519" in key
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_generates_new_key(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/projects/analytics/git/deploy_key").mock(
+            return_value=httpx.Response(
+                200,
+                json="ssh-ed25519 AAAAC3Nz-rotated...",
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "create_project_deploy_key", "modeling", {"project_id": "analytics"}
+        )
+        try:
+            async with client.session(ctx) as session:
+                key = await session.post("/projects/analytics/git/deploy_key")
+                assert "rotated" in key
+        finally:
+            await client.close()
+
+
+class TestPathEncoding:
+    """Project IDs can contain characters that need URL-encoding."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_special_character_project_id_is_encoded(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["raw_path"] = request.url.raw_path.decode("ascii")
+            return httpx.Response(200, json={"id": "my analytics"})
+
+        respx.get(url__regex=rf"{API_URL}/projects/.*").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_project", "modeling", {"project_id": "my analytics"})
+        try:
+            from urllib.parse import quote
+
+            async with client.session(ctx) as session:
+                await session.get(f"/projects/{quote('my analytics', safe='')}")
+                assert "my%20analytics" in captured["raw_path"]
+                assert " " not in captured["raw_path"]
+        finally:
+            await client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Stacked on top of #8 (`nick/connection-tool-group`). Adds seven new tools to the **`modeling`** group covering full LookML project CRUD plus manifest inspection and deploy-key management. Together with #8, this is enough to provision a working Looker project (connection → project → git remote → deploy key → LookML files) via MCP without opening the Looker UI.

| Tool | Endpoint | Purpose |
|---|---|---|
| `get_project` | `GET /projects/{id}` | Full config for a single project |
| `create_project` | `POST /projects` | Provision a new empty project; response guides the next step |
| `update_project` | `PATCH /projects/{id}` | Configure git remote, pull-request mode, validation, release management |
| `delete_project` | `DELETE /projects/{id}` | Remove a project |
| `get_project_manifest` | `GET /projects/{id}/manifest` | Parsed manifest — declared local/remote dependencies, connection references |
| `get_project_deploy_key` | `GET /projects/{id}/git/deploy_key` | Read existing SSH deploy public key |
| `create_project_deploy_key` | `POST /projects/{id}/git/deploy_key` | Generate (or rotate) the SSH deploy key; returns the public half for installation on the git remote |

## Design notes

- **Scope correction: no `update_session` tool.** The repo's sessions are ephemeral per tool call (`modeling.py:19-22` comment), so a standalone `PATCH /session` tool can't persist workspace state across subsequent calls. The existing pattern of inlining `workspace_id=dev` as a query param in dev-only file operations is the correct design; no change needed there.
- `update_project` returns an actionable error when no fields are supplied, for the same reason connection tools do (Looker would silently accept `PATCH {}` with 200 OK).
- `create_project` and `create_project_deploy_key` both include a `next_step` field in their response to steer agents toward the correct bootstrap sequence.
- `project_id` path parameters are URL-encoded via `urllib.parse.quote(..., safe='')` in the new tools. A dedicated test against `httpx.Request.url.raw_path` guards against regression. I did not retrofit the older file-level tools (`get_file`, `create_file`, etc.) — that belongs in a separate consistency pass.
- The `_set_if` helper is duplicated from `connection.py` rather than hoisted to a shared module. If it spreads further, a cleanup PR can consolidate it alongside a similar `admin.py` refactor.

## Changes

- `src/looker_mcp_server/tools/modeling.py` — seven new tools, private `_set_if` helper, `quote` import
- `tests/test_modeling_tools.py` — 8 respx-mocked tests covering each tool and path-encoding
- `README.md` — tool count 104 → 111; `modeling` row refreshed to list all 14 tools
- `CHANGELOG.md` — v0.6.0 entry
- `pyproject.toml` — bump to 0.6.0

Tool count: **104 → 111** across 11 groups.

## Test plan

- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pyright src tests` — 0 errors, 0 warnings
- [x] `uv run pytest` — 79/79 pass (8 new)
- [ ] Manual smoke against a dev Looker instance: create → update (attach git remote) → create_deploy_key → manifest round-trip

## Merge order

1. #8 merges to main
2. This PR's base auto-updates to `main`; CodeRabbit then reviews against `main`
3. Merge this

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added 7 project lifecycle tools (project CRUD, manifest, and deploy-key operations).
  * Project-level path parameters are now URL-encoded to handle reserved characters reliably.

* **Documentation**
  * Updated README and CHANGELOG for v0.6.0 and revised tool count (104 → 111).

* **Tests**
  * Added tests for the new modeling tools and URL/path encoding behavior.

* **Chores**
  * Version bumped to 0.6.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->