### PR TITLE
feat: add workflows tool group — Layer 2 provisioning compositions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-04-15
+
+### Added
+
+- **workflows** tool group (6 tools): Layer 2 task-oriented compositions over the Layer 1 atomic tools. Each orchestrates 2–5 Looker API calls into a single well-sequenced admin job with structured partial-failure reporting. Aligned with Anthropic's tool-design research: fewer higher-level tools improve agent tool-selection accuracy relative to many atomic ones.
+  - `provision_connection`: create + test a database connection; returns per-check test breakdown. Connection is left registered even on test failure so the caller can correct the specific failing check.
+  - `bootstrap_lookml_project`: create a LookML project, attach it to a git remote, and generate an SSH deploy key. Response includes the public key for installation on the git remote.
+  - `deploy_lookml_changes`: write a set of LookML file edits, validate, and — only if validation passes — deploy to production. Only falls back to create on a confirmed 404; other PATCH failures (auth, 5xx) propagate rather than being silently retried.
+  - `rollback_to_production`: safe wrapper around `reset_to_production` requiring an explicit `confirm=True` flag, since the operation is destructive.
+  - `provision_user`: end-to-end user onboarding in one call — create user + email credentials + role/group assignments + user-attribute values + invite email. Reports per-step status; guards against empty `user_id` from a malformed create response.
+  - `grant_access`: idempotent read-modify-write to add a user or group to a role's membership. Preserves existing members.
+- Total tool count: 147 → 153 across 15 groups
+
 ## [0.10.0] - 2026-04-15
 
 ### Added
@@ -19,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **content** group — content-validation audit (1 tool):
   - `validate_content`: run Looker's content validator across all looks and dashboards. Returns broken references grouped by error kind plus totals — useful before users see errors from a LookML change.
 - Total tool count: 140 → 147 across 14 groups
+
 
 ## [0.9.0] - 2026-04-15
 
