### PR TITLE
feat: add ops + audit workflow tools (Layer 2, part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-04-15
+
+### Added
+
+- **workflows** tool group — ops + audit compositions (7 new tools added to the group established in 0.11.0). Each orchestrates several Looker API calls with structured partial-failure reporting.
+  - `offboard_user`: terminate sessions + revoke API3 credentials + disable (default) or delete user. Non-destructive by default — explicit flag required to delete. `deactivated`/`deleted` flags reflect the actual step outcome, not the request mode.
+  - `rotate_api_credentials`: create a new API3 pair (returning the one-time `client_secret`); optional `delete_previous_id` argument handles the retire-after-verify step in the same workflow.
+  - `audit_query_activity`: scope enum (`slow`/`errors`/`frequent`/`by_user`/`by_content`) that picks the right `system__activity.history` query shape for common investigations.
+  - `audit_instance_health`: composite 3-section health report — failed PDT builds, failed scheduled-plan runs, content validation errors. Reports `sample_count` + `truncated` per section; `healthy` is False when any section errored, was truncated, or has a non-zero issue count.
+  - `investigate_runaway_queries`: list running queries above a runtime threshold, optionally `action='kill'` to terminate each.
+  - `find_stale_content`: `content_usage` query filtered on `days_since_last_accessed >= N`, sorted oldest-first.
+  - `disable_stale_sessions`: enumerate sessions older than N days, optionally `action='terminate'` to force-logout each. Dry-run by default.
+- Total tool count: 153 → 160 across 15 groups
+
 ## [0.11.0] - 2026-04-15
 
 ### Added
@@ -17,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `provision_user`: end-to-end user onboarding in one call — create user + email credentials + role/group assignments + user-attribute values + invite email. Reports per-step status; guards against empty `user_id` from a malformed create response.
   - `grant_access`: idempotent read-modify-write to add a user or group to a role's membership. Preserves existing members.
 - Total tool count: 147 → 153 across 15 groups
+
 
 ## [0.10.0] - 2026-04-15
 
@@ -179,6 +194,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[0.12.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.8.0...v0.9.0

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A full-featured [Model Context Protocol](https://modelcontextprotocol.io) (MCP) 
 
 ## Features
 
-- **153 tools** across 15 groups covering the full Looker API surface
+- **160 tools** across 15 groups covering the full Looker API surface
 - **Semantic layer queries** — query through LookML models, not raw SQL
 - **OAuth pass-through** — forward user tokens from an upstream gateway or MCP OAuth flow
 - **User impersonation** — admin sudo on self-hosted Looker, OAuth on Google Cloud core
@@ -113,7 +113,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **user_attributes** | `list_user_attributes`, `get_user_attribute`, `create_user_attribute`, `update_user_attribute`, `delete_user_attribute`, `list_user_attribute_group_values`, `set_user_attribute_group_values`, `delete_user_attribute_group_value`, `list_user_attribute_values_for_user`, `set_user_attribute_user_value`, `delete_user_attribute_user_value` | User attribute definitions plus per-group and per-user value overrides (row-level security, per-developer credentials, filter defaults) |
 | **credentials** | `list_credentials_api3`, `create_credentials_api3`, `get_credentials_api3`, `delete_credentials_api3`, `get_credentials_ldap`, `delete_credentials_ldap`, `get_credentials_saml`, `delete_credentials_saml`, `get_credentials_oidc`, `delete_credentials_oidc`, `get_credentials_google`, `delete_credentials_google` | Non-email credentials — API3 key-pair rotation plus get/delete for LDAP, SAML, OIDC, and Google SSO links |
 | **audit** | `get_query_history`, `get_content_usage`, `get_pdt_build_log`, `get_schedule_history`, `get_user_activity_log`, `list_running_queries`, `kill_query`, `list_active_sessions`, `get_session`, `terminate_session`, `list_project_ci_runs`, `get_project_ci_run`, `trigger_project_ci_run` | Query history, content usage, PDT build + schedule + event logs via system__activity, plus live-ops (running queries, sessions, CI runs) |
-| **workflows** | `provision_connection`, `bootstrap_lookml_project`, `deploy_lookml_changes`, `rollback_to_production`, `provision_user`, `grant_access` | Task-oriented compositions over atomic tools — one-call ergonomics for common admin jobs (provisioning, deploying LookML, onboarding users) |
+| **workflows** | `provision_connection`, `bootstrap_lookml_project`, `deploy_lookml_changes`, `rollback_to_production`, `provision_user`, `grant_access`, `offboard_user`, `rotate_api_credentials`, `audit_query_activity`, `audit_instance_health`, `investigate_runaway_queries`, `find_stale_content`, `disable_stale_sessions` | Task-oriented Layer 2 compositions — provisioning workflows (bootstrap, deploy, provision users) plus ops/audit workflows (offboard, rotate credentials, audit, cleanup) |
 
 ### Selecting Groups
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.11.0"
+version = "0.12.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/tools/workflows.py
+++ b/src/looker_mcp_server/tools/workflows.py
@@ -1,23 +1,24 @@
 """Workflows tool group — task-oriented compositions over atomic tools.
 
-These tools each orchestrate several Looker API calls to complete a full
-admin task (provision a connection, bootstrap a LookML project, onboard a
-user). They return a structured response that tells the caller what
-happened at each step, so partial failures surface clearly rather than
-bubbling up as one opaque error.
+Covers both halves of Layer 2: provisioning workflows (get an instance to
+a running state) and ops/audit workflows (keep it running, investigate,
+wind down).  Each orchestrates several Looker API calls to complete a
+full admin task and returns a structured response with per-step status
+so partial failures surface rather than being swallowed.
 
 Everything these tools can do is also doable by calling the underlying
 atomic tools (``connection``, ``modeling``, ``admin``, ``credentials``,
-``user_attributes``) in sequence. The value is in the orchestration:
-correct ordering, structured partial-failure reporting, and one-call
-ergonomics for common jobs.
+``user_attributes``, ``audit``) in sequence.  The value is in the
+orchestration: correct ordering, structured partial-failure reporting,
+and one-call ergonomics for common jobs.
 
-Admin-only surface; disabled by default. Enable with ``--groups workflows``.
+Admin-only surface; disabled by default.  Enable with ``--groups workflows``.
 """
 
 from __future__ import annotations
 
 import json
+from datetime import UTC
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
@@ -531,3 +532,652 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                 )
         except Exception as e:
             return format_api_error("grant_access", e)
+
+    # ── User lifecycle ───────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Offboard a user safely: optionally transfer their content, "
+            "terminate active sessions, revoke API3 credentials, and either "
+            "disable (default, reversible) or delete the user. Reports per-"
+            "step status. Default ``deactivate_only=True`` is non-destructive "
+            "— flip to False explicitly when you want the user record gone."
+        ),
+    )
+    async def offboard_user(
+        user_id: Annotated[str, "User ID"],
+        terminate_sessions: Annotated[bool, "Terminate all active sessions for this user"] = True,
+        revoke_api_credentials: Annotated[
+            bool, "Delete all API3 credential pairs attached to this user"
+        ] = True,
+        deactivate_only: Annotated[
+            bool, "Disable the user (True, reversible) vs delete (False, irreversible)"
+        ] = True,
+    ) -> str:
+        ctx = client.build_context("offboard_user", "workflows", {"user_id": user_id})
+        steps: list[dict[str, Any]] = []
+        try:
+            async with client.session(ctx) as session:
+                uid = _path_seg(user_id)
+
+                # Step 1: terminate sessions attributable to this user.
+                if terminate_sessions:
+                    try:
+                        sessions_list = await session.get("/sessions") or []
+                        victim_sessions = [
+                            s for s in sessions_list if str(s.get("user_id")) == user_id
+                        ]
+                        for s in victim_sessions:
+                            sid = s.get("id")
+                            if sid is not None:
+                                await session.delete(f"/sessions/{_path_seg(str(sid))}")
+                        steps.append(
+                            {
+                                "step": "terminate_sessions",
+                                "ok": True,
+                                "count": len(victim_sessions),
+                            }
+                        )
+                    except Exception as e:
+                        steps.append(
+                            {
+                                "step": "terminate_sessions",
+                                "ok": False,
+                                "error": format_api_error("terminate_sessions", e),
+                            }
+                        )
+
+                # Step 2: revoke all API3 credential pairs.
+                if revoke_api_credentials:
+                    try:
+                        api_creds = await session.get(f"/users/{uid}/credentials_api3") or []
+                        for c in api_creds:
+                            cid = c.get("id")
+                            if cid is not None:
+                                await session.delete(
+                                    f"/users/{uid}/credentials_api3/{_path_seg(str(cid))}"
+                                )
+                        steps.append(
+                            {
+                                "step": "revoke_api_credentials",
+                                "ok": True,
+                                "count": len(api_creds),
+                            }
+                        )
+                    except Exception as e:
+                        steps.append(
+                            {
+                                "step": "revoke_api_credentials",
+                                "ok": False,
+                                "error": format_api_error("revoke_api_credentials", e),
+                            }
+                        )
+
+                # Step 3: disable or delete the user.
+                try:
+                    if deactivate_only:
+                        await session.patch(f"/users/{uid}", body={"is_disabled": True})
+                        steps.append({"step": "disable_user", "ok": True})
+                    else:
+                        await session.delete(f"/users/{uid}")
+                        steps.append({"step": "delete_user", "ok": True})
+                except Exception as e:
+                    steps.append(
+                        {
+                            "step": "disable_user" if deactivate_only else "delete_user",
+                            "ok": False,
+                            "error": format_api_error("offboard_user", e),
+                        }
+                    )
+
+                all_ok = all(s.get("ok", True) for s in steps)
+
+                # deactivated / deleted must reflect the actual outcome
+                # of step 3 — not the requested mode. A caller who sees
+                # `deactivated: True` with `all_steps_ok: False` has a
+                # contradictory response.
+                def _step_succeeded(name: str) -> bool:
+                    return any(s.get("step") == name and s.get("ok") is True for s in steps)
+
+                return json.dumps(
+                    {
+                        "user_id": user_id,
+                        "all_steps_ok": all_ok,
+                        "requested_action": ("deactivate" if deactivate_only else "delete"),
+                        "deactivated": _step_succeeded("disable_user"),
+                        "deleted": _step_succeeded("delete_user"),
+                        "steps": steps,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("offboard_user", e)
+
+    @server.tool(
+        description=(
+            "Rotate a user's API3 credentials safely. Creates a new key "
+            "pair (returning the client_secret once), and optionally "
+            "deletes a specified previous pair. The default behavior does "
+            "NOT delete any existing credentials — the caller should "
+            "deploy the new pair to consumers, verify it works, then call "
+            "this tool again (or ``delete_credentials_api3``) with the "
+            "old credentials_api3_id to retire the old pair."
+        ),
+    )
+    async def rotate_api_credentials(
+        user_id: Annotated[str, "User ID"],
+        delete_previous_id: Annotated[
+            str | None,
+            (
+                "credentials_api3_id of a PREVIOUS key pair to delete. Pass "
+                "only after you've verified the new pair works."
+            ),
+        ] = None,
+    ) -> str:
+        ctx = client.build_context("rotate_api_credentials", "workflows", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                uid = _path_seg(user_id)
+
+                # Create the new pair.
+                new = await session.post(f"/users/{uid}/credentials_api3")
+
+                deletion_section: dict[str, Any] | None = None
+                if delete_previous_id is not None:
+                    try:
+                        await session.delete(
+                            f"/users/{uid}/credentials_api3/{_path_seg(delete_previous_id)}"
+                        )
+                        deletion_section = {
+                            "deleted_previous_id": delete_previous_id,
+                            "ok": True,
+                        }
+                    except Exception as e:
+                        deletion_section = {
+                            "deleted_previous_id": delete_previous_id,
+                            "ok": False,
+                            "error": format_api_error("rotate_api_credentials", e),
+                        }
+
+                return json.dumps(
+                    {
+                        "rotated": True,
+                        "user_id": user_id,
+                        "new_credentials": {
+                            "id": (new or {}).get("id"),
+                            "client_id": (new or {}).get("client_id"),
+                            "client_secret": (new or {}).get("client_secret"),
+                        },
+                        "old_pair_deletion": deletion_section,
+                        "warning": (
+                            "The client_secret is returned only once — store "
+                            "it now. If delete_previous_id was not provided, "
+                            "remember to delete the old pair after verifying "
+                            "the new one."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("rotate_api_credentials", e)
+
+    # ── Audit workflows ──────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Audit query activity with a scope preset. Picks the right "
+            "system__activity query shape for a common investigation: "
+            "'slow' = longest-running queries first, 'errors' = failed "
+            "queries only, 'frequent' = most-run queries (by user + "
+            "query fingerprint), 'by_user' = a single user's queries, "
+            "'by_content' = queries issued from a specific dashboard or "
+            "look. For custom audit queries, use the atomic "
+            "``get_query_history`` in the ``audit`` group or the generic "
+            "``query`` tool."
+        ),
+    )
+    async def audit_query_activity(
+        scope: Annotated[str, "'slow', 'errors', 'frequent', 'by_user', or 'by_content'"],
+        date_range: Annotated[str, "Looker filter-syntax date expression"] = "7 days",
+        user_email: Annotated[str | None, "Required when scope='by_user'"] = None,
+        dashboard_id: Annotated[str | None, "Dashboard to scope to when scope='by_content'"] = None,
+        look_id: Annotated[str | None, "Look to scope to when scope='by_content'"] = None,
+        limit: Annotated[int, "Maximum rows to return"] = 100,
+    ) -> str:
+        if scope not in ("slow", "errors", "frequent", "by_user", "by_content"):
+            return json.dumps(
+                {
+                    "error": (
+                        f"scope must be one of slow / errors / frequent / "
+                        f"by_user / by_content, got {scope!r}"
+                    )
+                },
+                indent=2,
+            )
+        if scope == "by_user" and not user_email:
+            return json.dumps({"error": "scope='by_user' requires user_email"}, indent=2)
+        if scope == "by_content" and not dashboard_id and not look_id:
+            return json.dumps(
+                {"error": "scope='by_content' requires either dashboard_id or look_id"},
+                indent=2,
+            )
+
+        filters: dict[str, str] = {"history.created_time": date_range}
+        sorts: list[str] = ["history.runtime desc"]
+        fields = [
+            "history.created_time",
+            "user.email",
+            "query.model",
+            "query.view",
+            "history.runtime",
+            "history.status",
+            "history.issuer_source",
+            "history.result_source",
+        ]
+
+        if scope == "slow":
+            # Default sort already surfaces slowest; no additional filter.
+            pass
+        elif scope == "errors":
+            filters["history.status"] = "-complete"
+            sorts = ["history.created_time desc"]
+        elif scope == "frequent":
+            # Most-run by user + model/view fingerprint.
+            fields = ["user.email", "query.model", "query.view", "history.count"]
+            sorts = ["history.count desc"]
+        elif scope == "by_user":
+            filters["user.email"] = user_email or ""
+            sorts = ["history.created_time desc"]
+        elif scope == "by_content":
+            if dashboard_id:
+                filters["dashboard.id"] = dashboard_id
+            if look_id:
+                filters["look.id"] = look_id
+            sorts = ["history.created_time desc"]
+
+        ctx = client.build_context(
+            "audit_query_activity", "workflows", {"scope": scope, "date_range": date_range}
+        )
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {
+                    "model": "system__activity",
+                    "view": "history",
+                    "fields": fields,
+                    "filters": filters,
+                    "sorts": sorts,
+                    "limit": str(limit),
+                }
+                query_def = await session.post("/queries", body=body)
+                rows = await session.get(f"/queries/{_path_seg(str(query_def['id']))}/run/json")
+                row_count = len(rows) if isinstance(rows, list) else 0
+                return json.dumps(
+                    {"scope": scope, "row_count": row_count, "rows": rows},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("audit_query_activity", e)
+
+    @server.tool(
+        description=(
+            "Produce a composite health report for the instance over a "
+            "time window: failed PDT builds, failed scheduled-plan runs, "
+            "and broken-content counts. Each per-query section returns "
+            "``sample_count`` and a ``sample`` capped at 10 rows — intended "
+            "for a triage at-a-glance view, not a full audit. If any "
+            "section hits its sample cap, the section's ``truncated`` "
+            "flag is set — drill into that section with the atomic audit "
+            "tool for exact counts. If any section fails outright, the "
+            "top-level ``healthy`` flag is False and ``partial_failure`` "
+            "is True, so a caller can never mistake a failed query for a "
+            "healthy instance."
+        ),
+    )
+    async def audit_instance_health(
+        date_range: Annotated[str, "Looker filter-syntax date expression"] = "24 hours",
+    ) -> str:
+        ctx = client.build_context("audit_instance_health", "workflows", {"date_range": date_range})
+        sections: dict[str, Any] = {}
+        sample_limit = 10
+        try:
+            async with client.session(ctx) as session:
+                # Section A: failed PDT builds.
+                try:
+                    body_pdt: dict[str, Any] = {
+                        "model": "system__activity",
+                        "view": "pdt_event_log",
+                        "fields": [
+                            "pdt_event_log.created_time",
+                            "pdt_event_log.model_name",
+                            "pdt_event_log.view_name",
+                            "pdt_event_log.status_code",
+                            "pdt_event_log.message",
+                        ],
+                        "filters": {
+                            "pdt_event_log.created_time": date_range,
+                            "pdt_event_log.status_code": "error",
+                        },
+                        "sorts": ["pdt_event_log.created_time desc"],
+                        "limit": str(sample_limit),
+                    }
+                    qd = await session.post("/queries", body=body_pdt)
+                    rows = await session.get(f"/queries/{_path_seg(str(qd['id']))}/run/json")
+                    sample_count = len(rows) if isinstance(rows, list) else 0
+                    sections["failed_pdt_builds"] = {
+                        "sample_count": sample_count,
+                        "sample": rows,
+                        "truncated": sample_count >= sample_limit,
+                    }
+                except Exception as e:
+                    sections["failed_pdt_builds"] = {
+                        "error": format_api_error("failed_pdt_builds", e)
+                    }
+
+                # Section B: failed scheduled-plan runs.
+                try:
+                    body_sched: dict[str, Any] = {
+                        "model": "system__activity",
+                        "view": "scheduled_plan",
+                        "fields": [
+                            "scheduled_job.finalized_time",
+                            "scheduled_plan.id",
+                            "scheduled_plan.name",
+                            "user.email",
+                            "scheduled_job.status",
+                            "scheduled_job.status_detail",
+                        ],
+                        "filters": {
+                            "scheduled_job.finalized_time": date_range,
+                            "scheduled_job.status": "-success",
+                        },
+                        "sorts": ["scheduled_job.finalized_time desc"],
+                        "limit": str(sample_limit),
+                    }
+                    qd = await session.post("/queries", body=body_sched)
+                    rows = await session.get(f"/queries/{_path_seg(str(qd['id']))}/run/json")
+                    sample_count = len(rows) if isinstance(rows, list) else 0
+                    sections["failed_schedule_runs"] = {
+                        "sample_count": sample_count,
+                        "sample": rows,
+                        "truncated": sample_count >= sample_limit,
+                    }
+                except Exception as e:
+                    sections["failed_schedule_runs"] = {
+                        "error": format_api_error("failed_schedule_runs", e)
+                    }
+
+                # Section C: content validation (no date filter — snapshot).
+                # total_errors is an exact count from Looker, not a sample.
+                try:
+                    result = await session.get("/content_validation")
+                    sections["content_validation"] = {
+                        "total_errors": (result or {}).get("total_errors"),
+                        "total_looks_validated": (result or {}).get("total_looks_validated"),
+                        "total_dashboards_validated": (result or {}).get(
+                            "total_dashboards_validated"
+                        ),
+                    }
+                except Exception as e:
+                    sections["content_validation"] = {
+                        "error": format_api_error("content_validation", e)
+                    }
+
+                # A section that errored out contributed zero to the
+                # counters below, but we don't actually know its state.
+                # Track that separately so 'healthy' can never be True
+                # when any section was uninspectable.
+                any_section_failed = any(
+                    "error" in section_data for section_data in sections.values()
+                )
+                any_section_truncated = any(
+                    section_data.get("truncated") for section_data in sections.values()
+                )
+
+                # sample_count is a lower bound when truncated is True.
+                # Caller should treat sections with truncated=True as
+                # "at least this many" and drill in via the atomic tools.
+                sample_issue_count = (
+                    sections.get("failed_pdt_builds", {}).get("sample_count", 0)
+                    + sections.get("failed_schedule_runs", {}).get("sample_count", 0)
+                    + (sections.get("content_validation", {}).get("total_errors") or 0)
+                )
+
+                return json.dumps(
+                    {
+                        "date_range": date_range,
+                        "healthy": (
+                            sample_issue_count == 0
+                            and not any_section_failed
+                            and not any_section_truncated
+                        ),
+                        "partial_failure": any_section_failed,
+                        "sample_issue_count": sample_issue_count,
+                        "any_section_truncated": any_section_truncated,
+                        "sections": sections,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("audit_instance_health", e)
+
+    @server.tool(
+        description=(
+            "List currently-running queries whose runtime exceeds "
+            "``threshold_seconds``, and optionally kill them. "
+            "``action='report'`` (default) returns the filtered list "
+            "without mutating anything; ``action='kill'`` terminates each "
+            "matching query via /running_queries DELETE. Use for instance "
+            "triage when the database is saturated."
+        ),
+    )
+    async def investigate_runaway_queries(
+        threshold_seconds: Annotated[
+            float, "Minimum runtime (in seconds) for a query to be considered runaway"
+        ] = 300,
+        action: Annotated[str, "'report' (default) or 'kill'"] = "report",
+    ) -> str:
+        if action not in ("report", "kill"):
+            return json.dumps(
+                {"error": f"action must be 'report' or 'kill', got {action!r}"},
+                indent=2,
+            )
+
+        ctx = client.build_context(
+            "investigate_runaway_queries",
+            "workflows",
+            {"threshold_seconds": threshold_seconds, "action": action},
+        )
+        try:
+            async with client.session(ctx) as session:
+                running = await session.get("/running_queries") or []
+                runaways = [q for q in running if (q.get("runtime") or 0) >= threshold_seconds]
+                trimmed = [
+                    {
+                        "query_task_id": q.get("query_task_id"),
+                        "query_id": q.get("query_id"),
+                        "source": q.get("source"),
+                        "runtime": q.get("runtime"),
+                        "user_id": q.get("user_id"),
+                        "user": (q.get("user") or {}).get("email"),
+                    }
+                    for q in runaways
+                ]
+
+                killed: list[dict[str, Any]] = []
+                if action == "kill":
+                    for q in runaways:
+                        qtid = q.get("query_task_id")
+                        if not qtid:
+                            continue
+                        try:
+                            await session.delete(f"/running_queries/{_path_seg(str(qtid))}")
+                            killed.append({"query_task_id": qtid, "ok": True})
+                        except Exception as e:
+                            killed.append(
+                                {
+                                    "query_task_id": qtid,
+                                    "ok": False,
+                                    "error": format_api_error("kill_query", e),
+                                }
+                            )
+
+                return json.dumps(
+                    {
+                        "threshold_seconds": threshold_seconds,
+                        "action": action,
+                        "runaway_count": len(runaways),
+                        "runaways": trimmed,
+                        "killed": killed if action == "kill" else None,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("investigate_runaway_queries", e)
+
+    @server.tool(
+        description=(
+            "Identify dashboards and looks that haven't been viewed in a "
+            "long time — candidates for deletion or archival. Queries "
+            "system__activity.content_usage over the window and filters "
+            "to content with the lowest view counts. Default threshold "
+            "is 90 days; tune via ``min_days_unused``."
+        ),
+    )
+    async def find_stale_content(
+        min_days_unused: Annotated[int, "Minimum days since last access"] = 90,
+        content_type: Annotated[str, "'dashboard', 'look', or 'all'"] = "all",
+        limit: Annotated[int, "Maximum rows to return"] = 100,
+    ) -> str:
+        # Looker filter syntax: `>=N` on days_since_last_accessed means
+        # "at least N days since last view", which is what we want. The
+        # earlier version of this tool used history.created_date with a
+        # date-window expression, which filters on activity-record
+        # creation rather than content last-view age — a different
+        # question with near-random results for this use case.
+        filters: dict[str, str] = {
+            "content_usage.days_since_last_accessed": f">={min_days_unused}",
+        }
+        if content_type != "all":
+            filters["content_usage.content_type"] = content_type
+
+        ctx = client.build_context(
+            "find_stale_content",
+            "workflows",
+            {"min_days_unused": min_days_unused, "content_type": content_type},
+        )
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {
+                    "model": "system__activity",
+                    "view": "content_usage",
+                    "fields": [
+                        "content_usage.content_type",
+                        "content_usage.content_id",
+                        "content_usage.content_title",
+                        "content_usage.last_accessed_date",
+                        "content_usage.view_count",
+                    ],
+                    "filters": filters,
+                    "sorts": ["content_usage.last_accessed_date asc"],
+                    "limit": str(limit),
+                }
+                qd = await session.post("/queries", body=body)
+                rows = await session.get(f"/queries/{_path_seg(str(qd['id']))}/run/json")
+                return json.dumps(
+                    {
+                        "min_days_unused": min_days_unused,
+                        "content_type": content_type,
+                        "stale_count": len(rows) if isinstance(rows, list) else 0,
+                        "rows": rows,
+                        "next_step": (
+                            "Review the list and delete via delete_look / "
+                            "delete_dashboard from the content group, or "
+                            "archive by moving to a trash folder."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("find_stale_content", e)
+
+    @server.tool(
+        description=(
+            "Terminate active user sessions older than ``max_age_days``. "
+            "Returns count + list of terminated session ids. Default "
+            "90 days matches common session-hygiene policies. Use "
+            "``action='report'`` for a dry-run that lists stale sessions "
+            "without terminating them."
+        ),
+    )
+    async def disable_stale_sessions(
+        max_age_days: Annotated[int, "Terminate sessions created older than this"] = 90,
+        action: Annotated[str, "'report' (default dry-run) or 'terminate'"] = "report",
+    ) -> str:
+        if action not in ("report", "terminate"):
+            return json.dumps(
+                {"error": f"action must be 'report' or 'terminate', got {action!r}"},
+                indent=2,
+            )
+
+        from datetime import datetime, timedelta
+
+        ctx = client.build_context(
+            "disable_stale_sessions",
+            "workflows",
+            {"max_age_days": max_age_days, "action": action},
+        )
+        try:
+            async with client.session(ctx) as session:
+                sessions_list = await session.get("/sessions") or []
+                cutoff = datetime.now(UTC) - timedelta(days=max_age_days)
+
+                stale: list[dict[str, Any]] = []
+                for s in sessions_list:
+                    created_raw = s.get("created_at")
+                    if not created_raw:
+                        continue
+                    try:
+                        created = datetime.fromisoformat(str(created_raw).replace("Z", "+00:00"))
+                    except ValueError:
+                        # Unparseable timestamp — skip rather than guess.
+                        continue
+                    if created < cutoff:
+                        stale.append(
+                            {
+                                "id": s.get("id"),
+                                "user_id": s.get("user_id"),
+                                "created_at": created_raw,
+                                "ip_address": s.get("ip_address"),
+                            }
+                        )
+
+                terminated: list[dict[str, Any]] = []
+                if action == "terminate":
+                    for s in stale:
+                        sid = s.get("id")
+                        if sid is None:
+                            continue
+                        try:
+                            await session.delete(f"/sessions/{_path_seg(str(sid))}")
+                            terminated.append({"id": sid, "ok": True})
+                        except Exception as e:
+                            terminated.append(
+                                {
+                                    "id": sid,
+                                    "ok": False,
+                                    "error": format_api_error("terminate_session", e),
+                                }
+                            )
+
+                return json.dumps(
+                    {
+                        "max_age_days": max_age_days,
+                        "action": action,
+                        "stale_count": len(stale),
+                        "stale_sessions": stale,
+                        "terminated": terminated if action == "terminate" else None,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("disable_stale_sessions", e)

--- a/src/looker_mcp_server/tools/workflows.py
+++ b/src/looker_mcp_server/tools/workflows.py
@@ -761,6 +761,19 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                 {"error": "scope='by_content' requires either dashboard_id or look_id"},
                 indent=2,
             )
+        # Passing both IDs would AND them into an intersection that
+        # matches zero rows in practice (a query can be from a dashboard
+        # OR a look, never both). Reject rather than silently return [].
+        if scope == "by_content" and dashboard_id and look_id:
+            return json.dumps(
+                {
+                    "error": (
+                        "scope='by_content' accepts exactly one of "
+                        "dashboard_id or look_id, not both"
+                    ),
+                },
+                indent=2,
+            )
 
         filters: dict[str, str] = {"history.created_time": date_range}
         sorts: list[str] = ["history.runtime desc"]
@@ -981,6 +994,16 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                 {"error": f"action must be 'report' or 'kill', got {action!r}"},
                 indent=2,
             )
+        # A non-positive threshold would match every running query — with
+        # action='kill' that's a kill-all. Reject before we get anywhere
+        # near the DELETE loop.
+        if threshold_seconds <= 0:
+            return json.dumps(
+                {
+                    "error": (f"threshold_seconds must be positive, got {threshold_seconds!r}"),
+                },
+                indent=2,
+            )
 
         ctx = client.build_context(
             "investigate_runaway_queries",
@@ -1118,6 +1141,16 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                 {"error": f"action must be 'report' or 'terminate', got {action!r}"},
                 indent=2,
             )
+        # Negative max_age_days pushes the cutoff into the future, which
+        # would mark every session as "older than" the cutoff — with
+        # action='terminate' that's a log-everyone-out. Reject early.
+        if max_age_days < 0:
+            return json.dumps(
+                {
+                    "error": (f"max_age_days must be non-negative, got {max_age_days!r}"),
+                },
+                indent=2,
+            )
 
         from datetime import datetime, timedelta
 
@@ -1140,6 +1173,13 @@ def register_workflow_tools(server: FastMCP, client: LookerClient) -> None:
                         created = datetime.fromisoformat(str(created_raw).replace("Z", "+00:00"))
                     except ValueError:
                         # Unparseable timestamp — skip rather than guess.
+                        continue
+                    # fromisoformat can return a naive datetime if the
+                    # input string has no timezone designator. Comparing
+                    # naive < aware raises TypeError, which would crash
+                    # the loop and tank the whole call. Skip naive rows
+                    # rather than assuming UTC.
+                    if created.tzinfo is None:
                         continue
                     if created < cutoff:
                         stale.append(

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -1,6 +1,7 @@
 """Tests for workflows tool group — task-oriented compositions."""
 
 import json
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pytest
@@ -10,6 +11,21 @@ from mcp.types import TextContent
 
 from looker_mcp_server.config import LookerConfig
 from looker_mcp_server.server import create_server
+
+
+def _iso_days_ago(days: int) -> str:
+    """Format a timestamp N days before now in Looker's ISO 8601 shape.
+
+    Using relative-to-now timestamps keeps the stale-session tests from
+    silently breaking as the calendar advances past the hard-coded dates
+    they originally used.
+    """
+    return (
+        (datetime.now(UTC) - timedelta(days=days))
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 @pytest.fixture
@@ -596,6 +612,490 @@ class TestGrantAccess:
             assert "principal_type" in payload["error"]
         finally:
             await client.close()
+
+
+# ══ offboard_user ════════════════════════════════════════════════════
+
+
+class TestOffboardUser:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_terminates_sessions_revokes_keys_disables(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/sessions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"id": 1001, "user_id": 42, "created_at": "2026-04-10T00:00:00Z"},
+                    {"id": 1002, "user_id": 7, "created_at": "2026-04-10T00:00:00Z"},
+                ],
+            )
+        )
+        terminated: list = []
+
+        def capture_terminate(request: httpx.Request) -> httpx.Response:
+            terminated.append(request.url.path)
+            return httpx.Response(204)
+
+        respx.delete(url__regex=rf"{API_URL}/sessions/\d+").mock(side_effect=capture_terminate)
+        respx.get(f"{API_URL}/users/42/credentials_api3").mock(
+            return_value=httpx.Response(200, json=[{"id": "99", "client_id": "abc"}])
+        )
+        respx.delete(f"{API_URL}/users/42/credentials_api3/99").mock(
+            return_value=httpx.Response(204)
+        )
+        respx.patch(f"{API_URL}/users/42").mock(
+            return_value=httpx.Response(200, json={"id": "42", "is_disabled": True})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp, "offboard_user", {"user_id": "42", "deactivate_only": True}
+            )
+            assert payload["all_steps_ok"] is True
+            assert payload["deactivated"] is True
+            # Terminated the session belonging to user 42, not the other one.
+            assert len(terminated) == 1
+            assert "/sessions/1001" in terminated[0]
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_mode_requires_explicit_flag(self, config):
+        """When deactivate_only=False, DELETE is used instead of PATCH."""
+        _mock_login_logout()
+        respx.get(f"{API_URL}/sessions").mock(return_value=httpx.Response(200, json=[]))
+        respx.get(f"{API_URL}/users/42/credentials_api3").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        delete_captured = {"called": False}
+
+        def capture_delete(request: httpx.Request) -> httpx.Response:
+            delete_captured["called"] = True
+            return httpx.Response(204)
+
+        respx.delete(f"{API_URL}/users/42").mock(side_effect=capture_delete)
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp, "offboard_user", {"user_id": "42", "deactivate_only": False}
+            )
+            assert payload["deleted"] is True
+            assert payload["deactivated"] is False
+            assert payload["requested_action"] == "delete"
+            assert delete_captured["called"] is True
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deactivated_flag_reflects_outcome_not_request(self, config):
+        """If the disable PATCH fails, `deactivated` must be False even
+        though the caller requested deactivate_only=True. Previously the
+        response mirrored the input, making a failed offboard look
+        successful to callers who only checked `deactivated`."""
+        _mock_login_logout()
+        respx.get(f"{API_URL}/sessions").mock(return_value=httpx.Response(200, json=[]))
+        respx.get(f"{API_URL}/users/42/credentials_api3").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        # PATCH /users/42 fails — Looker 403.
+        respx.patch(f"{API_URL}/users/42").mock(
+            return_value=httpx.Response(403, json={"message": "not authorized"})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp, "offboard_user", {"user_id": "42", "deactivate_only": True}
+            )
+            assert payload["all_steps_ok"] is False
+            # Critical: request was 'deactivate' but outcome was failure,
+            # so deactivated must be False (not True as before).
+            assert payload["requested_action"] == "deactivate"
+            assert payload["deactivated"] is False
+            assert payload["deleted"] is False
+            # The failing step is visible in the steps list.
+            failed = [s for s in payload["steps"] if not s.get("ok", True)]
+            assert len(failed) == 1
+            assert failed[0]["step"] == "disable_user"
+        finally:
+            await client.close()
+
+
+# ══ rotate_api_credentials ═══════════════════════════════════════════
+
+
+class TestRotateApiCredentials:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_only_when_no_previous_id(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/users/42/credentials_api3").mock(
+            return_value=httpx.Response(
+                201,
+                json={"id": "99", "client_id": "new", "client_secret": "ONCE-ONLY"},
+            )
+        )
+        # No delete mock — should not be called.
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(mcp, "rotate_api_credentials", {"user_id": "42"})
+            assert payload["rotated"] is True
+            assert payload["new_credentials"]["client_secret"] == "ONCE-ONLY"
+            assert payload["old_pair_deletion"] is None
+            # Verify no DELETE calls to credentials_api3/* happened.
+            del_calls = [
+                c
+                for c in respx.calls
+                if c.request.method == "DELETE" and "credentials_api3" in c.request.url.path
+            ]
+            assert del_calls == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_deletes_previous_when_id_provided(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/users/42/credentials_api3").mock(
+            return_value=httpx.Response(
+                201, json={"id": "99", "client_id": "new", "client_secret": "ONCE"}
+            )
+        )
+        respx.delete(f"{API_URL}/users/42/credentials_api3/old").mock(
+            return_value=httpx.Response(204)
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "rotate_api_credentials",
+                {"user_id": "42", "delete_previous_id": "old"},
+            )
+            assert payload["old_pair_deletion"]["ok"] is True
+            assert payload["old_pair_deletion"]["deleted_previous_id"] == "old"
+        finally:
+            await client.close()
+
+
+# ══ audit_query_activity (scope enum) ════════════════════════════════
+
+
+class TestAuditQueryActivity:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_errors_scope_filters_to_non_complete(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "q1"})
+
+        respx.post(f"{API_URL}/queries").mock(side_effect=capture)
+        respx.get(f"{API_URL}/queries/q1/run/json").mock(return_value=httpx.Response(200, json=[]))
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            await _invoke_tool(mcp, "audit_query_activity", {"scope": "errors"})
+            assert captured["body"]["filters"]["history.status"] == "-complete"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_by_user_scope_requires_user_email(self, config):
+        _mock_login_logout()
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(mcp, "audit_query_activity", {"scope": "by_user"})
+            assert "error" in payload
+            assert "user_email" in payload["error"]
+            # No POST /queries should have fired.
+            assert [c for c in respx.calls if c.request.url.path.endswith("/queries")] == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_rejects_unknown_scope(self, config):
+        _mock_login_logout()
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(mcp, "audit_query_activity", {"scope": "everything"})
+            assert "error" in payload
+            assert "scope" in payload["error"]
+        finally:
+            await client.close()
+
+
+# ══ audit_instance_health ════════════════════════════════════════════
+
+
+class TestAuditInstanceHealth:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_aggregates_three_sections(self, config):
+        _mock_login_logout()
+
+        # Each POST /queries returns a different query id so we can mock
+        # the run/json responses distinctly.
+        query_ids = iter(["pdt-q", "sched-q"])
+
+        def post_queries(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(201, json={"id": next(query_ids)})
+
+        respx.post(f"{API_URL}/queries").mock(side_effect=post_queries)
+        respx.get(f"{API_URL}/queries/pdt-q/run/json").mock(
+            return_value=httpx.Response(
+                200,
+                json=[{"pdt_event_log.status_code": "error", "pdt_event_log.message": "x"}],
+            )
+        )
+        respx.get(f"{API_URL}/queries/sched-q/run/json").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get(f"{API_URL}/content_validation").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "total_errors": 2,
+                    "total_looks_validated": 50,
+                    "total_dashboards_validated": 10,
+                },
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(mcp, "audit_instance_health", {})
+            assert payload["healthy"] is False
+            assert payload["partial_failure"] is False
+            # 1 PDT-build sample + 0 schedule samples + 2 content_validation errors = 3
+            assert payload["sample_issue_count"] == 3
+            assert payload["sections"]["failed_pdt_builds"]["sample_count"] == 1
+            assert payload["sections"]["failed_pdt_builds"]["truncated"] is False
+            assert payload["sections"]["content_validation"]["total_errors"] == 2
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_section_error_flips_healthy_false(self, config):
+        """A section whose query errors out must force healthy=False and
+        partial_failure=True, so the caller can never mistake an
+        uninspectable instance for a healthy one."""
+        _mock_login_logout()
+
+        # PDT query errors; schedule query succeeds with zero failures;
+        # content_validation succeeds with zero errors. Under the old
+        # shape the tool reported healthy=True because the erroring
+        # section contributed 0 to the total. Fixed: section error
+        # flips healthy to False regardless.
+        respx.post(f"{API_URL}/queries").mock(
+            side_effect=[
+                httpx.Response(500, json={"message": "server error"}),
+                httpx.Response(201, json={"id": "sched-q"}),
+            ]
+        )
+        respx.get(f"{API_URL}/queries/sched-q/run/json").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        respx.get(f"{API_URL}/content_validation").mock(
+            return_value=httpx.Response(200, json={"total_errors": 0, "total_looks_validated": 50})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(mcp, "audit_instance_health", {})
+            assert payload["healthy"] is False
+            assert payload["partial_failure"] is True
+            assert "error" in payload["sections"]["failed_pdt_builds"]
+        finally:
+            await client.close()
+
+
+# ══ investigate_runaway_queries ══════════════════════════════════════
+
+
+class TestInvestigateRunawayQueries:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_report_lists_above_threshold(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/running_queries").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"query_task_id": "a", "runtime": 400, "source": "dashboard"},
+                    {"query_task_id": "b", "runtime": 60, "source": "api"},
+                    {"query_task_id": "c", "runtime": 600, "source": "explore"},
+                ],
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "investigate_runaway_queries",
+                {"threshold_seconds": 300, "action": "report"},
+            )
+            assert payload["runaway_count"] == 2
+            task_ids = {r["query_task_id"] for r in payload["runaways"]}
+            assert task_ids == {"a", "c"}
+            # In report mode, no DELETE should fire.
+            assert payload["killed"] is None
+            assert [
+                c
+                for c in respx.calls
+                if c.request.method == "DELETE" and "running_queries" in c.request.url.path
+            ] == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_kill_terminates_each_runaway(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/running_queries").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"query_task_id": "a", "runtime": 400},
+                    {"query_task_id": "c", "runtime": 600},
+                ],
+            )
+        )
+        killed_paths: list = []
+
+        def capture_kill(request: httpx.Request) -> httpx.Response:
+            killed_paths.append(request.url.path)
+            return httpx.Response(204)
+
+        respx.delete(url__regex=rf"{API_URL}/running_queries/.+").mock(side_effect=capture_kill)
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "investigate_runaway_queries",
+                {"threshold_seconds": 100, "action": "kill"},
+            )
+            assert payload["runaway_count"] == 2
+            assert len(payload["killed"]) == 2
+            assert all(k["ok"] for k in payload["killed"])
+        finally:
+            await client.close()
+
+
+# ══ find_stale_content ═══════════════════════════════════════════════
+
+
+class TestFindStaleContent:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_scopes_content_type_and_sorts_oldest_first(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "q1"})
+
+        respx.post(f"{API_URL}/queries").mock(side_effect=capture)
+        respx.get(f"{API_URL}/queries/q1/run/json").mock(return_value=httpx.Response(200, json=[]))
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            await _invoke_tool(
+                mcp,
+                "find_stale_content",
+                {"min_days_unused": 120, "content_type": "dashboard"},
+            )
+            assert captured["body"]["view"] == "content_usage"
+            assert captured["body"]["filters"]["content_usage.content_type"] == "dashboard"
+            assert captured["body"]["sorts"] == ["content_usage.last_accessed_date asc"]
+        finally:
+            await client.close()
+
+
+# ══ disable_stale_sessions ═══════════════════════════════════════════
+
+
+class TestDisableStaleSessions:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_report_lists_without_terminating(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/sessions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    # ~200 days old — stale at the default 90d threshold.
+                    {"id": 1, "user_id": 7, "created_at": _iso_days_ago(200)},
+                    # Recent — within the threshold, must NOT be reported.
+                    {"id": 2, "user_id": 8, "created_at": _iso_days_ago(5)},
+                ],
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "disable_stale_sessions",
+                {"max_age_days": 90, "action": "report"},
+            )
+            assert payload["stale_count"] == 1
+            assert payload["stale_sessions"][0]["id"] == 1
+            # Report mode: no terminated list in response.
+            assert payload["terminated"] is None
+            # Safety: no DELETE calls.
+            assert [
+                c
+                for c in respx.calls
+                if c.request.method == "DELETE" and "/sessions/" in c.request.url.path
+            ] == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_terminate_kills_each_stale(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/sessions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"id": 1, "created_at": _iso_days_ago(220)},
+                    {"id": 2, "created_at": _iso_days_ago(180)},
+                    {"id": 3, "created_at": _iso_days_ago(5)},  # recent
+                ],
+            )
+        )
+        respx.delete(url__regex=rf"{API_URL}/sessions/\d+").mock(return_value=httpx.Response(204))
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "disable_stale_sessions",
+                {"max_age_days": 90, "action": "terminate"},
+            )
+            assert payload["stale_count"] == 2
+            assert len(payload["terminated"]) == 2
+            assert all(t["ok"] for t in payload["terminated"])
+        finally:
+            await client.close()
+
 
 
 # ══ Registration ═════════════════════════════════════════════════════

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -835,6 +835,28 @@ class TestAuditQueryActivity:
         finally:
             await client.close()
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_by_content_rejects_both_ids(self, config):
+        """Passing both dashboard_id and look_id would AND the filters
+        into an intersection that's always empty (a query can be from
+        one or the other, never both). Must reject with a clear error
+        rather than silently returning zero rows."""
+        _mock_login_logout()
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "audit_query_activity",
+                {"scope": "by_content", "dashboard_id": "d1", "look_id": "l1"},
+            )
+            assert "error" in payload
+            assert "exactly one" in payload["error"]
+            # No POST /queries should have fired.
+            assert [c for c in respx.calls if c.request.url.path.endswith("/queries")] == []
+        finally:
+            await client.close()
+
 
 # ══ audit_instance_health ════════════════════════════════════════════
 
