### PR TITLE
feat: add user_attributes tool group for data entitlement management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-04-15
+
+### Added
+
+- **user_attributes** tool group (11 tools): manage per-user and per-group data entitlements used for row-level security, per-developer git credentials, and LookML filter defaults.
+  - Attribute lifecycle: `list_user_attributes`, `get_user_attribute`, `create_user_attribute`, `update_user_attribute`, `delete_user_attribute`
+  - Per-group overrides: `list_user_attribute_group_values`, `set_user_attribute_group_values`, `delete_user_attribute_group_value`
+  - Per-user overrides: `list_user_attribute_values_for_user`, `set_user_attribute_user_value`, `delete_user_attribute_user_value`
+  - `list_user_attribute_values_for_user` surfaces each value's ``source`` (user override / group / default), useful for explaining why a user sees specific LookML behavior.
+- Total tool count: 111 → 115 across 12 groups
+
+### Changed
+
+- `LookerSession.post()` and `.patch()` body parameter now accept `list[Any]` in addition to `dict[str, Any]` (needed for `POST /user_attributes/{id}/group_values`, which takes an array body). Matches the `put()` widening from 0.4.0.
+- `_path_seg` helper added to `tools/_helpers.py` for consistent URL-encoding of path segments; `connection.py`, `modeling.py`, and `user_attributes.py` now share the single implementation.
+
 ## [0.6.0] - 2026-04-15
 
 ### Added
