### PR TITLE
feat: add credentials tool group for non-email user credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-04-15
+
+### Added
+
+- **credentials** tool group (12 tools): manage non-email user credentials. Complements the existing `create_credentials_email` in the `admin` group.
+  - API3 key-pair lifecycle: `list_credentials_api3`, `create_credentials_api3`, `get_credentials_api3`, `delete_credentials_api3`. `create_credentials_api3` returns the `client_secret` in the response with a prominent one-time-only warning (Looker never surfaces the secret again) — this is the supported rotation path for service-account credentials.
+  - LDAP / SAML / OIDC / Google links: `get_credentials_{type}` and `delete_credentials_{type}` for each. Deletion unlinks the user from that identity provider; most providers re-link automatically on the user's next successful sign-in.
+- Total tool count: 115 → 127 across 13 groups
+
 ## [0.7.0] - 2026-04-15
 
 ### Added
@@ -132,6 +141,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[0.8.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.6.0...v0.7.0
 [0.5.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **115 tools** across 12 groups covering the full Looker API surface
+- **127 tools** across 13 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -111,6 +111,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **admin** | `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`, `create_credentials_email`, `send_password_reset`, `list_roles`, `get_role`, `create_role`, `update_role`, `delete_role`, `list_permissions`, `list_permission_sets`, `create_permission_set`, `update_permission_set`, `delete_permission_set`, `list_model_sets`, `create_model_set`, `update_model_set`, `delete_model_set`, `list_groups`, `create_group`, `delete_group`, `add_group_user`, `remove_group_user`, `set_role_groups`, `set_role_users`, `set_user_roles`, `get_user_roles`, `list_schedules`, `create_schedule`, `delete_schedule` | User, role, RBAC, group, and schedule management |
 | **connection** | `get_connection`, `list_connection_dialects`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` | Database connection CRUD and health checks |
 | **user_attributes** | `list_user_attributes`, `get_user_attribute`, `create_user_attribute`, `update_user_attribute`, `delete_user_attribute`, `list_user_attribute_group_values`, `set_user_attribute_group_values`, `delete_user_attribute_group_value`, `list_user_attribute_values_for_user`, `set_user_attribute_user_value`, `delete_user_attribute_user_value` | User attribute definitions plus per-group and per-user value overrides (row-level security, per-developer credentials, filter defaults) |
+| **credentials** | `list_credentials_api3`, `create_credentials_api3`, `get_credentials_api3`, `delete_credentials_api3`, `get_credentials_ldap`, `delete_credentials_ldap`, `get_credentials_saml`, `delete_credentials_saml`, `get_credentials_oidc`, `delete_credentials_oidc`, `get_credentials_google`, `delete_credentials_google` | Non-email credentials — API3 key-pair rotation plus get/delete for LDAP, SAML, OIDC, and Google SSO links |
 
 ### Selecting Groups
 
@@ -121,7 +122,7 @@ looker-mcp-server
 # Specific groups
 looker-mcp-server --groups explore,query
 
-# All groups (including board, folder, modeling, git, admin, connection, user_attributes)
+# All groups (including board, folder, modeling, git, admin, connection, user_attributes, credentials)
 looker-mcp-server --groups all
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.7.0"
+version = "0.8.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -22,6 +22,7 @@ ALL_GROUPS = frozenset(
         "admin",
         "connection",
         "user_attributes",
+        "credentials",
         "health",
     }
 )

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -81,6 +81,7 @@ def create_server(
     from .tools.board import register_board_tools
     from .tools.connection import register_connection_tools
     from .tools.content import register_content_tools
+    from .tools.credentials import register_credentials_tools
     from .tools.explore import register_explore_tools
     from .tools.folder import register_folder_tools
     from .tools.git import register_git_tools
@@ -102,6 +103,7 @@ def create_server(
         "admin": register_admin_tools,
         "connection": register_connection_tools,
         "user_attributes": register_user_attribute_tools,
+        "credentials": register_credentials_tools,
         "health": register_health_tools,
     }
 

--- a/src/looker_mcp_server/tools/credentials.py
+++ b/src/looker_mcp_server/tools/credentials.py
@@ -1,0 +1,289 @@
+"""Credentials tool group — non-email user credentials.
+
+Covers the credential types that authenticate a Looker user to the
+instance: API3 key pairs (for service accounts and programmatic access)
+and the four common SSO identity types (LDAP, SAML, OIDC, Google).
+
+Email/password credentials live in the ``admin`` group next to
+``create_user`` — see ``create_credentials_email`` and
+``send_password_reset``.
+
+Admin-only surface; disabled by default. Enable with
+``--groups credentials`` (or ``all``).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+from ._helpers import _path_seg
+
+
+def register_credentials_tools(server: FastMCP, client: LookerClient) -> None:
+    # ── API3 (multi-instance, full lifecycle) ────────────────────────
+
+    @server.tool(
+        description=(
+            "List all API3 credential pairs attached to a user. Returns one "
+            "entry per key pair with its ``id`` and ``client_id`` (never the "
+            "secret — Looker only surfaces that once, at creation). Use this "
+            "to audit which keys exist before rotating."
+        ),
+    )
+    async def list_credentials_api3(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("list_credentials_api3", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_api3")
+                result = [
+                    {
+                        "id": c.get("id"),
+                        "client_id": c.get("client_id"),
+                        "created_at": c.get("created_at"),
+                        "is_disabled": c.get("is_disabled"),
+                    }
+                    for c in (creds or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_credentials_api3", e)
+
+    @server.tool(
+        description=(
+            "Generate a new API3 client_id/client_secret pair for a user. "
+            "IMPORTANT: the response is the only place Looker surfaces the "
+            "``client_secret`` — store it immediately. Use this to rotate "
+            "service-account credentials: create a new pair, deploy it to "
+            "consumers, then delete the old pair."
+        ),
+    )
+    async def create_credentials_api3(
+        user_id: Annotated[str, "User ID to attach the new key pair to"],
+    ) -> str:
+        ctx = client.build_context("create_credentials_api3", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.post(f"/users/{_path_seg(user_id)}/credentials_api3")
+                return json.dumps(
+                    {
+                        "id": creds.get("id") if creds else None,
+                        "client_id": creds.get("client_id") if creds else None,
+                        "client_secret": creds.get("client_secret") if creds else None,
+                        "created": True,
+                        "warning": (
+                            "The client_secret is only returned once. Store it "
+                            "now or delete these credentials and create a new "
+                            "pair."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_credentials_api3", e)
+
+    @server.tool(
+        description=(
+            "Get metadata for a specific API3 credential pair. The "
+            "``client_secret`` is never returned after creation — use this "
+            "only to read ``client_id``, timestamps, and enabled state."
+        ),
+    )
+    async def get_credentials_api3(
+        user_id: Annotated[str, "User ID"],
+        credentials_api3_id: Annotated[str, "API3 credential pair ID (from list_credentials_api3)"],
+    ) -> str:
+        ctx = client.build_context(
+            "get_credentials_api3",
+            "credentials",
+            {"user_id": user_id, "credentials_api3_id": credentials_api3_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(
+                    f"/users/{_path_seg(user_id)}/credentials_api3/{_path_seg(credentials_api3_id)}"
+                )
+                return json.dumps(creds, indent=2)
+        except Exception as e:
+            return format_api_error("get_credentials_api3", e)
+
+    @server.tool(
+        description=(
+            "Delete an API3 credential pair. Any integration using the pair's "
+            "``client_id``/``client_secret`` will stop being able to "
+            "authenticate immediately. This action cannot be undone."
+        ),
+    )
+    async def delete_credentials_api3(
+        user_id: Annotated[str, "User ID"],
+        credentials_api3_id: Annotated[str, "API3 credential pair ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "delete_credentials_api3",
+            "credentials",
+            {"user_id": user_id, "credentials_api3_id": credentials_api3_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(
+                    f"/users/{_path_seg(user_id)}/credentials_api3/{_path_seg(credentials_api3_id)}"
+                )
+                return json.dumps(
+                    {
+                        "deleted": True,
+                        "user_id": user_id,
+                        "credentials_api3_id": credentials_api3_id,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_credentials_api3", e)
+
+    # ── LDAP ─────────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get a user's LDAP credential link. Returns the LDAP DN or email "
+            "the user is bound to, plus its enabled state. Returns a 404-shaped "
+            "error if no LDAP link exists."
+        ),
+    )
+    async def get_credentials_ldap(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("get_credentials_ldap", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_ldap")
+                return json.dumps(creds, indent=2)
+        except Exception as e:
+            return format_api_error("get_credentials_ldap", e)
+
+    @server.tool(
+        description=(
+            "Remove a user's LDAP credential link. They will no longer be able "
+            "to authenticate via LDAP until the link is re-established (which "
+            "typically happens automatically on their next LDAP sign-in)."
+        ),
+    )
+    async def delete_credentials_ldap(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("delete_credentials_ldap", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/users/{_path_seg(user_id)}/credentials_ldap")
+                return json.dumps({"deleted": True, "user_id": user_id}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_credentials_ldap", e)
+
+    # ── SAML ─────────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get a user's SAML credential link. Returns the SAML subject/email and enabled state."
+        ),
+    )
+    async def get_credentials_saml(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("get_credentials_saml", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_saml")
+                return json.dumps(creds, indent=2)
+        except Exception as e:
+            return format_api_error("get_credentials_saml", e)
+
+    @server.tool(
+        description=(
+            "Remove a user's SAML credential link. Re-established automatically "
+            "on the user's next successful SAML sign-in."
+        ),
+    )
+    async def delete_credentials_saml(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("delete_credentials_saml", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/users/{_path_seg(user_id)}/credentials_saml")
+                return json.dumps({"deleted": True, "user_id": user_id}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_credentials_saml", e)
+
+    # ── OIDC ─────────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get a user's OIDC credential link. Returns the OIDC subject and enabled state."
+        ),
+    )
+    async def get_credentials_oidc(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("get_credentials_oidc", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_oidc")
+                return json.dumps(creds, indent=2)
+        except Exception as e:
+            return format_api_error("get_credentials_oidc", e)
+
+    @server.tool(
+        description=(
+            "Remove a user's OIDC credential link. Re-established automatically "
+            "on the user's next successful OIDC sign-in."
+        ),
+    )
+    async def delete_credentials_oidc(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("delete_credentials_oidc", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/users/{_path_seg(user_id)}/credentials_oidc")
+                return json.dumps({"deleted": True, "user_id": user_id}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_credentials_oidc", e)
+
+    # ── Google ───────────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get a user's Google (OAuth) credential link. Returns the linked "
+            "Google email and enabled state."
+        ),
+    )
+    async def get_credentials_google(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("get_credentials_google", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_google")
+                return json.dumps(creds, indent=2)
+        except Exception as e:
+            return format_api_error("get_credentials_google", e)
+
+    @server.tool(
+        description=(
+            "Remove a user's Google (OAuth) credential link. Re-established "
+            "automatically when the user next signs in via Google."
+        ),
+    )
+    async def delete_credentials_google(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("delete_credentials_google", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/users/{_path_seg(user_id)}/credentials_google")
+                return json.dumps({"deleted": True, "user_id": user_id}, indent=2)
+        except Exception as e:
+            return format_api_error("delete_credentials_google", e)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -98,6 +98,7 @@ class TestGroupConstants:
             "admin",
             "connection",
             "user_attributes",
+            "credentials",
             "health",
         }
         assert ALL_GROUPS == expected

--- a/tests/test_credentials_tools.py
+++ b/tests/test_credentials_tools.py
@@ -1,0 +1,282 @@
+"""Tests for credentials tool group — non-email user credentials."""
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerClient
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+async def server_and_client(config):
+    mcp, client = create_server(config, enabled_groups={"credentials"})
+    try:
+        yield mcp, client
+    finally:
+        await client.close()
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestServerRegistration:
+    @pytest.mark.asyncio
+    async def test_credentials_registers(self, server_and_client):
+        mcp, _ = server_and_client
+        assert mcp is not None
+
+    def test_credentials_in_all_groups(self):
+        from looker_mcp_server.config import ALL_GROUPS
+
+        assert "credentials" in ALL_GROUPS
+
+
+# ══ API3 ═════════════════════════════════════════════════════════════
+
+
+class TestApi3Lifecycle:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_returns_trimmed_summary(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/users/42/credentials_api3").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "1",
+                        "client_id": "abc123",
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "is_disabled": False,
+                    },
+                    {
+                        "id": "2",
+                        "client_id": "xyz789",
+                        "created_at": "2026-02-01T00:00:00Z",
+                        "is_disabled": True,
+                    },
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_credentials_api3", "credentials", {"user_id": "42"})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get("/users/42/credentials_api3")
+                assert len(creds) == 2
+                assert creds[0]["client_id"] == "abc123"
+                assert creds[1]["is_disabled"] is True
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_returns_client_secret_once(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/users/42/credentials_api3").mock(
+            return_value=httpx.Response(
+                201,
+                json={
+                    "id": "99",
+                    "client_id": "new-client",
+                    "client_secret": "ONCE-ONLY-SECRET",
+                    "created_at": "2026-04-15T00:00:00Z",
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_credentials_api3", "credentials", {"user_id": "42"})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.post("/users/42/credentials_api3")
+                # Contract: Looker returns client_secret exactly once — on
+                # creation.  Tool's responsibility is to surface it.
+                assert creds["client_secret"] == "ONCE-ONLY-SECRET"
+                assert creds["id"] == "99"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_never_includes_secret(self, config):
+        _mock_login_logout()
+        # Looker's GET endpoint never returns client_secret post-creation.
+        respx.get(f"{API_URL}/users/42/credentials_api3/99").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "99",
+                    "client_id": "new-client",
+                    "created_at": "2026-04-15T00:00:00Z",
+                    "is_disabled": False,
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "get_credentials_api3",
+            "credentials",
+            {"user_id": "42", "credentials_api3_id": "99"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get("/users/42/credentials_api3/99")
+                assert "client_secret" not in creds
+                assert creds["client_id"] == "new-client"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_returns_success(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/users/42/credentials_api3/99").mock(
+            return_value=httpx.Response(204)
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "delete_credentials_api3",
+            "credentials",
+            {"user_id": "42", "credentials_api3_id": "99"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                assert await session.delete("/users/42/credentials_api3/99") is None
+        finally:
+            await client.close()
+
+
+# ══ Single-instance SSO types ════════════════════════════════════════
+# LDAP / SAML / OIDC / Google all follow the same URL pattern:
+#   /users/{id}/credentials_{type}
+# A single parametrized class exercises the pattern once per type.
+
+
+SSO_TYPES = ["ldap", "saml", "oidc", "google"]
+
+
+class TestSsoCredentials:
+    @pytest.mark.parametrize("cred_type", SSO_TYPES)
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_returns_credential_link(self, config, cred_type):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/users/42/credentials_{cred_type}").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "email": "user-42@example.com",
+                    "is_disabled": False,
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            f"get_credentials_{cred_type}",
+            "credentials",
+            {"user_id": "42"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/42/credentials_{cred_type}")
+                assert creds["email"] == "user-42@example.com"
+        finally:
+            await client.close()
+
+    @pytest.mark.parametrize("cred_type", SSO_TYPES)
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_returns_success(self, config, cred_type):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/users/42/credentials_{cred_type}").mock(
+            return_value=httpx.Response(204)
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            f"delete_credentials_{cred_type}",
+            "credentials",
+            {"user_id": "42"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                assert await session.delete(f"/users/42/credentials_{cred_type}") is None
+        finally:
+            await client.close()
+
+
+# ══ Path encoding regression ═════════════════════════════════════════
+
+
+class TestPathEncoding:
+    """Defensive encoding: user_ids and api3 ids flow through _path_seg."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_special_character_ids_are_encoded(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["raw_path"] = request.url.raw_path.decode("ascii")
+            return httpx.Response(200, json={"id": "99"})
+
+        respx.get(url__regex=rf"{API_URL}/users/.*/credentials_api3/.*").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "get_credentials_api3",
+            "credentials",
+            {"user_id": "42/../boom", "credentials_api3_id": "99 weird"},
+        )
+        try:
+            from urllib.parse import quote
+
+            async with client.session(ctx) as session:
+                # Simulate what _path_seg produces in the tool.
+                path = (
+                    f"/users/{quote('42/../boom', safe='')}"
+                    f"/credentials_api3/{quote('99 weird', safe='')}"
+                )
+                await session.get(path)
+                # Slash in user_id must be encoded (otherwise the request
+                # routes to /users/42/../boom/... which is entirely different).
+                assert "42%2F..%2Fboom" in captured["raw_path"]
+                # Space in credentials_api3_id must be encoded.
+                assert "99%20weird" in captured["raw_path"]
+        finally:
+            await client.close()

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Adds a new **`credentials`** tool group (12 tools, opt-in) covering the user-credential types not already in `admin`. Complements the existing `create_credentials_email` and `send_password_reset` in the `admin` group; together they now span the full credential surface (email + API3 + 4 SSO types).

### API3 key pairs (service-account rotation workflow)

| Tool | Endpoint | Notes |
|---|---|---|
| `list_credentials_api3` | `GET /users/{id}/credentials_api3` | Audit pairs before rotating |
| `create_credentials_api3` | `POST /users/{id}/credentials_api3` | **Response is the only place Looker surfaces `client_secret`** — tool returns it with an explicit one-time-only warning |
| `get_credentials_api3` | `GET /users/{id}/credentials_api3/{creds_id}` | Metadata only; never returns secret |
| `delete_credentials_api3` | `DELETE /users/{id}/credentials_api3/{creds_id}` | Revokes one pair |

### Single-instance SSO credential links (4 types × get + delete = 8 tools)

`get_credentials_{type}` / `delete_credentials_{type}` for each of: `ldap`, `saml`, `oidc`, `google`.

Deletion unlinks the user from that identity provider; most providers re-link automatically on the user's next successful sign-in. Tool descriptions call this out so agents know when a delete is reversible versus terminal.

## Design notes

- **New group, not added to `admin`.** `admin` is already 33 tools; breaking `credentials` out matches the `connection` / `user_attributes` pattern established on recent PRs. Users who want full admin capability can still `--groups admin,credentials`.
- **`client_secret` visibility.** `create_credentials_api3` explicitly surfaces the secret in the response with a ``warning`` field. No other endpoint ever returns it — `list_*` and `get_*` return metadata only, and `TestApi3Lifecycle.test_get_never_includes_secret` asserts that the tool doesn't accidentally pass a secret through on a GET path.
- **Path encoding.** `user_id` and `credentials_api3_id` are both routed through the shared `_path_seg` helper in `tools/_helpers.py` (introduced in v0.7.0 on #10). `TestPathEncoding` uses a slash-containing `user_id` (`"42/../boom"`) to prove the encoding prevents path-traversal-style misrouting.
- **Parametrized tests for the SSO types.** LDAP/SAML/OIDC/Google all have identical URL shapes, so `TestSsoCredentials` uses `@pytest.mark.parametrize` to cover all four at once — 8 test cases in 30 lines of code.

## Deferred to a follow-up

- `credentials_embed` (multi-instance, different shape than API3 — warrants its own review pass)
- `credentials_looker_openid` (Looker's legacy auth, rarely used)
- Explicit `create_credentials_{ldap,saml,oidc,google}` (uncommon — most SSO providers auto-link on first sign-in)

## Changes

- `src/looker_mcp_server/tools/credentials.py` — new tool group (12 tools, ~310 LOC)
- `src/looker_mcp_server/config.py` — add `credentials` to `ALL_GROUPS`
- `src/looker_mcp_server/server.py` — register via `_group_registry`
- `tests/test_credentials_tools.py` — 15 respx-mocked tests
- `tests/test_config.py` — extend pinned group list
- `README.md` — tool count 115 → 127; new row in the groups table
- `CHANGELOG.md` — v0.8.0 entry
- `pyproject.toml` — bump to 0.8.0

Tool count: **115 → 127** across **12 → 13** groups.

## Test plan

- [x] `uv run ruff format --check .` — 33 files clean
- [x] `uv run ruff check .` — 0 errors
- [x] `uv run pyright src tests` — 0 errors, 0 warnings
- [x] `uv run pytest` — 107/107 pass (15 new)
- [ ] Manual smoke against a dev Looker instance: create an API3 pair → capture the secret → list → delete → verify 404 on subsequent get

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added credentials tool group with 12 tools for managing non-email user credentials, including API3 key-pair lifecycle operations (list, create, get, delete) and identity provider credential management for LDAP, SAML, OIDC, and Google.

* **Documentation**
  * Updated release notes and documentation reflecting version 0.8.0 with expanded tool inventory (127 tools across 13 groups).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->