@@ -995,6 +1017,27 @@ class TestInvestigateRunawayQueries:
         finally:
             await client.close()
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_rejects_non_positive_threshold(self, config):
+        """Critical safety property: a non-positive threshold would
+        match every running query. With action='kill' that's a
+        kill-all. Tool must reject before any /running_queries call."""
+        _mock_login_logout()
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "investigate_runaway_queries",
+                {"threshold_seconds": -1, "action": "kill"},
+            )
+            assert "error" in payload
+            assert "positive" in payload["error"]
+            # No GET /running_queries, no DELETE calls.
+            assert [c for c in respx.calls if "running_queries" in c.request.url.path] == []
+        finally:
+            await client.close()
+
 
 # ══ find_stale_content ═══════════════════════════════════════════════
 
@@ -1093,6 +1136,64 @@ class TestDisableStaleSessions:
             assert payload["stale_count"] == 2
             assert len(payload["terminated"]) == 2
             assert all(t["ok"] for t in payload["terminated"])
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_rejects_negative_max_age(self, config):
+        """Critical safety property: a negative max_age_days pushes the
+        cutoff into the future, which would make every session 'older'
+        than the cutoff. With action='terminate' that's a log-everyone-out.
+        Tool must reject before any /sessions call."""
+        _mock_login_logout()
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "disable_stale_sessions",
+                {"max_age_days": -1, "action": "terminate"},
+            )
+            assert "error" in payload
+            assert "non-negative" in payload["error"]
+            # No GET /sessions happened — tool failed fast on the guard.
+            assert [c for c in respx.calls if "/sessions" in c.request.url.path] == []
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_skips_timezone_naive_timestamps(self, config):
+        """Looker can return timestamps without a timezone designator;
+        datetime.fromisoformat returns a naive datetime, which would raise
+        TypeError on comparison with the UTC-aware cutoff and crash the
+        loop. Must skip naive rows gracefully rather than fail the call."""
+        _mock_login_logout()
+        # Mix a clearly-stale Z-suffixed row with a naive row and a
+        # recent row. The naive row must be skipped, not tank the call.
+        respx.get(f"{API_URL}/sessions").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"id": 1, "created_at": _iso_days_ago(200)},
+                    # Naive timestamp — no Z, no offset.
+                    {"id": 2, "created_at": "2025-01-01T00:00:00"},
+                    {"id": 3, "created_at": _iso_days_ago(5)},
+                ],
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"workflows"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "disable_stale_sessions",
+                {"max_age_days": 90, "action": "report"},
+            )
+            # Only the Z-suffixed 200-day-old row is flagged stale.
+            # The naive row was skipped; the recent row is inside the window.
+            assert payload["stale_count"] == 1
+            assert payload["stale_sessions"][0]["id"] == 1
         finally:
             await client.close()
 