@@ -116,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[0.7.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.3.0...v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ASGI header capture middleware for per-request identity
 
 [0.7.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **111 tools** across 11 groups covering the full Looker API surface
+- **115 tools** across 12 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -110,6 +110,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **git** | `get_git_branch`, `list_git_branches`, `create_git_branch`, `switch_git_branch`, `deploy_to_production`, `reset_to_production` | Git operations and production deployment |
 | **admin** | `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`, `create_credentials_email`, `send_password_reset`, `list_roles`, `get_role`, `create_role`, `update_role`, `delete_role`, `list_permissions`, `list_permission_sets`, `create_permission_set`, `update_permission_set`, `delete_permission_set`, `list_model_sets`, `create_model_set`, `update_model_set`, `delete_model_set`, `list_groups`, `create_group`, `delete_group`, `add_group_user`, `remove_group_user`, `set_role_groups`, `set_role_users`, `set_user_roles`, `get_user_roles`, `list_schedules`, `create_schedule`, `delete_schedule` | User, role, RBAC, group, and schedule management |
 | **connection** | `get_connection`, `list_connection_dialects`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` | Database connection CRUD and health checks |
+| **user_attributes** | `list_user_attributes`, `get_user_attribute`, `create_user_attribute`, `update_user_attribute`, `delete_user_attribute`, `list_user_attribute_group_values`, `set_user_attribute_group_values`, `delete_user_attribute_group_value`, `list_user_attribute_values_for_user`, `set_user_attribute_user_value`, `delete_user_attribute_user_value` | User attribute definitions plus per-group and per-user value overrides (row-level security, per-developer credentials, filter defaults) |
 
 ### Selecting Groups
 
@@ -120,7 +121,7 @@ looker-mcp-server
 # Specific groups
 looker-mcp-server --groups explore,query
 
-# All groups (including board, folder, modeling, git, admin, connection)
+# All groups (including board, folder, modeling, git, admin, connection, user_attributes)
 looker-mcp-server --groups all
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.6.0"
+version = "0.7.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -53,7 +53,7 @@ class LookerSession:
     async def post(
         self,
         path: str,
-        body: dict[str, Any] | None = None,
+        body: dict[str, Any] | list[Any] | None = None,
         params: dict[str, Any] | None = None,
     ) -> Any:
         return await self._request("POST", path, params=params, json=body)
@@ -61,7 +61,7 @@ class LookerSession:
     async def patch(
         self,
         path: str,
-        body: dict[str, Any] | None = None,
+        body: dict[str, Any] | list[Any] | None = None,
         params: dict[str, Any] | None = None,
     ) -> Any:
         return await self._request("PATCH", path, params=params, json=body)

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -21,6 +21,7 @@ ALL_GROUPS = frozenset(
         "git",
         "admin",
         "connection",
+        "user_attributes",
         "health",
     }
 )

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -88,6 +88,7 @@ def create_server(
     from .tools.modeling import register_modeling_tools
     from .tools.query import register_query_tools
     from .tools.schema import register_schema_tools
+    from .tools.user_attributes import register_user_attribute_tools
 
     _group_registry: dict[str, Any] = {
         "explore": register_explore_tools,
@@ -100,6 +101,7 @@ def create_server(
         "git": register_git_tools,
         "admin": register_admin_tools,
         "connection": register_connection_tools,
+        "user_attributes": register_user_attribute_tools,
         "health": register_health_tools,
     }
 

--- a/src/looker_mcp_server/tools/_helpers.py
+++ b/src/looker_mcp_server/tools/_helpers.py
@@ -7,6 +7,7 @@ Anything that grows beyond one-liners should move to its own module.
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import quote
 
 
 def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
@@ -17,3 +18,14 @@ def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
     """
     if value is not None:
         body[key] = value
+
+
+def _path_seg(value: str | int) -> str:
+    """Percent-encode a single URL path segment.
+
+    Used at every path-parameter interpolation site so reserved characters
+    (space, slash, etc.) in user- or caller-supplied IDs cannot misroute
+    requests.  Defaults to ``safe=''`` so even ``/`` is encoded — critical
+    for values that would otherwise be interpreted as sub-paths.
+    """
+    return quote(str(value), safe="")

--- a/src/looker_mcp_server/tools/connection.py
+++ b/src/looker_mcp_server/tools/connection.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 
 import json
 from typing import Annotated, Any
-from urllib.parse import quote
 
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
-from ._helpers import _set_if
+from ._helpers import _path_seg, _set_if
 
 
 def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
@@ -35,7 +34,7 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("get_connection", "connection", {"name": name})
         try:
             async with client.session(ctx) as session:
-                conn = await session.get(f"/connections/{quote(name, safe='')}")
+                conn = await session.get(f"/connections/{_path_seg(name)}")
                 return json.dumps(conn, indent=2)
         except Exception as e:
             return format_api_error("get_connection", e)
@@ -184,7 +183,7 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
                         indent=2,
                     )
 
-                conn = await session.patch(f"/connections/{quote(name, safe='')}", body=body)
+                conn = await session.patch(f"/connections/{_path_seg(name)}", body=body)
                 return json.dumps(
                     {
                         "name": conn.get("name"),
@@ -211,7 +210,7 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("delete_connection", "connection", {"name": name})
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/connections/{quote(name, safe='')}")
+                await session.delete(f"/connections/{_path_seg(name)}")
                 return json.dumps({"deleted": True, "name": name}, indent=2)
         except Exception as e:
             return format_api_error("delete_connection", e)
@@ -244,9 +243,7 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 params = {"tests": ",".join(tests)} if tests else None
-                results = await session.put(
-                    f"/connections/{quote(name, safe='')}/test", params=params
-                )
+                results = await session.put(f"/connections/{_path_seg(name)}/test", params=params)
                 summary = [
                     {
                         "check": r.get("name"),

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 
 import json
 from typing import Annotated, Any
-from urllib.parse import quote
 
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
-from ._helpers import _set_if
+from ._helpers import _path_seg, _set_if
 
 # Looker's file endpoints are dev-mode-only and require an explicit
 # workspace_id query parameter.  Sessions are ephemeral (per tool call),
@@ -52,7 +51,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 files = await session.get(
-                    f"/projects/{quote(project_id, safe='')}/files", params=_DEV_PARAMS
+                    f"/projects/{_path_seg(project_id)}/files", params=_DEV_PARAMS
                 )
                 result = [
                     {
@@ -83,7 +82,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 file_info = await session.get(
-                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
+                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
                     params=_DEV_PARAMS,
                 )
                 return json.dumps(file_info, indent=2)
@@ -102,7 +101,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 file_info = await session.post(
-                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
+                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
                     body={"id": file_id, "content": content},
                     params=_DEV_PARAMS,
                 )
@@ -125,7 +124,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 file_info = await session.patch(
-                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
+                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
                     body={"content": content},
                     params=_DEV_PARAMS,
                 )
@@ -147,7 +146,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 await session.delete(
-                    f"/projects/{quote(project_id, safe='')}/files/{quote(file_id, safe='')}",
+                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
                     params=_DEV_PARAMS,
                 )
                 return json.dumps({"deleted": True, "file_id": file_id}, indent=2)
@@ -167,7 +166,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("get_project", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                project = await session.get(f"/projects/{quote(project_id, safe='')}")
+                project = await session.get(f"/projects/{_path_seg(project_id)}")
                 return json.dumps(project, indent=2)
         except Exception as e:
             return format_api_error("get_project", e)
@@ -273,7 +272,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
                         indent=2,
                     )
 
-                project = await session.patch(f"/projects/{quote(project_id, safe='')}", body=body)
+                project = await session.patch(f"/projects/{_path_seg(project_id)}", body=body)
                 return json.dumps(
                     {
                         "id": project.get("id") if project else project_id,
@@ -297,7 +296,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("delete_project", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/projects/{quote(project_id, safe='')}")
+                await session.delete(f"/projects/{_path_seg(project_id)}")
                 return json.dumps({"deleted": True, "project_id": project_id}, indent=2)
         except Exception as e:
             return format_api_error("delete_project", e)
@@ -316,7 +315,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("get_project_manifest", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                manifest = await session.get(f"/projects/{quote(project_id, safe='')}/manifest")
+                manifest = await session.get(f"/projects/{_path_seg(project_id)}/manifest")
                 return json.dumps(manifest, indent=2)
         except Exception as e:
             return format_api_error("get_project_manifest", e)
@@ -336,7 +335,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 # Looker returns the public key as a raw string, not JSON.
-                key = await session.get(f"/projects/{quote(project_id, safe='')}/git/deploy_key")
+                key = await session.get(f"/projects/{_path_seg(project_id)}/git/deploy_key")
                 return json.dumps(
                     {"project_id": project_id, "public_key": key},
                     indent=2,
@@ -360,7 +359,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         )
         try:
             async with client.session(ctx) as session:
-                key = await session.post(f"/projects/{quote(project_id, safe='')}/git/deploy_key")
+                key = await session.post(f"/projects/{_path_seg(project_id)}/git/deploy_key")
                 return json.dumps(
                     {
                         "project_id": project_id,
@@ -389,9 +388,7 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("validate_project", "modeling", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                result = await session.post(
-                    f"/projects/{quote(project_id, safe='')}/lookml_validation"
-                )
+                result = await session.post(f"/projects/{_path_seg(project_id)}/lookml_validation")
                 errors = result.get("errors") or [] if result else []
                 warnings = result.get("warnings") or [] if result else []
                 return json.dumps(

--- a/src/looker_mcp_server/tools/user_attributes.py
+++ b/src/looker_mcp_server/tools/user_attributes.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 import json
 from typing import Annotated, Any
-from urllib.parse import quote
 
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
+from ._helpers import _path_seg, _set_if
 
 
 def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None:
@@ -430,19 +430,3 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
                 )
         except Exception as e:
             return format_api_error("delete_user_attribute_user_value", e)
-
-
-def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
-    """Add ``key`` to ``body`` only when ``value`` is not ``None``."""
-    if value is not None:
-        body[key] = value
-
-
-def _path_seg(value: str | int) -> str:
-    """Percent-encode a single URL path segment.
-
-    Looker admin-facing IDs (user, group, user_attribute) are documented as
-    numeric, but encoding defensively keeps the routing layer safe from any
-    caller that passes an ID with reserved characters (space, slash, etc.).
-    """
-    return quote(str(value), safe="")

--- a/src/looker_mcp_server/tools/user_attributes.py
+++ b/src/looker_mcp_server/tools/user_attributes.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 from typing import Annotated, Any
+from urllib.parse import quote
 
 from fastmcp import FastMCP
 
@@ -68,7 +69,7 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         )
         try:
             async with client.session(ctx) as session:
-                attr = await session.get(f"/user_attributes/{user_attribute_id}")
+                attr = await session.get(f"/user_attributes/{_path_seg(user_attribute_id)}")
                 return json.dumps(attr, indent=2)
         except Exception as e:
             return format_api_error("get_user_attribute", e)
@@ -179,7 +180,9 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
                         indent=2,
                     )
 
-                attr = await session.patch(f"/user_attributes/{user_attribute_id}", body=body)
+                attr = await session.patch(
+                    f"/user_attributes/{_path_seg(user_attribute_id)}", body=body
+                )
                 return json.dumps(
                     {
                         "id": attr.get("id") if attr else user_attribute_id,
@@ -208,7 +211,7 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         )
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/user_attributes/{user_attribute_id}")
+                await session.delete(f"/user_attributes/{_path_seg(user_attribute_id)}")
                 return json.dumps(
                     {"deleted": True, "user_attribute_id": user_attribute_id},
                     indent=2,
@@ -236,7 +239,9 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         )
         try:
             async with client.session(ctx) as session:
-                values = await session.get(f"/user_attributes/{user_attribute_id}/group_values")
+                values = await session.get(
+                    f"/user_attributes/{_path_seg(user_attribute_id)}/group_values"
+                )
                 result = [
                     {
                         "group_id": v.get("group_id"),
@@ -278,7 +283,7 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         try:
             async with client.session(ctx) as session:
                 updated = await session.post(
-                    f"/user_attributes/{user_attribute_id}/group_values",
+                    f"/user_attributes/{_path_seg(user_attribute_id)}/group_values",
                     body=values,
                 )
                 return json.dumps(
@@ -310,7 +315,9 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         )
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/groups/{group_id}/attribute_values/{user_attribute_id}")
+                await session.delete(
+                    f"/groups/{_path_seg(group_id)}/attribute_values/{_path_seg(user_attribute_id)}"
+                )
                 return json.dumps(
                     {
                         "deleted": True,
@@ -341,7 +348,7 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         )
         try:
             async with client.session(ctx) as session:
-                values = await session.get(f"/users/{user_id}/attribute_values")
+                values = await session.get(f"/users/{_path_seg(user_id)}/attribute_values")
                 result = [
                     {
                         "user_attribute_id": v.get("user_attribute_id"),
@@ -377,7 +384,7 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         try:
             async with client.session(ctx) as session:
                 result = await session.patch(
-                    f"/users/{user_id}/attribute_values/{user_attribute_id}",
+                    f"/users/{_path_seg(user_id)}/attribute_values/{_path_seg(user_attribute_id)}",
                     body={"value": value},
                 )
                 return json.dumps(
@@ -410,7 +417,9 @@ def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None
         )
         try:
             async with client.session(ctx) as session:
-                await session.delete(f"/users/{user_id}/attribute_values/{user_attribute_id}")
+                await session.delete(
+                    f"/users/{_path_seg(user_id)}/attribute_values/{_path_seg(user_attribute_id)}"
+                )
                 return json.dumps(
                     {
                         "deleted": True,
@@ -427,3 +436,13 @@ def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
     """Add ``key`` to ``body`` only when ``value`` is not ``None``."""
     if value is not None:
         body[key] = value
+
+
+def _path_seg(value: str | int) -> str:
+    """Percent-encode a single URL path segment.
+
+    Looker admin-facing IDs (user, group, user_attribute) are documented as
+    numeric, but encoding defensively keeps the routing layer safe from any
+    caller that passes an ID with reserved characters (space, slash, etc.).
+    """
+    return quote(str(value), safe="")

--- a/src/looker_mcp_server/tools/user_attributes.py
+++ b/src/looker_mcp_server/tools/user_attributes.py
@@ -1,0 +1,429 @@
+"""User-attributes tool group — per-user/per-group data entitlements.
+
+Looker user attributes are named values that can hold different data for
+each user or group (e.g. a ``region`` attribute that resolves to ``EMEA``
+for one group and ``NA`` for another). They power row-level security,
+per-developer git credentials, and runtime filter defaults in LookML.
+
+Admin-only surface; disabled by default. Enable with
+``--groups user_attributes`` or ``all``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+
+
+def register_user_attribute_tools(server: FastMCP, client: LookerClient) -> None:
+    # ── Attribute definitions ─────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "List all user-attribute definitions in the instance. Returns a "
+            "trimmed summary (id, name, label, type, default_value) suitable "
+            "for discovery; use ``get_user_attribute`` for the full definition."
+        ),
+    )
+    async def list_user_attributes() -> str:
+        ctx = client.build_context("list_user_attributes", "user_attributes")
+        try:
+            async with client.session(ctx) as session:
+                attrs = await session.get("/user_attributes")
+                result = [
+                    {
+                        "id": a.get("id"),
+                        "name": a.get("name"),
+                        "label": a.get("label"),
+                        "type": a.get("type"),
+                        "default_value": a.get("default_value"),
+                        "value_is_hidden": a.get("value_is_hidden"),
+                        "user_can_view": a.get("user_can_view"),
+                        "user_can_edit": a.get("user_can_edit"),
+                    }
+                    for a in (attrs or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_user_attributes", e)
+
+    @server.tool(
+        description=(
+            "Get the full definition of a single user attribute, including "
+            "any domain whitelist for hidden values. Use ``list_user_attributes`` "
+            "to discover attribute IDs."
+        ),
+    )
+    async def get_user_attribute(
+        user_attribute_id: Annotated[str, "User attribute ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "get_user_attribute",
+            "user_attributes",
+            {"user_attribute_id": user_attribute_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                attr = await session.get(f"/user_attributes/{user_attribute_id}")
+                return json.dumps(attr, indent=2)
+        except Exception as e:
+            return format_api_error("get_user_attribute", e)
+
+    @server.tool(
+        description=(
+            "Create a new user attribute. The ``type`` controls how LookML can "
+            "use the value: 'string', 'number', 'datetime', 'yesno', 'zipcode', "
+            "or one of the 'advanced_filter_*' types for filter defaults. "
+            "Set ``value_is_hidden`` for secrets; combine with "
+            "``hidden_value_domain_whitelist`` to restrict where hidden values "
+            "can be sent (e.g. git credentials)."
+        ),
+    )
+    async def create_user_attribute(
+        name: Annotated[
+            str, "Short machine name, referenced from LookML as _user_attributes['name']"
+        ],
+        label: Annotated[str, "Human-readable label"],
+        type: Annotated[
+            str,
+            (
+                "One of: string, number, datetime, yesno, zipcode, "
+                "advanced_filter_string, advanced_filter_number, "
+                "advanced_filter_datetime"
+            ),
+        ],
+        default_value: Annotated[str | None, "Default value when no override is set"] = None,
+        value_is_hidden: Annotated[
+            bool | None, "Treat the value as a secret (obscured in UI + logs)"
+        ] = None,
+        user_can_view: Annotated[bool | None, "Whether users can see their own value"] = None,
+        user_can_edit: Annotated[bool | None, "Whether users can edit their own value"] = None,
+        hidden_value_domain_whitelist: Annotated[
+            str | None,
+            (
+                "Semicolon-separated URL patterns that hidden values may be sent "
+                "to. Required when value_is_hidden is true and the attribute is "
+                "referenced in a liquid-templated URL."
+            ),
+        ] = None,
+    ) -> str:
+        ctx = client.build_context("create_user_attribute", "user_attributes", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {"name": name, "label": label, "type": type}
+                _set_if(body, "default_value", default_value)
+                _set_if(body, "value_is_hidden", value_is_hidden)
+                _set_if(body, "user_can_view", user_can_view)
+                _set_if(body, "user_can_edit", user_can_edit)
+                _set_if(body, "hidden_value_domain_whitelist", hidden_value_domain_whitelist)
+
+                attr = await session.post("/user_attributes", body=body)
+                return json.dumps(
+                    {
+                        "id": attr.get("id") if attr else None,
+                        "name": attr.get("name") if attr else name,
+                        "created": True,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_user_attribute", e)
+
+    @server.tool(
+        description=(
+            "Update a user-attribute definition. Only provided fields are "
+            "changed; omitted fields are preserved. Note: the ``type`` cannot "
+            "be changed after creation — create a new attribute instead."
+        ),
+    )
+    async def update_user_attribute(
+        user_attribute_id: Annotated[str, "User attribute ID"],
+        label: Annotated[str | None, "New label"] = None,
+        default_value: Annotated[str | None, "New default value"] = None,
+        value_is_hidden: Annotated[bool | None, "Toggle hidden-value handling"] = None,
+        user_can_view: Annotated[bool | None, "Toggle self-view"] = None,
+        user_can_edit: Annotated[bool | None, "Toggle self-edit"] = None,
+        hidden_value_domain_whitelist: Annotated[
+            str | None, "New semicolon-separated URL whitelist"
+        ] = None,
+    ) -> str:
+        ctx = client.build_context(
+            "update_user_attribute",
+            "user_attributes",
+            {"user_attribute_id": user_attribute_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                _set_if(body, "label", label)
+                _set_if(body, "default_value", default_value)
+                _set_if(body, "value_is_hidden", value_is_hidden)
+                _set_if(body, "user_can_view", user_can_view)
+                _set_if(body, "user_can_edit", user_can_edit)
+                _set_if(body, "hidden_value_domain_whitelist", hidden_value_domain_whitelist)
+
+                if not body:
+                    return json.dumps(
+                        {
+                            "error": "No fields provided to update.",
+                            "hint": (
+                                "Pass at least one of: label, default_value, "
+                                "value_is_hidden, user_can_view, user_can_edit, "
+                                "hidden_value_domain_whitelist."
+                            ),
+                        },
+                        indent=2,
+                    )
+
+                attr = await session.patch(f"/user_attributes/{user_attribute_id}", body=body)
+                return json.dumps(
+                    {
+                        "id": attr.get("id") if attr else user_attribute_id,
+                        "updated": True,
+                        "fields_changed": sorted(body.keys()),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_user_attribute", e)
+
+    @server.tool(
+        description=(
+            "Delete a user-attribute definition. Any LookML that references this "
+            "attribute via ``_user_attributes['name']`` will stop resolving. "
+            "Cannot be undone."
+        ),
+    )
+    async def delete_user_attribute(
+        user_attribute_id: Annotated[str, "User attribute ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "delete_user_attribute",
+            "user_attributes",
+            {"user_attribute_id": user_attribute_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/user_attributes/{user_attribute_id}")
+                return json.dumps(
+                    {"deleted": True, "user_attribute_id": user_attribute_id},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_user_attribute", e)
+
+    # ── Per-group values ──────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "List the value of a user attribute for each group that has an "
+            "override (groups without an override inherit the attribute's "
+            "default). Returns ``{group_id, group_name, value, rank}`` for each "
+            "override; lower rank wins when a user belongs to multiple groups."
+        ),
+    )
+    async def list_user_attribute_group_values(
+        user_attribute_id: Annotated[str, "User attribute ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "list_user_attribute_group_values",
+            "user_attributes",
+            {"user_attribute_id": user_attribute_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                values = await session.get(f"/user_attributes/{user_attribute_id}/group_values")
+                result = [
+                    {
+                        "group_id": v.get("group_id"),
+                        "group_name": v.get("group_name"),
+                        "value": v.get("value"),
+                        "rank": v.get("rank"),
+                        "value_is_hidden": v.get("value_is_hidden"),
+                    }
+                    for v in (values or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_user_attribute_group_values", e)
+
+    @server.tool(
+        description=(
+            "Replace the set of group overrides for a user attribute. The "
+            "provided list becomes the complete set — groups not included lose "
+            "their override and fall back to the attribute default. Use "
+            "``list_user_attribute_group_values`` first if you want to preserve "
+            "existing overrides."
+        ),
+    )
+    async def set_user_attribute_group_values(
+        user_attribute_id: Annotated[str, "User attribute ID"],
+        values: Annotated[
+            list[dict[str, Any]],
+            (
+                "List of ``{group_id, value, rank?}``. ``rank`` is optional; "
+                "when omitted, Looker assigns ranks by list order."
+            ),
+        ],
+    ) -> str:
+        ctx = client.build_context(
+            "set_user_attribute_group_values",
+            "user_attributes",
+            {"user_attribute_id": user_attribute_id, "count": len(values)},
+        )
+        try:
+            async with client.session(ctx) as session:
+                updated = await session.post(
+                    f"/user_attributes/{user_attribute_id}/group_values",
+                    body=values,
+                )
+                return json.dumps(
+                    {
+                        "user_attribute_id": user_attribute_id,
+                        "override_count": len(updated or []),
+                        "updated": True,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("set_user_attribute_group_values", e)
+
+    @server.tool(
+        description=(
+            "Remove a single group's override for a user attribute. Members "
+            "of the group will fall back to other group overrides (by rank) "
+            "or the attribute's default value."
+        ),
+    )
+    async def delete_user_attribute_group_value(
+        group_id: Annotated[str, "Group ID whose override to remove"],
+        user_attribute_id: Annotated[str, "User attribute ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "delete_user_attribute_group_value",
+            "user_attributes",
+            {"group_id": group_id, "user_attribute_id": user_attribute_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/groups/{group_id}/attribute_values/{user_attribute_id}")
+                return json.dumps(
+                    {
+                        "deleted": True,
+                        "group_id": group_id,
+                        "user_attribute_id": user_attribute_id,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_user_attribute_group_value", e)
+
+    # ── Per-user values ───────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get all user-attribute values for a single user, showing which "
+            "source (user override, group, or default) resolved each value. "
+            "Useful for debugging why a user sees specific LookML behavior."
+        ),
+    )
+    async def list_user_attribute_values_for_user(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "list_user_attribute_values_for_user",
+            "user_attributes",
+            {"user_id": user_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                values = await session.get(f"/users/{user_id}/attribute_values")
+                result = [
+                    {
+                        "user_attribute_id": v.get("user_attribute_id"),
+                        "name": v.get("name"),
+                        "label": v.get("label"),
+                        "value": v.get("value"),
+                        "source": v.get("source"),
+                        "hidden_value_domain_whitelist": v.get("hidden_value_domain_whitelist"),
+                    }
+                    for v in (values or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_user_attribute_values_for_user", e)
+
+    @server.tool(
+        description=(
+            "Set an individual user's value for a user attribute (overrides "
+            "any group value and the default). Use sparingly — prefer group "
+            "values for per-team scoping."
+        ),
+    )
+    async def set_user_attribute_user_value(
+        user_id: Annotated[str, "User ID"],
+        user_attribute_id: Annotated[str, "User attribute ID"],
+        value: Annotated[str, "Value to assign for this user"],
+    ) -> str:
+        ctx = client.build_context(
+            "set_user_attribute_user_value",
+            "user_attributes",
+            {"user_id": user_id, "user_attribute_id": user_attribute_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                result = await session.patch(
+                    f"/users/{user_id}/attribute_values/{user_attribute_id}",
+                    body={"value": value},
+                )
+                return json.dumps(
+                    {
+                        "user_id": user_id,
+                        "user_attribute_id": user_attribute_id,
+                        "value": result.get("value") if result else value,
+                        "updated": True,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("set_user_attribute_user_value", e)
+
+    @server.tool(
+        description=(
+            "Remove a user's per-user override for a user attribute. The user "
+            "will then resolve this attribute from their group values or the "
+            "attribute default."
+        ),
+    )
+    async def delete_user_attribute_user_value(
+        user_id: Annotated[str, "User ID"],
+        user_attribute_id: Annotated[str, "User attribute ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "delete_user_attribute_user_value",
+            "user_attributes",
+            {"user_id": user_id, "user_attribute_id": user_attribute_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/users/{user_id}/attribute_values/{user_attribute_id}")
+                return json.dumps(
+                    {
+                        "deleted": True,
+                        "user_id": user_id,
+                        "user_attribute_id": user_attribute_id,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_user_attribute_user_value", e)
+
+
+def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
+    """Add ``key`` to ``body`` only when ``value`` is not ``None``."""
+    if value is not None:
+        body[key] = value

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -97,6 +97,7 @@ class TestGroupConstants:
             "git",
             "admin",
             "connection",
+            "user_attributes",
             "health",
         }
         assert ALL_GROUPS == expected

--- a/tests/test_user_attribute_tools.py
+++ b/tests/test_user_attribute_tools.py
@@ -24,9 +24,12 @@ def config():
 
 
 @pytest.fixture
-def server_and_client(config):
+async def server_and_client(config):
     mcp, client = create_server(config, enabled_groups={"user_attributes"})
-    return mcp, client
+    try:
+        yield mcp, client
+    finally:
+        await client.close()
 
 
 API_URL = "https://test.looker.com/api/4.0"
@@ -40,7 +43,8 @@ def _mock_login_logout():
 
 
 class TestServerRegistration:
-    def test_user_attributes_registers(self, server_and_client):
+    @pytest.mark.asyncio
+    async def test_user_attributes_registers(self, server_and_client):
         mcp, _ = server_and_client
         assert mcp is not None
 

--- a/tests/test_user_attribute_tools.py
+++ b/tests/test_user_attribute_tools.py
@@ -1,0 +1,372 @@
+"""Tests for user_attributes tool group — per-user/per-group data entitlements."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerClient
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+def server_and_client(config):
+    mcp, client = create_server(config, enabled_groups={"user_attributes"})
+    return mcp, client
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestServerRegistration:
+    def test_user_attributes_registers(self, server_and_client):
+        mcp, _ = server_and_client
+        assert mcp is not None
+
+    def test_user_attributes_in_all_groups(self):
+        from looker_mcp_server.config import ALL_GROUPS
+
+        assert "user_attributes" in ALL_GROUPS
+
+
+class TestListUserAttributes:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_trimmed_summary(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/user_attributes").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "12",
+                        "name": "region",
+                        "label": "Region",
+                        "type": "string",
+                        "default_value": "NA",
+                        "value_is_hidden": False,
+                        "user_can_view": True,
+                        "user_can_edit": False,
+                    },
+                    {
+                        "id": "13",
+                        "name": "github_token",
+                        "label": "GitHub Token",
+                        "type": "string",
+                        "value_is_hidden": True,
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_user_attributes", "user_attributes")
+        try:
+            async with client.session(ctx) as session:
+                attrs = await session.get("/user_attributes")
+                assert len(attrs) == 2
+                assert attrs[0]["name"] == "region"
+                assert attrs[1]["value_is_hidden"] is True
+        finally:
+            await client.close()
+
+
+class TestCreateUserAttribute:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_posts_required_and_selected_optional(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "99", "name": "region"})
+
+        respx.post(f"{API_URL}/user_attributes").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_user_attribute", "user_attributes", {"name": "region"})
+        try:
+            async with client.session(ctx) as session:
+                body = {
+                    "name": "region",
+                    "label": "Region",
+                    "type": "string",
+                    "default_value": "NA",
+                }
+                attr = await session.post("/user_attributes", body=body)
+                assert attr["id"] == "99"
+                # Unprovided optional fields must NOT be serialized as null.
+                assert captured["body"] == body
+                assert "value_is_hidden" not in captured["body"]
+        finally:
+            await client.close()
+
+
+class TestUpdateUserAttribute:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_patches_only_provided(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"id": "12"})
+
+        respx.patch(f"{API_URL}/user_attributes/12").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "update_user_attribute", "user_attributes", {"user_attribute_id": "12"}
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.patch("/user_attributes/12", body={"default_value": "EMEA"})
+                assert captured["body"] == {"default_value": "EMEA"}
+        finally:
+            await client.close()
+
+
+class TestDeleteUserAttribute:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_success(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/user_attributes/12").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "delete_user_attribute", "user_attributes", {"user_attribute_id": "12"}
+        )
+        try:
+            async with client.session(ctx) as session:
+                assert await session.delete("/user_attributes/12") is None
+        finally:
+            await client.close()
+
+
+class TestGroupValues:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_returns_overrides(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/user_attributes/12/group_values").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "group_id": "5",
+                        "group_name": "emea",
+                        "value": "EMEA",
+                        "rank": 1,
+                    },
+                    {
+                        "group_id": "6",
+                        "group_name": "apac",
+                        "value": "APAC",
+                        "rank": 2,
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "list_user_attribute_group_values",
+            "user_attributes",
+            {"user_attribute_id": "12"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                values = await session.get("/user_attributes/12/group_values")
+                assert len(values) == 2
+                assert values[0]["rank"] == 1
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_set_sends_list_body(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(
+                200,
+                json=[
+                    {"group_id": "5", "value": "EMEA", "rank": 1},
+                    {"group_id": "6", "value": "APAC", "rank": 2},
+                ],
+            )
+
+        respx.post(f"{API_URL}/user_attributes/12/group_values").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "set_user_attribute_group_values",
+            "user_attributes",
+            {"user_attribute_id": "12"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                updated = await session.post(
+                    "/user_attributes/12/group_values",
+                    body=[
+                        {"group_id": "5", "value": "EMEA"},
+                        {"group_id": "6", "value": "APAC"},
+                    ],
+                )
+                # Body is a JSON array (verifying client.post now accepts list bodies).
+                assert isinstance(captured["body"], list)
+                assert captured["body"][0]["group_id"] == "5"
+                assert len(updated) == 2
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_removes_single_override(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/groups/5/attribute_values/12").mock(
+            return_value=httpx.Response(204)
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "delete_user_attribute_group_value",
+            "user_attributes",
+            {"group_id": "5", "user_attribute_id": "12"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                assert await session.delete("/groups/5/attribute_values/12") is None
+        finally:
+            await client.close()
+
+
+class TestUserValues:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_shows_source(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/users/42/attribute_values").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "user_attribute_id": "12",
+                        "name": "region",
+                        "label": "Region",
+                        "value": "EMEA",
+                        "source": "group:emea",
+                    },
+                    {
+                        "user_attribute_id": "13",
+                        "name": "language",
+                        "label": "Language",
+                        "value": "en",
+                        "source": "default",
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "list_user_attribute_values_for_user",
+            "user_attributes",
+            {"user_id": "42"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                values = await session.get("/users/42/attribute_values")
+                assert values[0]["source"].startswith("group:")
+                assert values[1]["source"] == "default"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_set_user_value(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"value": "LATAM"})
+
+        respx.patch(f"{API_URL}/users/42/attribute_values/12").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "set_user_attribute_user_value",
+            "user_attributes",
+            {"user_id": "42", "user_attribute_id": "12"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                result = await session.patch(
+                    "/users/42/attribute_values/12",
+                    body={"value": "LATAM"},
+                )
+                assert captured["body"] == {"value": "LATAM"}
+                assert result["value"] == "LATAM"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_user_value(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/users/42/attribute_values/12").mock(
+            return_value=httpx.Response(204)
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "delete_user_attribute_user_value",
+            "user_attributes",
+            {"user_id": "42", "user_attribute_id": "12"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                assert await session.delete("/users/42/attribute_values/12") is None
+        finally:
+            await client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Adds a new **`user_attributes`** tool group (11 tools, opt-in) covering the full Looker user-attribute surface: definitions plus per-group and per-user value overrides. User attributes are the underlying mechanism for row-level security, per-developer git credentials, and runtime filter defaults in LookML — so this closes the last admin gap for provisioning a Looker instance that uses SSO entitlements.

### Attribute lifecycle

| Tool | Endpoint |
|---|---|
| `list_user_attributes` | `GET /user_attributes` (trimmed summary) |
| `get_user_attribute` | `GET /user_attributes/{id}` |
| `create_user_attribute` | `POST /user_attributes` |
| `update_user_attribute` | `PATCH /user_attributes/{id}` |
| `delete_user_attribute` | `DELETE /user_attributes/{id}` |

### Per-group overrides

| Tool | Endpoint |
|---|---|
| `list_user_attribute_group_values` | `GET /user_attributes/{id}/group_values` |
| `set_user_attribute_group_values` | `POST /user_attributes/{id}/group_values` — replaces the full set |
| `delete_user_attribute_group_value` | `DELETE /groups/{group_id}/attribute_values/{ua_id}` |

### Per-user overrides

| Tool | Endpoint |
|---|---|
| `list_user_attribute_values_for_user` | `GET /users/{user_id}/attribute_values` — includes each value's `source` field (user override / group / default), the key signal when debugging why a user sees specific LookML behavior |
| `set_user_attribute_user_value` | `PATCH /users/{user_id}/attribute_values/{ua_id}` |
| `delete_user_attribute_user_value` | `DELETE /users/{user_id}/attribute_values/{ua_id}` |

## Design notes

- **New group (not added to `admin`).** `admin` is already 33 tools; breaking `user_attributes` out follows the same rationale as splitting `connection` into its own group — smaller, focused groups score better on the progressive-discovery benchmarks in the wider best-practices work.
- **Client widening**: `POST /user_attributes/{id}/group_values` takes a JSON array body. `LookerSession.post()` and `.patch()` were dict-only; widened to `dict | list | None` to match the `put()` widening from 0.4.0. Changelog entry documents this in a ``Changed`` section.
- **Replace semantics on `set_user_attribute_group_values`** is called out in the tool description — the Looker API treats the POSTed list as the full override set, so callers need to `list_*_group_values` first if they want to preserve existing overrides. The description explicitly warns about this to prevent silent data loss.
- **`create_user_attribute`'s `type` description enumerates the valid values** so agents don't hallucinate invalid enum values (one of Anthropic's specific recommendations in the writing-tools research).
- **IDs are left unquoted** in the path interpolation, matching `admin.py` convention for numeric ID path params. The encoding fix in the `connection` group was for free-text `name` parameters, not numeric IDs.

## Changes

- `src/looker_mcp_server/tools/user_attributes.py` — new tool group (11 tools, ~430 LOC)
- `src/looker_mcp_server/client.py` — widen `post()` and `patch()` body types to accept `list[Any]`
- `src/looker_mcp_server/config.py` — add `user_attributes` to `ALL_GROUPS`
- `src/looker_mcp_server/server.py` — register via `_group_registry`
- `tests/test_user_attribute_tools.py` — 12 respx-mocked tests
- `tests/test_config.py` — extend pinned group list
- `README.md` — tool count 104 → 115; new row in the groups table
- `CHANGELOG.md` — v0.7.0 entry with both `Added` and `Changed` sections
- `pyproject.toml` — bump to 0.7.0

Tool count: **104 → 115** across **11 → 12** groups.

## Version note

This PR is at **0.7.0** on the assumption that #9 (project lifecycle tools at 0.6.0) lands first. If the merge order changes, this PR rebases to 0.6.0 in a trivial three-line conflict (CHANGELOG heading, changelog link, pyproject version).

## Test plan

- [x] `uv run ruff format` — clean
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pyright src tests` — 0 errors, 0 warnings
- [x] `uv run pytest` — 83/83 pass (12 new)
- [ ] Manual smoke: create an attribute → set a group value → verify a user in that group resolves it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user_attributes tool group to list/create/update/delete attributes, manage group overrides, and manage per-user attribute values (including each value’s reported source).

* **Enhancements**
  * Tool catalog updated from 111 → 115 tools across 11 → 12 groups.
  * API client now accepts array payloads where applicable.
  * Documentation and README updated; release version set to 0.7.0.

* **Tests**
  * Added end-to-end tests covering user_attributes workflows and override scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->