### PR TITLE
feat: add audit tool group for query history and live-ops observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-04-15
+
+### Added
+
+- **audit** tool group (13 tools): observability surface covering query history, content usage, PDT/schedule logs, event audit, and live-ops triage.
+  - `system__activity` wrappers (5): `get_query_history`, `get_content_usage`, `get_pdt_build_log`, `get_schedule_history`, `get_user_activity_log`. Each composes the right explore + field set + filters over Looker's built-in audit model so callers don't have to know the schema; custom queries can still use the generic `query` tool.
+  - Live-ops (8): `list_running_queries` + `kill_query` for active-query triage, `list_active_sessions` + `get_session` + `terminate_session` for session audit and offboarding, and `list_project_ci_runs` + `get_project_ci_run` + `trigger_project_ci_run` for LookML CI visibility.
+- Total tool count: 127 → 140 across 14 groups
+
 ## [0.8.0] - 2026-04-15
 
 ### Added
@@ -141,6 +150,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[0.9.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.6.0...v0.7.0
 [0.5.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.4.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **127 tools** across 13 groups covering the full Looker API surface
+- **140 tools** across 14 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -112,6 +112,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **connection** | `get_connection`, `list_connection_dialects`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` | Database connection CRUD and health checks |
 | **user_attributes** | `list_user_attributes`, `get_user_attribute`, `create_user_attribute`, `update_user_attribute`, `delete_user_attribute`, `list_user_attribute_group_values`, `set_user_attribute_group_values`, `delete_user_attribute_group_value`, `list_user_attribute_values_for_user`, `set_user_attribute_user_value`, `delete_user_attribute_user_value` | User attribute definitions plus per-group and per-user value overrides (row-level security, per-developer credentials, filter defaults) |
 | **credentials** | `list_credentials_api3`, `create_credentials_api3`, `get_credentials_api3`, `delete_credentials_api3`, `get_credentials_ldap`, `delete_credentials_ldap`, `get_credentials_saml`, `delete_credentials_saml`, `get_credentials_oidc`, `delete_credentials_oidc`, `get_credentials_google`, `delete_credentials_google` | Non-email credentials — API3 key-pair rotation plus get/delete for LDAP, SAML, OIDC, and Google SSO links |
+| **audit** | `get_query_history`, `get_content_usage`, `get_pdt_build_log`, `get_schedule_history`, `get_user_activity_log`, `list_running_queries`, `kill_query`, `list_active_sessions`, `get_session`, `terminate_session`, `list_project_ci_runs`, `get_project_ci_run`, `trigger_project_ci_run` | Query history, content usage, PDT build + schedule + event logs via system__activity, plus live-ops (running queries, sessions, CI runs) |
 
 ### Selecting Groups
 
@@ -122,7 +123,7 @@ looker-mcp-server
 # Specific groups
 looker-mcp-server --groups explore,query
 
-# All groups (including board, folder, modeling, git, admin, connection, user_attributes, credentials)
+# All groups (including board, folder, modeling, git, admin, connection, user_attributes, credentials, audit)
 looker-mcp-server --groups all
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.8.0"
+version = "0.9.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -23,6 +23,7 @@ ALL_GROUPS = frozenset(
         "connection",
         "user_attributes",
         "credentials",
+        "audit",
         "health",
     }
 )

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -78,6 +78,7 @@ def create_server(
     groups = enabled_groups or DEFAULT_GROUPS
 
     from .tools.admin import register_admin_tools
+    from .tools.audit import register_audit_tools
     from .tools.board import register_board_tools
     from .tools.connection import register_connection_tools
     from .tools.content import register_content_tools
@@ -104,6 +105,7 @@ def create_server(
         "connection": register_connection_tools,
         "user_attributes": register_user_attribute_tools,
         "credentials": register_credentials_tools,
+        "audit": register_audit_tools,
         "health": register_health_tools,
     }
 

--- a/src/looker_mcp_server/tools/audit.py
+++ b/src/looker_mcp_server/tools/audit.py
@@ -1,0 +1,497 @@
+"""Audit tool group — query history, content usage, live-ops observability.
+
+Covers two observability surfaces:
+
+1. **``system__activity`` wrappers** — thin convenience queries over
+   Looker's built-in ``system__activity`` LookML model, which is the
+   canonical source of query history, content usage, PDT build logs,
+   scheduled-plan run history, and event/login audit data. Each wrapper
+   composes the right explore + fields + filters for a common audit
+   question so callers don't have to know the schema; custom queries
+   against ``system__activity`` can still use the generic ``query`` tool.
+
+2. **Live-ops REST endpoints** — current instance state that isn't
+   available through ``system__activity``: running queries, active user
+   sessions, and project CI runs.  These are higher-velocity signals used
+   for triage rather than historical audit.
+
+Admin-only surface; disabled by default. Enable with ``--groups audit``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+from ._helpers import _path_seg
+
+
+def register_audit_tools(server: FastMCP, client: LookerClient) -> None:
+    # ── system__activity wrappers ────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Audit query history from Looker's system__activity model. "
+            "Returns rows of {time, user, model/explore, runtime, status, "
+            "source} for queries run in the given window. Default sort is "
+            "slowest-first, which surfaces runaway queries and cache misses. "
+            "Use to answer: who ran what, when, how long did it take, which "
+            "cache tier, did it fail?"
+        ),
+    )
+    async def get_query_history(
+        date_range: Annotated[
+            str,
+            (
+                "Looker filter-syntax date expression, e.g. '7 days', "
+                "'yesterday', '2026-04-01 to 2026-04-15'"
+            ),
+        ] = "7 days",
+        user_email: Annotated[str | None, "Filter to a single user's queries"] = None,
+        dashboard_id: Annotated[
+            str | None, "Filter to queries issued from a specific dashboard"
+        ] = None,
+        min_runtime_seconds: Annotated[
+            float | None, "Exclude queries that ran faster than this threshold"
+        ] = None,
+        errors_only: Annotated[bool, "Only include queries whose status is not 'complete'"] = False,
+        limit: Annotated[int, "Maximum rows to return"] = 500,
+    ) -> str:
+        filters: dict[str, str] = {"history.created_time": date_range}
+        if user_email is not None:
+            filters["user.email"] = user_email
+        if dashboard_id is not None:
+            filters["dashboard.id"] = dashboard_id
+        if min_runtime_seconds is not None:
+            filters["history.runtime"] = f">={min_runtime_seconds}"
+        if errors_only:
+            filters["history.status"] = "-complete"
+
+        return await _run_system_activity_query(
+            client=client,
+            tool_name="get_query_history",
+            explore="history",
+            fields=[
+                "history.created_time",
+                "user.email",
+                "query.model",
+                "query.view",
+                "history.runtime",
+                "history.status",
+                "history.issuer_source",
+                "history.result_source",
+                "dashboard.id",
+                "look.id",
+            ],
+            filters=filters,
+            sorts=["history.runtime desc"],
+            limit=limit,
+        )
+
+    @server.tool(
+        description=(
+            "Audit content usage (dashboards + looks) over a time window. "
+            "Returns each piece of content with its view count, API count, "
+            "and last-viewed timestamp. Default sort is most-viewed first. "
+            "Use to identify popular or stale content, or to answer 'is "
+            "anyone still using dashboard X before I delete it'."
+        ),
+    )
+    async def get_content_usage(
+        date_range: Annotated[str, "Looker filter-syntax date expression"] = "30 days",
+        content_type: Annotated[str, "'dashboard', 'look', or 'all' (both types)"] = "all",
+        min_views: Annotated[int, "Exclude content with fewer views than this"] = 0,
+        limit: Annotated[int, "Maximum rows to return"] = 100,
+    ) -> str:
+        filters: dict[str, str] = {"history.created_date": date_range}
+        if content_type != "all":
+            filters["content_usage.content_type"] = content_type
+        if min_views > 0:
+            filters["content_usage.view_count"] = f">={min_views}"
+
+        return await _run_system_activity_query(
+            client=client,
+            tool_name="get_content_usage",
+            explore="content_usage",
+            fields=[
+                "content_usage.content_type",
+                "content_usage.content_id",
+                "content_usage.content_title",
+                "content_usage.last_accessed_date",
+                "content_usage.view_count",
+                "content_usage.api_count",
+            ],
+            filters=filters,
+            sorts=["content_usage.view_count desc"],
+            limit=limit,
+        )
+
+    @server.tool(
+        description=(
+            "Audit PDT (Persistent Derived Table) build events. Returns rows "
+            "describing each build attempt — when it ran, against which "
+            "model/view, runtime, status, and any error message. Filter by "
+            "``failed_only`` to triage broken PDTs."
+        ),
+    )
+    async def get_pdt_build_log(
+        date_range: Annotated[str, "Looker filter-syntax date expression"] = "7 days",
+        model: Annotated[str | None, "Filter to one LookML model"] = None,
+        view: Annotated[str | None, "Filter to one view (PDT name)"] = None,
+        failed_only: Annotated[bool, "Only include builds with errors"] = False,
+        limit: Annotated[int, "Maximum rows to return"] = 500,
+    ) -> str:
+        filters: dict[str, str] = {"pdt_event_log.created_time": date_range}
+        if model is not None:
+            filters["pdt_event_log.model_name"] = model
+        if view is not None:
+            filters["pdt_event_log.view_name"] = view
+        if failed_only:
+            filters["pdt_event_log.status_code"] = "error"
+
+        return await _run_system_activity_query(
+            client=client,
+            tool_name="get_pdt_build_log",
+            explore="pdt_event_log",
+            fields=[
+                "pdt_event_log.created_time",
+                "pdt_event_log.model_name",
+                "pdt_event_log.view_name",
+                "pdt_event_log.action_name",
+                "pdt_event_log.status_code",
+                "pdt_event_log.runtime",
+                "pdt_event_log.message",
+            ],
+            filters=filters,
+            sorts=["pdt_event_log.created_time desc"],
+            limit=limit,
+        )
+
+    @server.tool(
+        description=(
+            "Audit scheduled-plan run history. Returns one row per run with "
+            "plan title, owner, timestamp, and status. Filter by "
+            "``failed_only`` to triage broken schedules (most common use)."
+        ),
+    )
+    async def get_schedule_history(
+        date_range: Annotated[str, "Looker filter-syntax date expression"] = "7 days",
+        schedule_id: Annotated[str | None, "Filter to one schedule"] = None,
+        failed_only: Annotated[bool, "Only include non-successful runs"] = False,
+        limit: Annotated[int, "Maximum rows to return"] = 500,
+    ) -> str:
+        filters: dict[str, str] = {"scheduled_job.finalized_time": date_range}
+        if schedule_id is not None:
+            filters["scheduled_plan.id"] = schedule_id
+        if failed_only:
+            filters["scheduled_job.status"] = "-success"
+
+        return await _run_system_activity_query(
+            client=client,
+            tool_name="get_schedule_history",
+            explore="scheduled_plan",
+            fields=[
+                "scheduled_job.finalized_time",
+                "scheduled_plan.id",
+                "scheduled_plan.name",
+                "user.email",
+                "scheduled_job.status",
+                "scheduled_job.status_detail",
+            ],
+            filters=filters,
+            sorts=["scheduled_job.finalized_time desc"],
+            limit=limit,
+        )
+
+    @server.tool(
+        description=(
+            "Audit Looker event log (logins, permission changes, content "
+            "create/update/delete, sudo activity). Returns rows of "
+            "{time, user, event_type, object_type, object_id}. Use to "
+            "answer 'who changed permissions on X' or 'who has logged in "
+            "recently'. ``event_types`` accepts a comma-separated list — "
+            "common values: 'login', 'logout', 'create_dashboard', "
+            "'update_user', 'sudo_login'."
+        ),
+    )
+    async def get_user_activity_log(
+        date_range: Annotated[str, "Looker filter-syntax date expression"] = "7 days",
+        user_email: Annotated[str | None, "Filter to one user's events"] = None,
+        event_types: Annotated[str | None, "Comma-separated list of event names to include"] = None,
+        limit: Annotated[int, "Maximum rows to return"] = 500,
+    ) -> str:
+        filters: dict[str, str] = {"event.created_time": date_range}
+        if user_email is not None:
+            filters["user.email"] = user_email
+        if event_types is not None:
+            filters["event.name"] = event_types
+
+        return await _run_system_activity_query(
+            client=client,
+            tool_name="get_user_activity_log",
+            explore="event",
+            fields=[
+                "event.created_time",
+                "user.email",
+                "event.name",
+                "event.object_type",
+                "event.object_id",
+            ],
+            filters=filters,
+            sorts=["event.created_time desc"],
+            limit=limit,
+        )
+
+    # ── Live-ops: running queries ────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "List currently-running queries against the Looker instance. "
+            "Returns query_task_id, source (e.g. dashboard, api, explore), "
+            "runtime-so-far, and the user who issued the query. Use for "
+            "triage when the instance is slow — pair with ``kill_query`` "
+            "to stop runaway queries."
+        ),
+    )
+    async def list_running_queries() -> str:
+        ctx = client.build_context("list_running_queries", "audit")
+        try:
+            async with client.session(ctx) as session:
+                running = await session.get("/running_queries")
+                result = [
+                    {
+                        "query_task_id": q.get("query_task_id"),
+                        "query_id": q.get("query_id"),
+                        "source": q.get("source"),
+                        "created_at": q.get("created_at"),
+                        "runtime": q.get("runtime"),
+                        "user_id": q.get("user_id"),
+                        "user": (q.get("user") or {}).get("email"),
+                    }
+                    for q in (running or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_running_queries", e)
+
+    @server.tool(
+        description=(
+            "Kill a currently-running query by its query_task_id (from "
+            "``list_running_queries``). The query's database work is "
+            "aborted and the issuing user sees an error. Use sparingly — "
+            "killing a query mid-flight can leave partial state in scratch "
+            "schemas for some databases."
+        ),
+    )
+    async def kill_query(
+        query_task_id: Annotated[str, "query_task_id of the running query"],
+    ) -> str:
+        ctx = client.build_context("kill_query", "audit", {"query_task_id": query_task_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/running_queries/{_path_seg(query_task_id)}")
+                return json.dumps({"killed": True, "query_task_id": query_task_id}, indent=2)
+        except Exception as e:
+            return format_api_error("kill_query", e)
+
+    # ── Live-ops: sessions ───────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "List all currently active user sessions on the Looker instance. "
+            "Returns session id, user, IP, created time, and expiration. "
+            "Use for compliance audits or to identify stale sessions before "
+            "terminating them."
+        ),
+    )
+    async def list_active_sessions() -> str:
+        ctx = client.build_context("list_active_sessions", "audit")
+        try:
+            async with client.session(ctx) as session:
+                sessions_list = await session.get("/sessions")
+                result = [
+                    {
+                        "id": s.get("id"),
+                        "user_id": s.get("user_id"),
+                        "ip_address": s.get("ip_address"),
+                        "browser": s.get("browser"),
+                        "created_at": s.get("created_at"),
+                        "expires_at": s.get("expires_at"),
+                        "extended_at": s.get("extended_at"),
+                    }
+                    for s in (sessions_list or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_active_sessions", e)
+
+    @server.tool(
+        description=(
+            "Get metadata for a single session by id (from "
+            "``list_active_sessions``). Useful when auditing a specific "
+            "session without enumerating the whole list."
+        ),
+    )
+    async def get_session(
+        session_id: Annotated[str, "Session ID"],
+    ) -> str:
+        ctx = client.build_context("get_session", "audit", {"session_id": session_id})
+        try:
+            async with client.session(ctx) as session:
+                data = await session.get(f"/sessions/{_path_seg(session_id)}")
+                return json.dumps(data, indent=2)
+        except Exception as e:
+            return format_api_error("get_session", e)
+
+    @server.tool(
+        description=(
+            "Terminate a user session by id. The user is signed out and "
+            "will need to re-authenticate. Use for offboarding or to force "
+            "re-auth after a permission change."
+        ),
+    )
+    async def terminate_session(
+        session_id: Annotated[str, "Session ID to terminate"],
+    ) -> str:
+        ctx = client.build_context("terminate_session", "audit", {"session_id": session_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/sessions/{_path_seg(session_id)}")
+                return json.dumps({"terminated": True, "session_id": session_id}, indent=2)
+        except Exception as e:
+            return format_api_error("terminate_session", e)
+
+    # ── Live-ops: project CI runs ────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "List Looker CI (continuous integration) runs for a LookML "
+            "project. Returns each run with its trigger, status, "
+            "started/finalized timestamps, and summary counts. Use to "
+            "answer 'is the CI pipeline healthy' or 'when did LookML "
+            "validation last pass'."
+        ),
+    )
+    async def list_project_ci_runs(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context("list_project_ci_runs", "audit", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                runs = await session.get(f"/projects/{_path_seg(project_id)}/ci/runs")
+                result = [
+                    {
+                        "id": r.get("id"),
+                        "status": r.get("status"),
+                        "trigger": r.get("trigger"),
+                        "branch": r.get("branch"),
+                        "started_at": r.get("started_at"),
+                        "finalized_at": r.get("finalized_at"),
+                    }
+                    for r in (runs or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_project_ci_runs", e)
+
+    @server.tool(
+        description=(
+            "Get details for a single CI run, including the per-suite "
+            "results and any error messages. Useful to diagnose a CI "
+            "failure surfaced by ``list_project_ci_runs``."
+        ),
+    )
+    async def get_project_ci_run(
+        project_id: Annotated[str, "LookML project ID"],
+        run_id: Annotated[str, "CI run ID"],
+    ) -> str:
+        ctx = client.build_context(
+            "get_project_ci_run",
+            "audit",
+            {"project_id": project_id, "run_id": run_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                run = await session.get(
+                    f"/projects/{_path_seg(project_id)}/ci/runs/{_path_seg(run_id)}"
+                )
+                return json.dumps(run, indent=2)
+        except Exception as e:
+            return format_api_error("get_project_ci_run", e)
+
+    @server.tool(
+        description=(
+            "Trigger a new CI run for a LookML project. Returns the run "
+            "id so the caller can poll ``get_project_ci_run`` for "
+            "completion. Pair with the ``modeling`` group's "
+            "``validate_project`` for ad-hoc LookML validation — CI runs "
+            "exercise the full configured suite set."
+        ),
+    )
+    async def trigger_project_ci_run(
+        project_id: Annotated[str, "LookML project ID"],
+        branch: Annotated[
+            str | None,
+            "Branch to validate (defaults to the project's production branch)",
+        ] = None,
+    ) -> str:
+        ctx = client.build_context("trigger_project_ci_run", "audit", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                if branch is not None:
+                    body["branch"] = branch
+                run = await session.post(
+                    f"/projects/{_path_seg(project_id)}/ci/runs", body=body or None
+                )
+                return json.dumps(
+                    {
+                        "id": run.get("id") if run else None,
+                        "status": run.get("status") if run else None,
+                        "triggered": True,
+                        "next_step": ("Poll get_project_ci_run to watch for completion."),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("trigger_project_ci_run", e)
+
+
+async def _run_system_activity_query(
+    *,
+    client: LookerClient,
+    tool_name: str,
+    explore: str,
+    fields: list[str],
+    filters: dict[str, str],
+    sorts: list[str] | None = None,
+    limit: int = 500,
+) -> str:
+    """Compose + run an inline query against the ``system__activity`` model.
+
+    Thin wrapper around ``POST /queries`` + ``GET /queries/{id}/run/json``.
+    Each audit tool picks the right explore, field list, and filter map for
+    its question; this helper handles the boilerplate.
+    """
+    ctx = client.build_context(tool_name, "audit", {"explore": explore})
+    try:
+        async with client.session(ctx) as session:
+            body: dict[str, Any] = {
+                "model": "system__activity",
+                "view": explore,
+                "fields": fields,
+                "filters": filters,
+                "limit": str(limit),
+            }
+            if sorts:
+                body["sorts"] = sorts
+
+            query_def = await session.post("/queries", body=body)
+            rows = await session.get(f"/queries/{_path_seg(str(query_def['id']))}/run/json")
+            row_count = len(rows) if isinstance(rows, list) else 0
+            return json.dumps({"row_count": row_count, "rows": rows}, indent=2)
+    except Exception as e:
+        return format_api_error(tool_name, e)

--- a/tests/test_audit_tools.py
+++ b/tests/test_audit_tools.py
@@ -1,0 +1,420 @@
+"""Tests for audit tool group — query history, content usage, live-ops observability."""
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerClient
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+async def server_and_client(config):
+    mcp, client = create_server(config, enabled_groups={"audit"})
+    try:
+        yield mcp, client
+    finally:
+        await client.close()
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+def _mock_system_activity_query(
+    captured_body: dict,
+    rows: list[dict],
+    query_id: str = "abc123",
+) -> None:
+    """Stand up the two-hop query flow: POST /queries, then GET /queries/{id}/run/json."""
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        captured_body["body"] = json.loads(request.content.decode())
+        return httpx.Response(201, json={"id": query_id})
+
+    respx.post(f"{API_URL}/queries").mock(side_effect=capture)
+    respx.get(f"{API_URL}/queries/{query_id}/run/json").mock(
+        return_value=httpx.Response(200, json=rows)
+    )
+
+
+class TestServerRegistration:
+    @pytest.mark.asyncio
+    async def test_audit_registers(self, server_and_client):
+        mcp, _ = server_and_client
+        assert mcp is not None
+
+    def test_audit_in_all_groups(self):
+        from looker_mcp_server.config import ALL_GROUPS
+
+        assert "audit" in ALL_GROUPS
+
+
+# ══ system__activity wrappers ════════════════════════════════════════
+
+
+class TestGetQueryHistory:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_builds_system_activity_query(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+        _mock_system_activity_query(
+            captured,
+            rows=[
+                {
+                    "history.created_time": "2026-04-15 10:00",
+                    "user.email": "a@example.com",
+                    "query.model": "ecommerce",
+                    "history.runtime": 12.3,
+                    "history.status": "complete",
+                }
+            ],
+        )
+
+        from fastmcp import Client
+        from mcp.types import TextContent
+
+        mcp, client = create_server(config, enabled_groups={"audit"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "get_query_history",
+                    {"date_range": "7 days", "errors_only": True},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["row_count"] == 1
+
+                # The POST body should be the system__activity history query
+                # with our filters applied.
+                assert captured["body"]["model"] == "system__activity"
+                assert captured["body"]["view"] == "history"
+                assert "history.created_time" in captured["body"]["filters"]
+                assert captured["body"]["filters"]["history.status"] == "-complete"
+                assert captured["body"]["sorts"] == ["history.runtime desc"]
+        finally:
+            await client.close()
+
+
+class TestGetContentUsage:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_scopes_to_content_type(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+        _mock_system_activity_query(captured, rows=[])
+
+        from fastmcp import Client
+
+        mcp, client = create_server(config, enabled_groups={"audit"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "get_content_usage",
+                    {"content_type": "dashboard", "min_views": 10},
+                )
+                assert captured["body"]["view"] == "content_usage"
+                assert captured["body"]["filters"]["content_usage.content_type"] == "dashboard"
+                assert captured["body"]["filters"]["content_usage.view_count"] == ">=10"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_all_content_type_does_not_filter(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+        _mock_system_activity_query(captured, rows=[])
+
+        from fastmcp import Client
+
+        mcp, client = create_server(config, enabled_groups={"audit"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool("get_content_usage", {"content_type": "all"})
+                # 'all' means no content_type filter — must not be in the body.
+                assert "content_usage.content_type" not in captured["body"]["filters"]
+        finally:
+            await client.close()
+
+
+class TestGetPdtBuildLog:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_failed_only_filter(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+        _mock_system_activity_query(captured, rows=[])
+
+        from fastmcp import Client
+
+        mcp, client = create_server(config, enabled_groups={"audit"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "get_pdt_build_log", {"failed_only": True, "model": "ecommerce"}
+                )
+                assert captured["body"]["view"] == "pdt_event_log"
+                assert captured["body"]["filters"]["pdt_event_log.status_code"] == "error"
+                assert captured["body"]["filters"]["pdt_event_log.model_name"] == "ecommerce"
+        finally:
+            await client.close()
+
+
+class TestGetScheduleHistory:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_failed_only_uses_negative_filter(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+        _mock_system_activity_query(captured, rows=[])
+
+        from fastmcp import Client
+
+        mcp, client = create_server(config, enabled_groups={"audit"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool("get_schedule_history", {"failed_only": True})
+                # Looker filter syntax: "-value" means "not equal to".
+                assert captured["body"]["filters"]["scheduled_job.status"] == "-success"
+        finally:
+            await client.close()
+
+
+class TestGetUserActivityLog:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_event_types_pass_through(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+        _mock_system_activity_query(captured, rows=[])
+
+        from fastmcp import Client
+
+        mcp, client = create_server(config, enabled_groups={"audit"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "get_user_activity_log",
+                    {
+                        "event_types": "login,logout",
+                        "user_email": "a@example.com",
+                    },
+                )
+                assert captured["body"]["view"] == "event"
+                assert captured["body"]["filters"]["event.name"] == "login,logout"
+                assert captured["body"]["filters"]["user.email"] == "a@example.com"
+        finally:
+            await client.close()
+
+
+# ══ Live-ops: running queries + sessions ═════════════════════════════
+
+
+class TestRunningQueries:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_returns_trimmed_summary(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/running_queries").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "query_task_id": "task-1",
+                        "query_id": 42,
+                        "source": "dashboard",
+                        "runtime": 8.1,
+                        "user_id": 7,
+                        "user": {"email": "ops@example.com"},
+                    }
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_running_queries", "audit")
+        try:
+            async with client.session(ctx) as session:
+                running = await session.get("/running_queries")
+                assert running[0]["query_task_id"] == "task-1"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_kill_hits_delete_endpoint(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/running_queries/task-1").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("kill_query", "audit", {"query_task_id": "task-1"})
+        try:
+            async with client.session(ctx) as session:
+                assert await session.delete("/running_queries/task-1") is None
+        finally:
+            await client.close()
+
+
+class TestSessions:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_active_sessions(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/sessions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": 1001,
+                        "user_id": 42,
+                        "ip_address": "10.0.0.1",
+                        "browser": "Chrome",
+                    }
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_active_sessions", "audit")
+        try:
+            async with client.session(ctx) as session:
+                sessions_list = await session.get("/sessions")
+                assert len(sessions_list) == 1
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_terminate_session(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/sessions/1001").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("terminate_session", "audit", {"session_id": "1001"})
+        try:
+            async with client.session(ctx) as session:
+                assert await session.delete("/sessions/1001") is None
+        finally:
+            await client.close()
+
+
+# ══ Live-ops: project CI runs ════════════════════════════════════════
+
+
+class TestProjectCi:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_runs(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/analytics/ci/runs").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "run-1",
+                        "status": "success",
+                        "branch": "main",
+                        "started_at": "2026-04-15T10:00:00Z",
+                    }
+                ],
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("list_project_ci_runs", "audit", {"project_id": "analytics"})
+        try:
+            async with client.session(ctx) as session:
+                runs = await session.get("/projects/analytics/ci/runs")
+                assert runs[0]["status"] == "success"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_trigger_sends_branch_when_provided(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "run-99", "status": "pending"})
+
+        respx.post(f"{API_URL}/projects/analytics/ci/runs").mock(side_effect=capture)
+
+        from fastmcp import Client
+
+        mcp, client = create_server(config, enabled_groups={"audit"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "trigger_project_ci_run",
+                    {"project_id": "analytics", "branch": "feature-x"},
+                )
+                assert captured["body"] == {"branch": "feature-x"}
+        finally:
+            await client.close()
+
+
+# ══ Path encoding regression ═════════════════════════════════════════
+
+
+class TestPathEncoding:
+    """Defensive encoding: query_task_id / session_id / project_id flow through _path_seg."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_session_id_with_slash_is_encoded(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["raw_path"] = request.url.raw_path.decode("ascii")
+            return httpx.Response(204)
+
+        respx.delete(url__regex=rf"{API_URL}/sessions/.*").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("terminate_session", "audit", {"session_id": "../boom"})
+        try:
+            from urllib.parse import quote
+
+            async with client.session(ctx) as session:
+                await session.delete(f"/sessions/{quote('../boom', safe='')}")
+                raw = captured["raw_path"]
+                # Either full encoding of `..` or just the slash — both prevent traversal.
+                assert "%2E%2E%2Fboom" in raw or "..%2Fboom" in raw
+                assert "/sessions/../boom" not in raw
+        finally:
+            await client.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,6 +99,7 @@ class TestGroupConstants:
             "connection",
             "user_attributes",
             "credentials",
+            "audit",
             "health",
         }
         assert ALL_GROUPS == expected

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Adds a new **`audit`** tool group (13 tools, opt-in) covering the two observability surfaces that every Looker admin eventually needs: **historical audit data** (queries, content use, PDT builds, schedule runs, user events) and **current instance state** (running queries, active sessions, CI runs).

Directly addresses the "query history / audits / logs should be exposed through the tools" gap — previously reachable only by writing raw queries against `system__activity` with the generic `query` tool.

### `system__activity` wrappers (5 tools)

Thin composed queries over Looker's built-in audit model:

| Tool | Explore | Answers |
|---|---|---|
| `get_query_history` | `history` | Who ran what, when, how long, cache tier, did it fail? Default sort: slowest first. |
| `get_content_usage` | `content_usage` | Dashboards/looks with view counts over a window. Default sort: most-viewed first. |
| `get_pdt_build_log` | `pdt_event_log` | PDT build events + runtime + error messages. `failed_only=True` triages breakage. |
| `get_schedule_history` | `scheduled_plan` | Scheduled plan runs. `failed_only` uses Looker's `-success` negative-filter syntax. |
| `get_user_activity_log` | `event` | Logins, permission changes, sudo activity, content mutations. |

Each wrapper routes through a module-local `_run_system_activity_query` helper that handles the two-hop `POST /queries` + `GET /queries/{id}/run/json` boilerplate. Each tool picks the right explore/fields/filters for its question.

### Live-ops REST (8 tools)

| Tool | Endpoint | Purpose |
|---|---|---|
| `list_running_queries` / `kill_query` | `/running_queries` | Active-query triage |
| `list_active_sessions` / `get_session` / `terminate_session` | `/sessions` | Session audit + force-logout |
| `list_project_ci_runs` / `get_project_ci_run` / `trigger_project_ci_run` | `/projects/{id}/ci/runs` | LookML CI visibility |

`trigger_project_ci_run` returns a `next_step` hint pointing callers at `get_project_ci_run` for polling — the same response-as-documentation pattern used in recent PRs (`create_credentials_api3` warning field, `bootstrap` next_step fields in PR #9).

## Design notes

- **Thin wrappers, not heavy abstractions.** Each `system__activity` wrapper composes ~10 lines of filter logic. Custom audit queries can still go through the generic `query` tool — these wrappers are for the frequently-asked-questions path where field names and filter syntax shouldn't be a barrier.
- **Looker filter syntax exposed, not hidden.** `date_range` parameters accept raw Looker filter strings ("7 days", "yesterday", "2026-04-01 to 2026-04-15") rather than structured date objects. Cheaper to document than to reinvent.
- **Defensive path encoding** via shared `_path_seg`. `TestPathEncoding` exercises a traversal-style `session_id = "../boom"` and proves it doesn't escape the `/sessions/` prefix.
- **system__activity field names are best-effort.** The Looker API doesn't expose a schema endpoint for system__activity explores, so field lists come from Looker's documented explore definitions. If a Looker version rejects a field name, the tool returns a `format_api_error`-shaped error with the Looker response, which callers can use to adjust.

## Scope deferred

Other audit-adjacent work called out in ULT-2264 that's not in this PR:

- Dedicated `get_*` tools for schedule plan `.runs` endpoint (distinct from scheduled_plan system__activity explore)
- Integration hub audit (update logs per hub)
- Backup audit (`get_backup_configuration` read-only)

These are smaller and better grouped with the admin/settings PRs that ULT-2264 P1 still tracks.

## Changes

- `src/looker_mcp_server/tools/audit.py` — new tool group (13 tools, ~490 LOC), module-local `_run_system_activity_query` helper
- `src/looker_mcp_server/config.py` — add `audit` to `ALL_GROUPS`
- `src/looker_mcp_server/server.py` — register via `_group_registry`
- `tests/test_audit_tools.py` — 15 respx-mocked tests
- `tests/test_config.py` — extend pinned group list
- `README.md` — tool count 127 → 140; new row in the groups table
- `CHANGELOG.md` — v0.9.0 entry
- `pyproject.toml` — bump to 0.9.0

Tool count: **127 → 140** across **13 → 14** groups.

## Test plan

- [x] `uv run ruff format --check .` — 35 files clean
- [x] `uv run ruff check .` — 0 errors
- [x] `uv run pyright src tests` — 0 errors, 0 warnings
- [x] `uv run pytest` — 122/122 pass (15 new)
- [ ] Manual smoke against a dev Looker instance: run `get_query_history` with `errors_only=True` over 24h, `list_running_queries`, `list_active_sessions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "audit" tool group containing 13 tools for system activity tracking (query history, content usage, PDT build logs, schedule history, user activity logs) and live operations monitoring (running queries, active sessions, CI runs management).

* **Version Bump**
  * Updated version to 0.9.0. Total tool inventory increased from 127 to 140 tools across 14 groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->