--- a/tests/test_workflow_tools.py
+++ b/tests/test_workflow_tools.py
@@ -1097,7 +1097,6 @@ class TestDisableStaleSessions:
             await client.close()
 
 
-
 # ══ Registration ═════════════════════════════════════════════════════
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Second half of Layer 2 workflow tools. Seven task-oriented compositions for the "keep running / investigate / wind down" side of admin work — the counterpart to PR #14's provisioning workflows.

### 7 workflows, grouped by admin concern

| Concern | Tool | What it composes |
|---|---|---|
| User lifecycle | `offboard_user` | Terminate sessions + revoke API3 credentials + disable (or delete) user |
| User lifecycle | `rotate_api_credentials` | Create new API3 pair + optional delete of specified previous pair |
| Audit | `audit_query_activity` | Scope enum (`slow` / `errors` / `frequent` / `by_user` / `by_content`) over `system__activity.history` |
| Audit | `audit_instance_health` | Composite 3-section report: failed PDTs + failed schedules + content validation |
| Audit | `investigate_runaway_queries` | List queries above runtime threshold; optional `action='kill'` |
| Audit | `find_stale_content` | `content_usage` filtered to unused content, sorted oldest-first |
| Ops | `disable_stale_sessions` | Sessions older than N days; dry-run by default; optional `action='terminate'` |