@@ -165,6 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[0.11.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.7.0...v0.8.0

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ looker-mcp-server
 # Specific groups
 looker-mcp-server --groups explore,query
 
-# All groups (including board, folder, modeling, git, admin, connection, user_attributes, credentials, audit)
+# All groups (including board, folder, modeling, git, admin, connection, user_attributes, credentials, audit, workflows)
 looker-mcp-server --groups all
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **147 tools** across 14 groups covering the full Looker API surface
+- **153 tools** across 15 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -113,6 +113,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **user_attributes** | `list_user_attributes`, `get_user_attribute`, `create_user_attribute`, `update_user_attribute`, `delete_user_attribute`, `list_user_attribute_group_values`, `set_user_attribute_group_values`, `delete_user_attribute_group_value`, `list_user_attribute_values_for_user`, `set_user_attribute_user_value`, `delete_user_attribute_user_value` | User attribute definitions plus per-group and per-user value overrides (row-level security, per-developer credentials, filter defaults) |
 | **credentials** | `list_credentials_api3`, `create_credentials_api3`, `get_credentials_api3`, `delete_credentials_api3`, `get_credentials_ldap`, `delete_credentials_ldap`, `get_credentials_saml`, `delete_credentials_saml`, `get_credentials_oidc`, `delete_credentials_oidc`, `get_credentials_google`, `delete_credentials_google` | Non-email credentials — API3 key-pair rotation plus get/delete for LDAP, SAML, OIDC, and Google SSO links |
 | **audit** | `get_query_history`, `get_content_usage`, `get_pdt_build_log`, `get_schedule_history`, `get_user_activity_log`, `list_running_queries`, `kill_query`, `list_active_sessions`, `get_session`, `terminate_session`, `list_project_ci_runs`, `get_project_ci_run`, `trigger_project_ci_run` | Query history, content usage, PDT build + schedule + event logs via system__activity, plus live-ops (running queries, sessions, CI runs) |
+| **workflows** | `provision_connection`, `bootstrap_lookml_project`, `deploy_lookml_changes`, `rollback_to_production`, `provision_user`, `grant_access` | Task-oriented compositions over atomic tools — one-call ergonomics for common admin jobs (provisioning, deploying LookML, onboarding users) |
 
 ### Selecting Groups
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.10.0"
+version = "0.11.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -24,6 +24,7 @@ ALL_GROUPS = frozenset(
         "user_attributes",
         "credentials",
         "audit",
+        "workflows",
         "health",
     }
 )

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -91,6 +91,7 @@ def create_server(
     from .tools.query import register_query_tools
     from .tools.schema import register_schema_tools
     from .tools.user_attributes import register_user_attribute_tools
+    from .tools.workflows import register_workflow_tools
 
     _group_registry: dict[str, Any] = {
         "explore": register_explore_tools,
@@ -106,6 +107,7 @@ def create_server(
         "user_attributes": register_user_attribute_tools,
         "credentials": register_credentials_tools,
         "audit": register_audit_tools,
+        "workflows": register_workflow_tools,
         "health": register_health_tools,
     }
 

--- a/src/looker_mcp_server/tools/workflows.py
+++ b/src/looker_mcp_server/tools/workflows.py
@@ -1,0 +1,506 @@
+"""Workflows tool group — task-oriented compositions over atomic tools.
+
+These tools each orchestrate several Looker API calls to complete a full
+admin task (provision a connection, bootstrap a LookML project, onboard a
+user). They return a structured response that tells the caller what
+happened at each step, so partial failures surface clearly rather than
+bubbling up as one opaque error.
+
+Everything these tools can do is also doable by calling the underlying
+atomic tools (``connection``, ``modeling``, ``admin``, ``credentials``,
+``user_attributes``) in sequence. The value is in the orchestration:
+correct ordering, structured partial-failure reporting, and one-call
+ergonomics for common jobs.
+
+Admin-only surface; disabled by default. Enable with ``--groups workflows``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+from ._helpers import _path_seg, _set_if
+
+
+def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
+    # ── Day 1: data layer ────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Create a database connection and run Looker's built-in test "
+            "suite against it in one call. Returns the created connection "
+            "summary plus the per-check test breakdown (connect, query, "
+            "tmp_table, cdt, pdt). If any check fails, the connection is "
+            "still left in place — caller can update or delete it based on "
+            "which specific check failed. Replaces calling "
+            "``create_connection`` then ``test_connection`` separately."
+        ),
+    )
+    async def provision_connection(
+        name: Annotated[str, "Unique connection name"],
+        dialect_name: Annotated[
+            str, "Database dialect (e.g. 'snowflake', 'bigquery_standard_sql')"
+        ],
+        host: Annotated[str | None, "Database host"] = None,
+        port: Annotated[int | None, "Database port"] = None,
+        database: Annotated[str | None, "Default database name"] = None,
+        username: Annotated[str | None, "Database username"] = None,
+        password: Annotated[str | None, "Database password"] = None,
+        schema: Annotated[str | None, "Default schema"] = None,
+        tmp_db_name: Annotated[str | None, "Scratch schema for PDTs"] = None,
+        ssl: Annotated[bool | None, "Use SSL/TLS"] = None,
+        pdts_enabled: Annotated[bool | None, "Enable PDTs"] = None,
+    ) -> str:
+        ctx = client.build_context("provision_connection", "workflows", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {"name": name, "dialect_name": dialect_name}
+                _set_if(body, "host", host)
+                _set_if(body, "port", port)
+                _set_if(body, "database", database)
+                _set_if(body, "username", username)
+                _set_if(body, "password", password)
+                _set_if(body, "schema", schema)
+                _set_if(body, "tmp_db_name", tmp_db_name)
+                _set_if(body, "ssl", ssl)
+                _set_if(body, "pdts_enabled", pdts_enabled)
+
+                conn = await session.post("/connections", body=body)
+
+                # Run Looker's test suite against the new connection.
+                try:
+                    results = await session.put(f"/connections/{_path_seg(name)}/test")
+                    checks = [
+                        {
+                            "check": r.get("name"),
+                            "status": r.get("status"),
+                            "message": r.get("message"),
+                        }
+                        for r in (results or [])
+                    ]
+                    all_ok = bool(checks) and all(c["status"] == "success" for c in checks)
+                    test_section = {"ran": True, "healthy": all_ok, "checks": checks}
+                except Exception as test_err:
+                    test_section = {
+                        "ran": False,
+                        "error": format_api_error("test_connection", test_err),
+                    }
+
+                return json.dumps(
+                    {
+                        "created": True,
+                        "name": conn.get("name"),
+                        "dialect_name": conn.get("dialect_name"),
+                        "test": test_section,
+                        "next_step": (
+                            "If any test check failed, call update_connection "
+                            "to correct the specific field (e.g. tmp_db_name "
+                            "for tmp_table failures) then test_connection "
+                            "again. Connection is left registered so LookML "
+                            "can reference it regardless of test state."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("provision_connection", e)
+
+    @server.tool(
+        description=(
+            "Stand up a new LookML project wired to a git remote. Creates "
+            "the project, sets its git configuration, and generates an SSH "
+            "deploy key. The response includes the deploy key's public half "
+            "— the caller must install it on the git remote (e.g. as a "
+            "GitHub deploy key with write access) before git push operations "
+            "will succeed. Replaces calling ``create_project``, "
+            "``update_project``, and ``create_project_deploy_key`` in "
+            "sequence."
+        ),
+    )
+    async def bootstrap_lookml_project(
+        name: Annotated[str, "Project name (becomes the ID)"],
+        git_remote_url: Annotated[str, "Git remote URL to clone/push to"],
+        git_service_name: Annotated[
+            str, "Git host — 'github', 'gitlab', 'bitbucket', or 'custom'"
+        ] = "github",
+        git_production_branch_name: Annotated[
+            str | None, "Production branch (default is main/master depending on git service)"
+        ] = None,
+        pull_request_mode: Annotated[str, "'off', 'links', 'recommended', or 'required'"] = "links",
+    ) -> str:
+        ctx = client.build_context("bootstrap_lookml_project", "workflows", {"name": name})
+        try:
+            async with client.session(ctx) as session:
+                # Step 1: create the project.
+                project = await session.post("/projects", body={"name": name})
+                project_id = (project or {}).get("id", name)
+
+                # Step 2: attach the git configuration.
+                update_body: dict[str, Any] = {
+                    "git_remote_url": git_remote_url,
+                    "git_service_name": git_service_name,
+                    "pull_request_mode": pull_request_mode,
+                }
+                _set_if(update_body, "git_production_branch_name", git_production_branch_name)
+                await session.patch(f"/projects/{_path_seg(project_id)}", body=update_body)
+
+                # Step 3: generate the SSH deploy key.
+                deploy_key = await session.post(f"/projects/{_path_seg(project_id)}/git/deploy_key")
+
+                return json.dumps(
+                    {
+                        "created": True,
+                        "project_id": project_id,
+                        "git_remote_url": git_remote_url,
+                        "git_service_name": git_service_name,
+                        "deploy_key_public": deploy_key,
+                        "next_step": (
+                            "Install deploy_key_public on the git remote as "
+                            "a deploy key with write access. Then create a "
+                            "dev branch with create_git_branch and start "
+                            "authoring LookML with create_file."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("bootstrap_lookml_project", e)
+
+    # ── Day 2: LookML workflow ───────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Commit a set of LookML file edits and deploy them to "
+            "production. Writes each file in the dev workspace, runs LookML "
+            "validation (unless ``validate=False``), and — only if "
+            "validation passes — deploys to production. Returns a "
+            "step-by-step report of what happened. If validation fails, "
+            "no deploy is attempted and the dev-workspace edits remain "
+            "for the caller to fix."
+        ),
+    )
+    async def deploy_lookml_changes(
+        project_id: Annotated[str, "LookML project ID"],
+        files: Annotated[
+            dict[str, str],
+            "Mapping of file path (e.g. 'views/orders.view.lkml') to new content",
+        ],
+        validate: Annotated[
+            bool, "Run LookML validation before deploy; skip deploy on errors"
+        ] = True,
+    ) -> str:
+        if not files:
+            return json.dumps(
+                {
+                    "error": "No files provided.",
+                    "hint": (
+                        "Pass a dict mapping file paths to file contents, e.g. "
+                        "{'views/orders.view.lkml': '<lkml source>'}."
+                    ),
+                },
+                indent=2,
+            )
+
+        ctx = client.build_context("deploy_lookml_changes", "workflows", {"project_id": project_id})
+        dev_params = {"workspace_id": "dev"}
+        per_file: list[dict[str, Any]] = []
+        try:
+            async with client.session(ctx) as session:
+                # Step 1: write each file (PATCH if it exists, POST if not).
+                # Looker's API returns 404 for PATCH on a nonexistent file, so
+                # we try PATCH first and fall back to POST on that signal.
+                for path, content in files.items():
+                    pseg = _path_seg(project_id)
+                    fseg = _path_seg(path)
+                    try:
+                        await session.patch(
+                            f"/projects/{pseg}/files/{fseg}",
+                            body={"content": content},
+                            params=dev_params,
+                        )
+                        per_file.append({"path": path, "action": "updated"})
+                    except Exception:
+                        await session.post(
+                            f"/projects/{pseg}/files/{fseg}",
+                            body={"id": path, "content": content},
+                            params=dev_params,
+                        )
+                        per_file.append({"path": path, "action": "created"})
+
+                # Step 2: optional validation.
+                validation_section: dict[str, Any] | None = None
+                if validate:
+                    result = await session.post(
+                        f"/projects/{_path_seg(project_id)}/lookml_validation"
+                    )
+                    errors = (result or {}).get("errors") or []
+                    warnings = (result or {}).get("warnings") or []
+                    validation_section = {
+                        "valid": len(errors) == 0,
+                        "error_count": len(errors),
+                        "warning_count": len(warnings),
+                        "errors": errors,
+                    }
+                    if errors:
+                        return json.dumps(
+                            {
+                                "files": per_file,
+                                "validation": validation_section,
+                                "deployed": False,
+                                "reason": "Validation errors — skipped deploy.",
+                                "next_step": (
+                                    "Fix the reported errors with another "
+                                    "deploy_lookml_changes call (or "
+                                    "update_file directly), then retry."
+                                ),
+                            },
+                            indent=2,
+                        )
+
+                # Step 3: deploy to production.
+                await session.post(f"/projects/{_path_seg(project_id)}/deploy_to_production")
+
+                return json.dumps(
+                    {
+                        "files": per_file,
+                        "validation": validation_section,
+                        "deployed": True,
+                        "project_id": project_id,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("deploy_lookml_changes", e)
+
+    @server.tool(
+        description=(
+            "Abandon dev-workspace changes and reset the project's dev "
+            "branch to match production. Wraps ``reset_to_production`` with "
+            "a required ``confirm=True`` guard because the operation cannot "
+            "be undone. Use when LookML edits have gotten into a stuck state."
+        ),
+    )
+    async def rollback_to_production(
+        project_id: Annotated[str, "LookML project ID"],
+        confirm: Annotated[
+            bool, "Must be True; prevents accidental data loss from stale tool calls"
+        ] = False,
+    ) -> str:
+        if not confirm:
+            return json.dumps(
+                {
+                    "error": "Confirmation required.",
+                    "hint": (
+                        "This operation discards all dev-workspace changes on "
+                        "the project. Re-issue with confirm=True to proceed."
+                    ),
+                },
+                indent=2,
+            )
+
+        ctx = client.build_context(
+            "rollback_to_production", "workflows", {"project_id": project_id}
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.post(
+                    f"/projects/{_path_seg(project_id)}/reset_to_production",
+                    params={"workspace_id": "dev"},
+                )
+                return json.dumps(
+                    {
+                        "reset": True,
+                        "project_id": project_id,
+                        "workspace": "dev",
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("rollback_to_production", e)
+
+    # ── Day 3: onboarding + access ───────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Onboard a new user end-to-end in one call. Creates the user, "
+            "attaches email credentials, assigns direct roles, adds to "
+            "groups, sets per-user attribute values, and (optionally) sends "
+            "the welcome email. The response reports per-step status so a "
+            "partial failure (e.g. group assignment failed) is visible "
+            "without the user record being rolled back. Replaces calling "
+            "create_user + create_credentials_email + set_user_roles + "
+            "add_group_user (×N) + set_user_attribute_user_value (×N) + "
+            "send_password_reset in sequence."
+        ),
+    )
+    async def provision_user(
+        email: Annotated[str, "Email address (also login identifier)"],
+        first_name: Annotated[str, "First name"],
+        last_name: Annotated[str, "Last name"],
+        role_ids: Annotated[list[int] | None, "Role IDs to assign directly"] = None,
+        group_ids: Annotated[list[int] | None, "Group IDs to add the user to"] = None,
+        user_attribute_values: Annotated[
+            dict[str, str] | None,
+            "Per-user attribute overrides, keyed by user_attribute_id",
+        ] = None,
+        send_invite: Annotated[
+            bool, "Send the welcome / password-reset email after provisioning"
+        ] = True,
+    ) -> str:
+        ctx = client.build_context("provision_user", "workflows", {"email": email})
+        steps: list[dict[str, Any]] = []
+        try:
+            async with client.session(ctx) as session:
+                # Step 1: create the user record.
+                user_body: dict[str, Any] = {
+                    "first_name": first_name,
+                    "last_name": last_name,
+                    "email": email,
+                }
+                if role_ids:
+                    user_body["role_ids"] = role_ids
+                if group_ids:
+                    user_body["group_ids"] = group_ids
+                user = await session.post("/users", body=user_body)
+                user_id = str((user or {}).get("id", ""))
+                steps.append({"step": "create_user", "user_id": user_id})
+
+                # Step 2: attach email credentials so the user can log in.
+                try:
+                    await session.post(
+                        f"/users/{_path_seg(user_id)}/credentials_email",
+                        body={"email": email},
+                    )
+                    steps.append({"step": "create_credentials_email", "ok": True})
+                except Exception as e:
+                    steps.append(
+                        {
+                            "step": "create_credentials_email",
+                            "ok": False,
+                            "error": format_api_error("create_credentials_email", e),
+                        }
+                    )
+
+                # Step 3: per-user attribute values (optional).
+                if user_attribute_values:
+                    for ua_id, value in user_attribute_values.items():
+                        try:
+                            await session.patch(
+                                f"/users/{_path_seg(user_id)}/attribute_values/{_path_seg(ua_id)}",
+                                body={"value": value},
+                            )
+                            steps.append(
+                                {
+                                    "step": "set_user_attribute_user_value",
+                                    "user_attribute_id": ua_id,
+                                    "ok": True,
+                                }
+                            )
+                        except Exception as e:
+                            steps.append(
+                                {
+                                    "step": "set_user_attribute_user_value",
+                                    "user_attribute_id": ua_id,
+                                    "ok": False,
+                                    "error": format_api_error("set_user_attribute_user_value", e),
+                                }
+                            )
+
+                # Step 4: invite email (optional, depends on step 2 succeeding).
+                if send_invite:
+                    try:
+                        await session.post(
+                            f"/users/{_path_seg(user_id)}/credentials_email/send_password_reset"
+                        )
+                        steps.append({"step": "send_password_reset", "ok": True})
+                    except Exception as e:
+                        steps.append(
+                            {
+                                "step": "send_password_reset",
+                                "ok": False,
+                                "error": format_api_error("send_password_reset", e),
+                            }
+                        )
+
+                all_ok = all(s.get("ok", True) for s in steps)
+                return json.dumps(
+                    {
+                        "user_id": user_id,
+                        "email": email,
+                        "all_steps_ok": all_ok,
+                        "steps": steps,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("provision_user", e)
+
+    @server.tool(
+        description=(
+            "Grant a user or group access to a role. For a user principal, "
+            "this adds them to the role's direct user list; for a group "
+            "principal, it adds the group to the role's group list. Either "
+            "way the call is read-modify-write against the role's "
+            "membership — existing assignments are preserved."
+        ),
+    )
+    async def grant_access(
+        principal_type: Annotated[str, "'user' or 'group'"],
+        principal_id: Annotated[str, "User ID or group ID"],
+        role_id: Annotated[str, "Role ID to grant"],
+    ) -> str:
+        if principal_type not in ("user", "group"):
+            return json.dumps(
+                {
+                    "error": f"principal_type must be 'user' or 'group', got {principal_type!r}",
+                },
+                indent=2,
+            )
+
+        ctx = client.build_context(
+            "grant_access",
+            "workflows",
+            {
+                "principal_type": principal_type,
+                "principal_id": principal_id,
+                "role_id": role_id,
+            },
+        )
+        try:
+            async with client.session(ctx) as session:
+                endpoint = "users" if principal_type == "user" else "groups"
+                # Step 1: read current membership.
+                current = await session.get(f"/roles/{_path_seg(role_id)}/{endpoint}")
+                current_ids = [int(m["id"]) for m in (current or []) if m.get("id")]
+                principal_int = int(principal_id)
+
+                if principal_int in current_ids:
+                    return json.dumps(
+                        {
+                            "already_granted": True,
+                            "role_id": role_id,
+                            "principal_type": principal_type,
+                            "principal_id": principal_id,
+                        },
+                        indent=2,
+                    )
+
+                # Step 2: write the augmented list back.
+                new_ids = sorted({*current_ids, principal_int})
+                await session.put(f"/roles/{_path_seg(role_id)}/{endpoint}", body=new_ids)
+                return json.dumps(
+                    {
+                        "granted": True,
+                        "role_id": role_id,
+                        "principal_type": principal_type,
+                        "principal_id": principal_id,
+                        "member_count": len(new_ids),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("grant_access", e)

--- a/src/looker_mcp_server/tools/workflows.py
+++ b/src/looker_mcp_server/tools/workflows.py
@@ -22,7 +22,7 @@ from typing import Annotated, Any
 
 from fastmcp import FastMCP
 
-from ..client import LookerClient, format_api_error
+from ..client import LookerApiError, LookerClient, format_api_error
 from ._helpers import _path_seg, _set_if
 
 
@@ -216,6 +216,11 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                 for path, content in files.items():
                     pseg = _path_seg(project_id)
                     fseg = _path_seg(path)
+                    # Only fall back to POST on a confirmed 404 (the file
+                    # doesn't exist yet). Other errors — auth, permissions,
+                    # 5xx, network — must propagate rather than being
+                    # silently retried as a create, which would double
+                    # the side effects and mask the real cause.
                     try:
                         await session.patch(
                             f"/projects/{pseg}/files/{fseg}",
@@ -223,7 +228,9 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                             params=dev_params,
                         )
                         per_file.append({"path": path, "action": "updated"})
-                    except Exception:
+                    except LookerApiError as e:
+                        if e.status_code != 404:
+                            raise
                         await session.post(
                             f"/projects/{pseg}/files/{fseg}",
                             body={"id": path, "content": content},
@@ -368,6 +375,26 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                 user = await session.post("/users", body=user_body)
                 user_id = str((user or {}).get("id", ""))
                 steps.append({"step": "create_user", "user_id": user_id})
+
+                # Short-circuit if the create call didn't return a usable
+                # id. Downstream endpoints take a user_id path param;
+                # continuing with an empty id would issue malformed URLs
+                # like /users//credentials_email and surface Looker 404s
+                # that obscure the original root cause.
+                if not user_id:
+                    return json.dumps(
+                        {
+                            "error": "User creation returned no id.",
+                            "hint": (
+                                "Looker's POST /users responded without an "
+                                "'id' field. Check the response body for an "
+                                "API-level error before retrying."
+                            ),
+                            "user_response": user,
+                            "steps": steps,
+                        },
+                        indent=2,
+                    )
 
                 # Step 2: attach email credentials so the user can log in.
                 try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,6 +100,7 @@ class TestGroupConstants:
             "user_attributes",
             "credentials",
             "audit",
+            "workflows",
             "health",
         }
         assert ALL_GROUPS == expected

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -1,0 +1,492 @@
+"""Tests for workflows tool group — task-oriented compositions."""
+
+import json
+
+import httpx
+import pytest
+import respx
+from fastmcp import Client
+from mcp.types import TextContent
+
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+def _invoke_tool(mcp, tool_name: str, args: dict):
+    """Helper to call a tool via fastmcp Client and return the parsed payload."""
+
+    async def _run():
+        async with Client(mcp) as mcp_client:
+            result = await mcp_client.call_tool(tool_name, args)
+            content = result.content[0]
+            assert isinstance(content, TextContent)
+            return json.loads(content.text)
+
+    return _run
+
+
+# ══ provision_connection ═════════════════════════════════════════════
+
+
+class TestProvisionConnection:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_creates_then_tests(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/connections").mock(
+            return_value=httpx.Response(
+                201, json={"name": "warehouse", "dialect_name": "snowflake"}
+            )
+        )
+        respx.put(f"{API_URL}/connections/warehouse/test").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"name": "connect", "status": "success", "message": "OK"},
+                    {"name": "query", "status": "success", "message": "OK"},
+                    {"name": "tmp_table", "status": "success", "message": "OK"},
+                ],
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "provision_connection",
+                {"name": "warehouse", "dialect_name": "snowflake"},
+            )()
+            assert payload["created"] is True
+            assert payload["test"]["ran"] is True
+            assert payload["test"]["healthy"] is True
+            assert len(payload["test"]["checks"]) == 3
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_keeps_connection_when_test_fails(self, config):
+        """Partial failure: connection created, but a check failed. We
+        report the breakdown rather than rolling back the connection."""
+        _mock_login_logout()
+        respx.post(f"{API_URL}/connections").mock(
+            return_value=httpx.Response(
+                201, json={"name": "warehouse", "dialect_name": "snowflake"}
+            )
+        )
+        respx.put(f"{API_URL}/connections/warehouse/test").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"name": "connect", "status": "success", "message": "OK"},
+                    {
+                        "name": "tmp_table",
+                        "status": "error",
+                        "message": "Missing scratch schema",
+                    },
+                ],
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "provision_connection",
+                {"name": "warehouse", "dialect_name": "snowflake"},
+            )()
+            assert payload["created"] is True
+            assert payload["test"]["ran"] is True
+            assert payload["test"]["healthy"] is False
+            # The failing check is surfaced so agent can decide next step.
+            failing = [c for c in payload["test"]["checks"] if c["status"] == "error"]
+            assert len(failing) == 1
+            assert failing[0]["check"] == "tmp_table"
+        finally:
+            await client.close()
+
+
+# ══ bootstrap_lookml_project ═════════════════════════════════════════
+
+
+class TestBootstrapLookmlProject:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_chains_create_update_deploy_key(self, config):
+        _mock_login_logout()
+
+        respx.post(f"{API_URL}/projects").mock(
+            return_value=httpx.Response(201, json={"id": "analytics", "name": "analytics"})
+        )
+        captured_patch: dict = {}
+
+        def capture_patch(request: httpx.Request) -> httpx.Response:
+            captured_patch["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"id": "analytics"})
+
+        respx.patch(f"{API_URL}/projects/analytics").mock(side_effect=capture_patch)
+        respx.post(f"{API_URL}/projects/analytics/git/deploy_key").mock(
+            return_value=httpx.Response(200, json="ssh-ed25519 AAAAC3Nz...")
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "bootstrap_lookml_project",
+                {
+                    "name": "analytics",
+                    "git_remote_url": "git@github.com:example/analytics.git",
+                    "git_service_name": "github",
+                },
+            )()
+            assert payload["created"] is True
+            assert payload["project_id"] == "analytics"
+            assert "ssh-ed25519" in payload["deploy_key_public"]
+            # Git config patched with the right fields.
+            assert captured_patch["body"]["git_remote_url"].endswith("analytics.git")
+            assert captured_patch["body"]["git_service_name"] == "github"
+        finally:
+            await client.close()
+
+
+# ══ deploy_lookml_changes ════════════════════════════════════════════
+
+
+class TestDeployLookmlChanges:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_skips_deploy_on_validation_errors(self, config):
+        """Critical safety property: validation errors must not trigger
+        a deploy. The test fails if the POST /deploy_to_production mock
+        is called."""
+        _mock_login_logout()
+
+        # File writes — PATCH succeeds for both files.
+        respx.patch(url__regex=rf"{API_URL}/projects/analytics/files/.*").mock(
+            return_value=httpx.Response(200, json={"id": "whatever"})
+        )
+
+        # Validation returns errors.
+        respx.post(f"{API_URL}/projects/analytics/lookml_validation").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "errors": [
+                        {
+                            "severity": "error",
+                            "message": "unknown field",
+                            "source_file": "views/orders.view.lkml",
+                            "line": 42,
+                        }
+                    ],
+                    "warnings": [],
+                },
+            )
+        )
+
+        # No mock for deploy_to_production — if it's called, the test errors.
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "deploy_lookml_changes",
+                {
+                    "project_id": "analytics",
+                    "files": {"views/orders.view.lkml": "view: orders {}"},
+                    "validate": True,
+                },
+            )()
+            assert payload["deployed"] is False
+            assert payload["validation"]["valid"] is False
+            assert payload["validation"]["error_count"] == 1
+
+            # Verify no deploy call happened.
+            deploy_calls = [
+                c for c in respx.calls if c.request.url.path.endswith("/deploy_to_production")
+            ]
+            assert deploy_calls == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deploys_when_validation_passes(self, config):
+        _mock_login_logout()
+        respx.patch(url__regex=rf"{API_URL}/projects/analytics/files/.*").mock(
+            return_value=httpx.Response(200, json={"id": "whatever"})
+        )
+        respx.post(f"{API_URL}/projects/analytics/lookml_validation").mock(
+            return_value=httpx.Response(200, json={"errors": [], "warnings": []})
+        )
+        deploy_captured: dict = {"called": False}
+
+        def capture_deploy(request: httpx.Request) -> httpx.Response:
+            deploy_captured["called"] = True
+            return httpx.Response(200, json={})
+
+        respx.post(f"{API_URL}/projects/analytics/deploy_to_production").mock(
+            side_effect=capture_deploy
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "deploy_lookml_changes",
+                {
+                    "project_id": "analytics",
+                    "files": {"views/orders.view.lkml": "view: orders {}"},
+                },
+            )()
+            assert payload["deployed"] is True
+            assert deploy_captured["called"] is True
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_files_returns_error(self, config):
+        _mock_login_logout()
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "deploy_lookml_changes",
+                {"project_id": "analytics", "files": {}},
+            )()
+            assert payload["error"] == "No files provided."
+        finally:
+            await client.close()
+
+
+# ══ rollback_to_production ═══════════════════════════════════════════
+
+
+class TestRollbackToProduction:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_requires_confirm_flag(self, config):
+        _mock_login_logout()
+        # No reset mock — if the tool forgets the confirm check, the test errors.
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp, "rollback_to_production", {"project_id": "analytics"}
+            )()
+            assert payload["error"] == "Confirmation required."
+            # Safety: no POST to reset_to_production happened.
+            assert [c for c in respx.calls if "reset_to_production" in c.request.url.path] == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_resets_when_confirmed(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/projects/analytics/reset_to_production").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "rollback_to_production",
+                {"project_id": "analytics", "confirm": True},
+            )()
+            assert payload["reset"] is True
+        finally:
+            await client.close()
+
+
+# ══ provision_user ═══════════════════════════════════════════════════
+
+
+class TestProvisionUser:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_chains_all_steps(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/users").mock(
+            return_value=httpx.Response(201, json={"id": "99", "email": "a@example.com"})
+        )
+        respx.post(f"{API_URL}/users/99/credentials_email").mock(
+            return_value=httpx.Response(201, json={"email": "a@example.com"})
+        )
+        respx.patch(f"{API_URL}/users/99/attribute_values/5").mock(
+            return_value=httpx.Response(200, json={"value": "EMEA"})
+        )
+        respx.post(f"{API_URL}/users/99/credentials_email/send_password_reset").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "provision_user",
+                {
+                    "email": "a@example.com",
+                    "first_name": "Alice",
+                    "last_name": "Example",
+                    "role_ids": [1, 2],
+                    "group_ids": [3],
+                    "user_attribute_values": {"5": "EMEA"},
+                    "send_invite": True,
+                },
+            )()
+            assert payload["all_steps_ok"] is True
+            step_names = [s["step"] for s in payload["steps"]]
+            assert "create_user" in step_names
+            assert "create_credentials_email" in step_names
+            assert "set_user_attribute_user_value" in step_names
+            assert "send_password_reset" in step_names
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_reports_partial_failure_without_rollback(self, config):
+        """If credential attachment fails, the user record stays put and
+        the failure is reported per-step."""
+        _mock_login_logout()
+        respx.post(f"{API_URL}/users").mock(
+            return_value=httpx.Response(201, json={"id": "99", "email": "a@example.com"})
+        )
+        respx.post(f"{API_URL}/users/99/credentials_email").mock(
+            return_value=httpx.Response(
+                409, json={"message": "Credentials already exist for email"}
+            )
+        )
+        respx.post(f"{API_URL}/users/99/credentials_email/send_password_reset").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "provision_user",
+                {
+                    "email": "a@example.com",
+                    "first_name": "Alice",
+                    "last_name": "Example",
+                    "send_invite": True,
+                },
+            )()
+            assert payload["all_steps_ok"] is False
+            creds_step = next(
+                s for s in payload["steps"] if s["step"] == "create_credentials_email"
+            )
+            assert creds_step["ok"] is False
+            # User was NOT rolled back — they exist and have an id.
+            assert payload["user_id"] == "99"
+        finally:
+            await client.close()
+
+
+# ══ grant_access ═════════════════════════════════════════════════════
+
+
+class TestGrantAccess:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_adds_user_to_role(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/roles/5/users").mock(
+            return_value=httpx.Response(200, json=[{"id": "1", "email": "existing@example.com"}])
+        )
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json=[])
+
+        respx.put(f"{API_URL}/roles/5/users").mock(side_effect=capture)
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "grant_access",
+                {"principal_type": "user", "principal_id": "42", "role_id": "5"},
+            )()
+            assert payload["granted"] is True
+            # Augmented list preserves the existing member.
+            assert set(captured["body"]) == {1, 42}
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_idempotent_when_already_granted(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/roles/5/groups").mock(
+            return_value=httpx.Response(200, json=[{"id": "7", "name": "analysts"}])
+        )
+        # No PUT mock — if the tool forgets the idempotency check, the test errors.
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "grant_access",
+                {"principal_type": "group", "principal_id": "7", "role_id": "5"},
+            )()
+            assert payload["already_granted"] is True
+            # Verify no PUT call was made.
+            assert [c for c in respx.calls if c.request.method == "PUT"] == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_rejects_invalid_principal_type(self, config):
+        _mock_login_logout()
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "grant_access",
+                {"principal_type": "service", "principal_id": "1", "role_id": "5"},
+            )()
+            assert "error" in payload
+            assert "principal_type" in payload["error"]
+        finally:
+            await client.close()
+
+
+# ══ Registration ═════════════════════════════════════════════════════
+
+
+class TestServerRegistration:
+    def test_workflows_in_all_groups(self):
+        from looker_mcp_server.config import ALL_GROUPS
+
+        assert "workflows" in ALL_GROUPS

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -33,17 +33,13 @@ def _mock_login_logout():
     respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
 
 
-def _invoke_tool(mcp, tool_name: str, args: dict):
-    """Helper to call a tool via fastmcp Client and return the parsed payload."""
-
-    async def _run():
-        async with Client(mcp) as mcp_client:
-            result = await mcp_client.call_tool(tool_name, args)
-            content = result.content[0]
-            assert isinstance(content, TextContent)
-            return json.loads(content.text)
-
-    return _run
+async def _invoke_tool(mcp, tool_name: str, args: dict):
+    """Call a tool through the MCP server and return the parsed payload."""
+    async with Client(mcp) as mcp_client:
+        result = await mcp_client.call_tool(tool_name, args)
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        return json.loads(content.text)
 
 
 # ══ provision_connection ═════════════════════════════════════════════
@@ -76,7 +72,7 @@ class TestProvisionConnection:
                 mcp,
                 "provision_connection",
                 {"name": "warehouse", "dialect_name": "snowflake"},
-            )()
+            )
             assert payload["created"] is True
             assert payload["test"]["ran"] is True
             assert payload["test"]["healthy"] is True
@@ -115,7 +111,7 @@ class TestProvisionConnection:
                 mcp,
                 "provision_connection",
                 {"name": "warehouse", "dialect_name": "snowflake"},
-            )()
+            )
             assert payload["created"] is True
             assert payload["test"]["ran"] is True
             assert payload["test"]["healthy"] is False
@@ -160,7 +156,7 @@ class TestBootstrapLookmlProject:
                     "git_remote_url": "git@github.com:example/analytics.git",
                     "git_service_name": "github",
                 },
-            )()
+            )
             assert payload["created"] is True
             assert payload["project_id"] == "analytics"
             assert "ssh-ed25519" in payload["deploy_key_public"]
@@ -218,7 +214,7 @@ class TestDeployLookmlChanges:
                     "files": {"views/orders.view.lkml": "view: orders {}"},
                     "validate": True,
                 },
-            )()
+            )
             assert payload["deployed"] is False
             assert payload["validation"]["valid"] is False
             assert payload["validation"]["error_count"] == 1
@@ -243,7 +239,14 @@ class TestDeployLookmlChanges:
         respx.patch(url__regex=rf"{API_URL}/projects/analytics/files/.*").mock(
             return_value=httpx.Response(500, json={"message": "internal server error"})
         )
-        # No POST or deploy mocks — if either is called, the test errors.
+        # Explicit routes for the forbidden calls so .called gives a
+        # clear yes/no signal rather than having to filter respx.calls.
+        create_fallback_route = respx.post(
+            url__regex=rf"{API_URL}/projects/analytics/files/.*"
+        ).mock(return_value=httpx.Response(201, json={"id": "unexpected"}))
+        deploy_route = respx.post(f"{API_URL}/projects/analytics/deploy_to_production").mock(
+            return_value=httpx.Response(200, json={})
+        )
 
         mcp, client = create_server(config, enabled_groups={"workflows"})
         try:
@@ -255,22 +258,14 @@ class TestDeployLookmlChanges:
                     "files": {"views/orders.view.lkml": "view: orders {}"},
                     "validate": True,
                 },
-            )()
+            )
             # Error surfaces to caller — tool's top-level exception
             # handler returns the format_api_error envelope.
             assert "error" in payload
-            # Safety invariants: no create-as-fallback, no validation,
-            # no deploy. The tool fails fast on the first bad PATCH.
-            post_calls = [
-                c
-                for c in respx.calls
-                if c.request.method == "POST" and "/files/" in c.request.url.path
-            ]
-            assert post_calls == []
-            deploy_calls = [
-                c for c in respx.calls if c.request.url.path.endswith("/deploy_to_production")
-            ]
-            assert deploy_calls == []
+            # Safety invariants: no create-as-fallback, no deploy.
+            # The tool fails fast on the first bad PATCH.
+            assert create_fallback_route.called is False
+            assert deploy_route.called is False
         finally:
             await client.close()
 
@@ -309,7 +304,7 @@ class TestDeployLookmlChanges:
                     "project_id": "analytics",
                     "files": {"views/new.view.lkml": "view: new {}"},
                 },
-            )()
+            )
             assert payload["deployed"] is True
             assert payload["files"][0]["action"] == "created"
             assert create_captured["called"] is True
@@ -345,7 +340,7 @@ class TestDeployLookmlChanges:
                     "project_id": "analytics",
                     "files": {"views/orders.view.lkml": "view: orders {}"},
                 },
-            )()
+            )
             assert payload["deployed"] is True
             assert deploy_captured["called"] is True
         finally:
@@ -362,7 +357,7 @@ class TestDeployLookmlChanges:
                 mcp,
                 "deploy_lookml_changes",
                 {"project_id": "analytics", "files": {}},
-            )()
+            )
             assert payload["error"] == "No files provided."
         finally:
             await client.close()
@@ -380,9 +375,7 @@ class TestRollbackToProduction:
 
         mcp, client = create_server(config, enabled_groups={"workflows"})
         try:
-            payload = await _invoke_tool(
-                mcp, "rollback_to_production", {"project_id": "analytics"}
-            )()
+            payload = await _invoke_tool(mcp, "rollback_to_production", {"project_id": "analytics"})
             assert payload["error"] == "Confirmation required."
             # Safety: no POST to reset_to_production happened.
             assert [c for c in respx.calls if "reset_to_production" in c.request.url.path] == []
@@ -403,7 +396,7 @@ class TestRollbackToProduction:
                 mcp,
                 "rollback_to_production",
                 {"project_id": "analytics", "confirm": True},
-            )()
+            )
             assert payload["reset"] is True
         finally:
             await client.close()
@@ -444,7 +437,7 @@ class TestProvisionUser:
                     "user_attribute_values": {"5": "EMEA"},
                     "send_invite": True,
                 },
-            )()
+            )
             assert payload["all_steps_ok"] is True
             step_names = [s["step"] for s in payload["steps"]]
             assert "create_user" in step_names
@@ -483,7 +476,7 @@ class TestProvisionUser:
                     "last_name": "Example",
                     "send_invite": True,
                 },
-            )()
+            )
             assert payload["all_steps_ok"] is False
             creds_step = next(
                 s for s in payload["steps"] if s["step"] == "create_credentials_email"
@@ -519,7 +512,7 @@ class TestProvisionUser:
                     "user_attribute_values": {"5": "EMEA"},
                     "send_invite": True,
                 },
-            )()
+            )
             assert "error" in payload
             assert "no id" in payload["error"].lower()
             # No downstream POSTs happened — tool failed fast.
@@ -558,7 +551,7 @@ class TestGrantAccess:
                 mcp,
                 "grant_access",
                 {"principal_type": "user", "principal_id": "42", "role_id": "5"},
-            )()
+            )
             assert payload["granted"] is True
             # Augmented list preserves the existing member.
             assert set(captured["body"]) == {1, 42}
@@ -580,7 +573,7 @@ class TestGrantAccess:
                 mcp,
                 "grant_access",
                 {"principal_type": "group", "principal_id": "7", "role_id": "5"},
-            )()
+            )
             assert payload["already_granted"] is True
             # Verify no PUT call was made.
             assert [c for c in respx.calls if c.request.method == "PUT"] == []
@@ -598,7 +591,7 @@ class TestGrantAccess:
                 mcp,
                 "grant_access",
                 {"principal_type": "service", "principal_id": "1", "role_id": "5"},
-            )()
+            )
             assert "error" in payload
             assert "principal_type" in payload["error"]
         finally:

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -233,6 +233,91 @@ class TestDeployLookmlChanges:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_fails_on_non_404_patch_error(self, config):
+        """Non-404 PATCH failures (auth, 5xx, etc.) must propagate — we
+        must NOT silently fall back to POST, which would double side
+        effects and mask the real cause."""
+        _mock_login_logout()
+
+        # PATCH returns 500 — simulating a server error / transient.
+        respx.patch(url__regex=rf"{API_URL}/projects/analytics/files/.*").mock(
+            return_value=httpx.Response(500, json={"message": "internal server error"})
+        )
+        # No POST or deploy mocks — if either is called, the test errors.
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "deploy_lookml_changes",
+                {
+                    "project_id": "analytics",
+                    "files": {"views/orders.view.lkml": "view: orders {}"},
+                    "validate": True,
+                },
+            )()
+            # Error surfaces to caller — tool's top-level exception
+            # handler returns the format_api_error envelope.
+            assert "error" in payload
+            # Safety invariants: no create-as-fallback, no validation,
+            # no deploy. The tool fails fast on the first bad PATCH.
+            post_calls = [
+                c
+                for c in respx.calls
+                if c.request.method == "POST" and "/files/" in c.request.url.path
+            ]
+            assert post_calls == []
+            deploy_calls = [
+                c for c in respx.calls if c.request.url.path.endswith("/deploy_to_production")
+            ]
+            assert deploy_calls == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_creates_missing_file_on_404(self, config):
+        """The 404→POST fallback path still works for genuinely missing
+        files. Complements test_fails_on_non_404_patch_error."""
+        _mock_login_logout()
+
+        respx.patch(url__regex=rf"{API_URL}/projects/analytics/files/.*").mock(
+            return_value=httpx.Response(404, json={"message": "file not found"})
+        )
+        create_captured: dict = {"called": False}
+
+        def capture_post(request: httpx.Request) -> httpx.Response:
+            create_captured["called"] = True
+            return httpx.Response(200, json={"id": "views/new.view.lkml"})
+
+        respx.post(url__regex=rf"{API_URL}/projects/analytics/files/.*").mock(
+            side_effect=capture_post
+        )
+        respx.post(f"{API_URL}/projects/analytics/lookml_validation").mock(
+            return_value=httpx.Response(200, json={"errors": [], "warnings": []})
+        )
+        respx.post(f"{API_URL}/projects/analytics/deploy_to_production").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "deploy_lookml_changes",
+                {
+                    "project_id": "analytics",
+                    "files": {"views/new.view.lkml": "view: new {}"},
+                },
+            )()
+            assert payload["deployed"] is True
+            assert payload["files"][0]["action"] == "created"
+            assert create_captured["called"] is True
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_deploys_when_validation_passes(self, config):
         _mock_login_logout()
         respx.patch(url__regex=rf"{API_URL}/projects/analytics/files/.*").mock(
@@ -406,6 +491,44 @@ class TestProvisionUser:
             assert creds_step["ok"] is False
             # User was NOT rolled back — they exist and have an id.
             assert payload["user_id"] == "99"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_short_circuits_on_empty_user_id(self, config):
+        """If POST /users returns no id, downstream calls would get a
+        malformed URL like /users//credentials_email. Tool must detect
+        this and short-circuit with a clear error."""
+        _mock_login_logout()
+        # POST /users succeeds but returns no id field.
+        respx.post(f"{API_URL}/users").mock(
+            return_value=httpx.Response(201, json={"email": "a@example.com"})
+        )
+        # No mocks for downstream endpoints — if any are called, the test errors.
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "provision_user",
+                {
+                    "email": "a@example.com",
+                    "first_name": "Alice",
+                    "last_name": "Example",
+                    "user_attribute_values": {"5": "EMEA"},
+                    "send_invite": True,
+                },
+            )()
+            assert "error" in payload
+            assert "no id" in payload["error"].lower()
+            # No downstream POSTs happened — tool failed fast.
+            post_calls = [c for c in respx.calls if c.request.method == "POST"]
+            # Exactly two: /login (session setup), and POST /users.
+            post_paths = {c.request.url.path for c in post_calls}
+            assert all(p.endswith("/login") or p.endswith("/users") for p in post_paths), (
+                f"Unexpected POST calls: {post_paths}"
+            )
         finally:
             await client.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

First half of Layer 2 — task-oriented workflow tools that compose the Layer 1 atomic tools into one-call admin jobs. Matches the motivation from ULT-668 / Anthropic's tool-design research: **fewer higher-level task tools score better on agent selection accuracy than many atomic ones** (79.5% → 88.1% on Opus 4.5 benchmarks).

### 6 workflows, grouped by admin-lifecycle day

| Day | Tool | Replaces | Structured partial-failure signal |
|---|---|---|---|
| 1 | `provision_connection` | `create_connection` + `test_connection` | Per-check breakdown (`connect`, `query`, `tmp_table`, `cdt`, `pdt`) left on partial failure |
| 1 | `bootstrap_lookml_project` | `create_project` + `update_project` + `create_project_deploy_key` | `deploy_key_public` returned with `next_step` to install on git remote |
| 2 | `deploy_lookml_changes` | N × file writes + `validate_project` + `deploy_to_production` | Validation errors block deploy — files left in dev workspace for repair |
| 2 | `rollback_to_production` | `reset_to_production` with safety wrapper | Requires explicit `confirm=True` flag |
| 3 | `provision_user` | `create_user` + `create_credentials_email` + role/group assignment + attribute values + `send_password_reset` | Per-step status in response; partial failures don't roll back the user record |
| 3 | `grant_access` | `get_role_users`/`get_role_groups` + `set_role_users`/`set_role_groups` read-modify-write | Idempotent — `already_granted: true` when principal is already a member |

## Design notes

- **Each workflow makes its HTTP calls directly.** Tool functions are closures inside `register_*_tools()` so they're not importable across modules. This means workflows duplicate the HTTP call logic rather than calling atomic tool functions — fine, since the atomic tools' shape is the stable contract.
- **Partial-failure reporting, not rollback.** Looker's API doesn't support transactions across these endpoints, so `provision_user` and `deploy_lookml_changes` report per-step status in the response rather than attempting to undo earlier steps. Rollback is a caller decision: e.g. if `create_credentials_email` fails because the user already exists with that email, the agent probably wants to reuse the existing user rather than delete and retry.
- **`deploy_lookml_changes` safety is test-enforced.** `test_skips_deploy_on_validation_errors` mocks the validation response to return errors and asserts **zero** calls to `POST /deploy_to_production`. If a refactor accidentally makes deploy fall through the error path, the test catches it.
- **`rollback_to_production` requires `confirm=True`.** A stale or mis-routed tool call without the flag returns an error instead of silently discarding dev-workspace work. Same pattern applied to destructive git operations elsewhere in this codebase.
- **Response shape carries UX load.** Each tool returns `{success_flags, step_results, next_step?}` so agents can read the response and know what to do next without a separate follow-up query. Same convention as recent PRs (`create_credentials_api3.warning`, `trigger_project_ci_run.next_step`).

## Scope deferred

- **configure_smtp / apply_instance_settings:** blocked on atomic instance-settings tools (`get_setting`, `update_setting`, `get_session_config`) that don't yet exist. Writing workflow code against a `/setting` shape I haven't verified would be premature — better to land the atomic tools in a separate PR first, then build the workflow on top with confidence.
- **Ops workflows** (offboard_user, rotate_api_credentials, audit_query_activity with scope enum, audit_instance_health, investigate_runaway_queries, find_stale_content) → **PR #15**.

## Merge-order note

This PR is authored against main at v0.9.0 and bumps to **v0.11.0**, leapfrogging PR #13's in-flight v0.10.0. If #13 merges first (likely), this PR rebases cleanly — only the CHANGELOG/README tool-count headers need refresh. If this merges first, #13 rebases to v0.11.0.

## Changes

- `src/looker_mcp_server/tools/workflows.py` — new tool group (6 tools, ~500 LOC)
- `src/looker_mcp_server/config.py` — add `workflows` to `ALL_GROUPS`
- `src/looker_mcp_server/server.py` — register via `_group_registry`
- `tests/test_workflow_tools.py` — 14 respx-mocked tests including 4 safety-property tests
- `tests/test_config.py` — extend pinned group list
- `README.md` — tool count + new row
- `CHANGELOG.md` — v0.11.0 entry
- `pyproject.toml` — bump to 0.11.0

Tool count: **140 → 146** across **14 → 15** groups (measured against main pre-#13).

## Test plan

- [x] `uv run ruff format --check .` — 37 files clean
- [x] `uv run ruff check .` — 0 errors
- [x] `uv run pyright src tests` — 0 errors, 0 warnings
- [x] `uv run pytest` — 136/136 pass (14 new)
- [ ] Manual smoke: round-trip each workflow against a dev Looker instance end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Workflows tool group with six admin workflow tools for connection provisioning, LookML project bootstrapping/deploy/rollback, user provisioning, and granting access.

* **Documentation**
  * Updated changelog and README for v0.11.0, listing 153 tools across 15 groups.

* **Tests**
  * Added unit and end-to-end tests validating Workflows behavior and error handling.

* **Chores**
  * Bumped project version to 0.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->