## Design notes

- **Non-destructive defaults everywhere that mutates.** `offboard_user.deactivate_only=True`, `disable_stale_sessions.action='report'`, `investigate_runaway_queries.action='report'`. Tests cover each of these safety properties explicitly by asserting zero DELETE calls on the dry-run path.
- **`audit_query_activity` uses a scope enum rather than 5 separate tools.** Per ULT-668's best-practices research, fewer higher-level tools score better on agent selection accuracy. The enum picks the right explore fields + filter map + sort for each investigation shape; scope-specific required args (`user_email` for `by_user`, `dashboard_id`/`look_id` for `by_content`) are validated up-front with an actionable error.
- **`rotate_api_credentials` models the two-phase rotation workflow.** Default behavior creates the new pair only and returns the secret once; `delete_previous_id` is the explicit retire-after-verify argument. Either phase can be a separate tool call, or both can happen together when the caller knows the old id up-front.
- **`audit_instance_health` returns `total_issue_count` as a scalar triage signal.** Lets an agent quickly decide "is there anything to look at" before drilling into section details. Each section returns a `sample` of up to 10 rows so the response is scannable even when counts are large.
- **`disable_stale_sessions` uses `datetime.fromisoformat` with a Z→+00:00 shim.** Looker returns ISO 8601 timestamps sometimes as `2026-04-15T10:00:00Z` and sometimes as `...+00:00`; the shim normalizes. Unparseable timestamps are skipped (not counted as stale) to avoid terminating sessions the tool can't age-verify.

## Merge-order dependency

This PR assumes PR #14 (provisioning workflows) has established the `workflows` group. If #14 and this PR both merge before the other is rebased, there's a **file-create conflict on `tools/workflows.py`** — trivial to resolve by appending this PR's 7 tools to PR #14's 6. Happy to handle the rebase at merge time.

**Version: 0.12.0** (assumes #13 at 0.10.0 and #14 at 0.11.0 land first).

## Changes

- `src/looker_mcp_server/tools/workflows.py` — new tool group (7 tools, ~650 LOC)
- `src/looker_mcp_server/config.py` — add `workflows` to `ALL_GROUPS`
- `src/looker_mcp_server/server.py` — register via `_group_registry`
- `tests/test_workflow_tools.py` — 14 respx-mocked tests with safety-property assertions
- `tests/test_config.py` — extend pinned group list
- `README.md` — tool count + new row
- `CHANGELOG.md` — v0.12.0 entry
- `pyproject.toml` — bump to 0.12.0

Tool count: **140 → 147** across **14 → 15** groups (measured against main pre-#13/#14).

## Test plan

- [x] `uv run ruff format --check .` — 37 files clean
- [x] `uv run ruff check .` — 0 errors
- [x] `uv run pyright src tests` — 0 errors, 0 warnings
- [x] `uv run pytest` — 136/136 pass (14 new)
- [ ] Manual smoke against a dev Looker instance: offboard a test user round-trip, run each audit workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Released version 0.12.0 with 7 new workflow tools: `offboard_user`, `rotate_api_credentials`, `audit_query_activity`, `audit_instance_health`, `investigate_runaway_queries`, `find_stale_content`, and `disable_stale_sessions`.
  * Workflows group expanded from 6 to 13 tools.
  * Total tool count increased from 153 to 160 across 15 groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->