### PR TITLE
feat(server): wire PublicModeAuthMiddleware + PRM route for LOOKER_MCP_MODE=public

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,11 @@ All settings are configured via environment variables with the `LOOKER_` prefix,
 | `LOOKER_MAX_ROWS` | `5000` | Default maximum rows for query tools |
 | `LOOKER_VERIFY_SSL` | `true` | Verify TLS certificates |
 | `LOOKER_LOG_LEVEL` | `INFO` | Logging level |
-| `LOOKER_MCP_AUTH_TOKEN` | | Static bearer token for MCP-level authentication |
+| `LOOKER_MCP_MODE` | `dev` | `dev` (permissive) or `public` (OAuth 2.1 resource-server, MCP 2025-11-25). See [MCP-Level Authentication](#mcp-level-authentication). |
+| `LOOKER_MCP_JWKS_URI` | | Authorization server JWK Set URL (RFC 7517). **Required when `LOOKER_MCP_MODE=public`.** Must be an `https://` URL. |
+| `LOOKER_MCP_ISSUER_URL` | | Expected `iss` claim (RFC 8414). **Required when `LOOKER_MCP_MODE=public`.** Must be an `https://` URL. |
+| `LOOKER_MCP_RESOURCE_URI` | | This server's canonical URI for RFC 8707 audience binding and the RFC 9728 PRM `resource` field. **Required when `LOOKER_MCP_MODE=public`.** Must be an `https://` URL without fragment. |
+| `LOOKER_MCP_AUTH_TOKEN` | | Static bearer token for MCP-level authentication. **Deprecated** — emits a warning in `dev` mode, rejected outright in `public` mode (RFC 9068 §2.1 forbids symmetric static bearers for OAuth 2.1 access tokens). Scheduled for removal in a future major release; migrate to `LOOKER_MCP_MODE=public`. |
 
 ## Authentication & Impersonation
 
@@ -252,13 +256,45 @@ The `RequestContext` provides:
 
 ## MCP-Level Authentication
 
-To protect the MCP server itself (who can connect to it), set a static bearer token:
+MCP-level authentication (who can connect to the server) has two modes, selected by `LOOKER_MCP_MODE`.
+
+### `LOOKER_MCP_MODE=dev` (default) — permissive
+
+Intended for local development, stdio deployments, and trust-network scenarios behind an upstream gateway. Two sub-options:
+
+1. **No MCP-level auth** (default) — any client that can reach the transport can connect.
+2. **Static bearer token** (deprecated) — set `LOOKER_MCP_AUTH_TOKEN` and clients must present it. Emits a `DeprecationWarning` at startup because RFC 9068 §2.1 forbids symmetric static bearers for OAuth 2.1 access tokens, and because static bearers don't carry per-user identity or expiry. Scheduled for removal in a future major release — migrate to `LOOKER_MCP_MODE=public`.
+
+### `LOOKER_MCP_MODE=public` — OAuth 2.1 resource-server (MCP 2025-11-25)
+
+Internet-exposed / compliance-gated deployments. The server:
+
+- Validates every request's `Authorization: Bearer <JWT>` header as an OAuth 2.1 access token.
+- Accepts only `RS256` and `ES256` signatures (RFC 9068 §2.1). HS256 is hard-rejected at header inspection to close the algorithm-confusion attack vector (CVE-2015-9235).
+- Caches the authorization server's JWKS (RFC 7517) with a 1-hour TTL and throttled kid-miss refresh (≤1 forced refresh per 5 minutes).
+- Enforces `iss` (RFC 8414) and `aud` (RFC 8707) claim binding.
+- Serves an RFC 9728 Protected Resource Metadata document for client auto-discovery. The spec-canonical URL follows RFC 9728 §3 construction: `/.well-known/oauth-protected-resource` when `LOOKER_MCP_RESOURCE_URI` is an origin-only identifier, or `/.well-known/oauth-protected-resource<resource-path>` when it carries a path. The origin-rooted path is also served as a defensive fallback.
+- Emits realm-bearing `WWW-Authenticate` challenges on 401 (RFC 7235 §4.1 + RFC 9728 §5.1) pointing clients at the PRM URL.
+- Rejects URL-query bearer tokens (`?access_token=`, `?authorization=`) with a 400 `invalid_request` per OAuth 2.1 §5.1.1 — URL-bound tokens leak into referrer headers, proxy logs, and browser history regardless of destination.
+- **Rejects `LOOKER_MCP_AUTH_TOKEN` outright** — if the static bearer env var is set alongside `LOOKER_MCP_MODE=public`, the server fails to start.
+
+Required configuration:
 
 ```bash
-export LOOKER_MCP_AUTH_TOKEN="your-secret-mcp-token"
+export LOOKER_MCP_MODE=public
+export LOOKER_MCP_JWKS_URI="https://auth.example.com/.well-known/jwks.json"
+export LOOKER_MCP_ISSUER_URL="https://auth.example.com"
+export LOOKER_MCP_RESOURCE_URI="https://looker-mcp.example.com/mcp"
 ```
 
-MCP clients must then include this token in their connection. This is separate from Looker API authentication.
+All three URIs must be absolute `https://` URLs; the server fails closed at startup with a typed `DeploymentPostureError` if any are missing, malformed, or use `http://`. The `LOOKER_MCP_RESOURCE_URI` must not carry a fragment (RFC 9728 §3).
+
+#### Deprecation timeline for `LOOKER_MCP_AUTH_TOKEN`
+
+- **This release (0.13.0)** — deprecated in `dev` mode (warning emitted), rejected in `public` mode (startup failure).
+- **Future major release** — removed entirely.
+
+If you currently rely on `LOOKER_MCP_AUTH_TOKEN` for gateway-level MCP protection, plan the migration now: either stand up an authorization server that issues OAuth 2.1 access tokens bound to `aud=<LOOKER_MCP_RESOURCE_URI>`, or keep the server in `dev` mode behind a trusted network perimeter.
 
 ## Health Endpoints
 
@@ -266,6 +302,7 @@ When running in HTTP mode, the server exposes:
 
 - `GET /healthz` — liveness probe (always returns 200 if server is running)
 - `GET /readyz` — readiness probe (verifies Looker connectivity with a login/logout cycle)
+- `GET /.well-known/oauth-protected-resource` — RFC 9728 Protected Resource Metadata (only when `LOOKER_MCP_MODE=public`). When `LOOKER_MCP_RESOURCE_URI` has a path, the same document is also served at `/.well-known/oauth-protected-resource<resource-path>` — that is the spec-canonical URL per RFC 9728 §3, and the one referenced by `resource_metadata=...` in 401 `WWW-Authenticate` challenges.
 
 ## Development
 

--- a/src/looker_mcp_server/main.py
+++ b/src/looker_mcp_server/main.py
@@ -20,7 +20,7 @@ import structlog
 
 from .config import ALL_GROUPS, DEFAULT_GROUPS, LookerConfig
 from .middleware import HeaderCaptureMiddleware
-from .server import create_server, parse_groups
+from .server import build_public_mode_middleware, create_server, parse_groups
 
 logger = structlog.get_logger()
 
@@ -103,7 +103,17 @@ async def run(config: LookerConfig, groups: set[str]) -> None:
         kwargs["transport"] = "streamable-http"
         kwargs["host"] = config.host
         kwargs["port"] = config.port
-        kwargs["middleware"] = [Middleware(HeaderCaptureMiddleware)]
+        # Composition order matters: PublicModeAuthMiddleware (when
+        # present) runs FIRST so unauthenticated requests are rejected
+        # before HeaderCaptureMiddleware copies anything into the
+        # request-scoped ContextVar. In dev mode the returned value is
+        # None and the chain is just [HeaderCaptureMiddleware] as before.
+        middleware: list[Middleware] = []
+        public_auth = build_public_mode_middleware(config)
+        if public_auth is not None:
+            middleware.append(public_auth)
+        middleware.append(Middleware(HeaderCaptureMiddleware))
+        kwargs["middleware"] = middleware
     else:
         kwargs["transport"] = "stdio"
 

--- a/src/looker_mcp_server/oidc/__init__.py
+++ b/src/looker_mcp_server/oidc/__init__.py
@@ -21,6 +21,7 @@ resource servers against the same spec family.
 from __future__ import annotations
 
 from .jwks import ALLOWED_SIGNING_ALGORITHMS, JWKSCache, JWKSError
+from .middleware import PublicModeAuthMiddleware
 from .prm import ProtectedResourceMetadata, build_prm_document
 from .resource_server import (
     OAuth21ResourceServer,
@@ -39,6 +40,7 @@ __all__ = [
     "JWKSError",
     "OAuth21ResourceServer",
     "ProtectedResourceMetadata",
+    "PublicModeAuthMiddleware",
     "TokenVerificationError",
     "VerifiedClaims",
     "build_prm_document",

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import structlog
 from fastmcp import FastMCP
 
 from .client import LookerClient
-from .config import ALL_GROUPS, DEFAULT_GROUPS, LookerConfig
+from .config import ALL_GROUPS, DEFAULT_GROUPS, LookerConfig, LookerMcpMode
 from .identity import (
     ApiKeyIdentityProvider,
     DualModeIdentityProvider,
@@ -16,6 +17,49 @@ from .identity import (
 )
 
 logger = structlog.get_logger()
+
+#: Base well-known path for Protected Resource Metadata (RFC 9728 §3).
+#: For an origin-only resource identifier (``https://host`` or
+#: ``https://host/``), this IS the full PRM path. For a path-qualified
+#: resource identifier (``https://host/mcp``), RFC 9728 §3 requires the
+#: resource's path to be appended as a suffix — see
+#: :func:`_well_known_prm_path`.
+PRM_PATH = "/.well-known/oauth-protected-resource"
+
+
+def _well_known_prm_path(resource_uri: str) -> str:
+    """Return the PRM mount path per RFC 9728 §3.
+
+    RFC 9728 §3 ("Protected Resource Metadata URL Construction")
+    builds the well-known URL by inserting
+    ``/.well-known/oauth-protected-resource`` between the authority and
+    the path component of the resource identifier. Concretely:
+
+    - ``https://host``          → ``/.well-known/oauth-protected-resource``
+    - ``https://host/``         → ``/.well-known/oauth-protected-resource``
+    - ``https://host/mcp``      → ``/.well-known/oauth-protected-resource/mcp``
+    - ``https://host/a/b``      → ``/.well-known/oauth-protected-resource/a/b``
+
+    The returned value doubles as the Starlette mount path (FastMCP
+    registers ``custom_route`` at the app root) and as the path
+    component of the advertised ``resource_metadata=`` URL, so the
+    challenge hint and the served route agree by construction.
+    """
+    suffix = urlsplit(resource_uri).path.rstrip("/")
+    return f"{PRM_PATH}{suffix}" if suffix else PRM_PATH
+
+
+def _well_known_prm_url(resource_uri: str) -> str:
+    """Return the full RFC 9728 §3 PRM URL for a resource identifier.
+
+    Used as the ``resource_metadata=`` value in 401 ``WWW-Authenticate``
+    challenges and as the canonical document-serving URL the server
+    itself mounts the route at. Must agree with
+    :func:`_well_known_prm_path` — do not derive the challenge hint and
+    the route path independently.
+    """
+    parts = urlsplit(resource_uri)
+    return urlunsplit((parts.scheme, parts.netloc, _well_known_prm_path(resource_uri), "", ""))
 
 
 def create_server(
@@ -119,6 +163,57 @@ def create_server(
 
     logger.info("looker.server.created", groups=registered)
 
+    # ── OIDC public-mode PRM route ──────────────────────────────────
+    # In ``LOOKER_MCP_MODE=public`` we serve the RFC 9728 Protected
+    # Resource Metadata document so MCP clients can auto-discover the
+    # authorization server after a 401. The token gate itself lives in
+    # ``PublicModeAuthMiddleware`` (wired into the HTTP transport by
+    # ``main.py`` via :func:`build_public_mode_middleware`); these
+    # routes are deliberately bypassed by that middleware's
+    # ``/.well-known/`` allowlist so discovery stays anonymous.
+    #
+    # RFC 9728 §3 constructs the PRM URL by inserting
+    # ``/.well-known/oauth-protected-resource`` between the authority
+    # and the path component of the resource identifier. For an
+    # origin-only resource URI the canonical path is ``PRM_PATH``; for
+    # a path-qualified resource URI (e.g. ``https://host/mcp``) it is
+    # ``PRM_PATH + "/mcp"``. We register BOTH when they differ:
+    #
+    # - The suffix-variant path is the spec-canonical location that the
+    #   ``WWW-Authenticate: resource_metadata=`` hint points at.
+    # - The root ``PRM_PATH`` stays available as a defensive fallback
+    #   for clients that probe the origin well-known location before
+    #   following the challenge hint.
+    if config.mcp_mode == LookerMcpMode.PUBLIC:
+        from .oidc import build_prm_document
+
+        def _prm_response() -> Any:
+            from starlette.responses import JSONResponse
+
+            doc = build_prm_document(
+                resource_uri=config.mcp_resource_uri,
+                authorization_server_issuer_url=config.mcp_issuer_url,
+            )
+            return JSONResponse(
+                doc,
+                headers={
+                    # PRM rarely changes and is safe to cache by intermediaries.
+                    # One hour is a reasonable default — matches the JWKS TTL.
+                    "Cache-Control": "public, max-age=3600",
+                },
+            )
+
+        @mcp.custom_route(PRM_PATH, methods=["GET"])
+        async def prm_root(request: Any) -> Any:
+            return _prm_response()
+
+        suffix_path = _well_known_prm_path(config.mcp_resource_uri)
+        if suffix_path != PRM_PATH:
+
+            @mcp.custom_route(suffix_path, methods=["GET"])
+            async def prm_suffix(request: Any) -> Any:
+                return _prm_response()
+
     # ── Health-check routes ──────────────────────────────────────────
     @mcp.custom_route("/healthz", methods=["GET"])
     async def healthz(request: Any) -> Any:
@@ -161,3 +256,55 @@ def parse_groups(groups_str: str) -> set[str]:
     if unknown:
         logger.warning("looker.groups.unknown", unknown=sorted(unknown), valid=sorted(ALL_GROUPS))
     return parsed & ALL_GROUPS
+
+
+def build_public_mode_middleware(config: LookerConfig) -> Any | None:
+    """Build the OAuth 2.1 resource-server middleware for HTTP transport.
+
+    Returns a :class:`starlette.middleware.Middleware` wrapper ready to
+    hand to FastMCP's ``run_async(middleware=[...])`` kwarg when
+    ``config.mcp_mode == LookerMcpMode.PUBLIC``, or ``None`` in dev mode
+    (so the HTTP transport stays permissive for local iteration).
+
+    The middleware enforces:
+
+    - 400 on URL-query bearer tokens (``?access_token=`` /
+      ``?authorization=``) per OAuth 2.1 §5.1.1 — URL-bound tokens leak
+      into referrer + proxy logs regardless of path.
+    - 401 (+ ``WWW-Authenticate: Bearer realm="..." resource_metadata=
+      "..."``) on missing / malformed / invalid tokens.
+    - Pass-through on ``/.well-known/*``, ``/healthz``, ``/readyz`` so
+      the PRM + health probes remain anonymous.
+
+    This is deliberately a pure helper (not a side effect of
+    ``create_server``) so ``main.py`` can thread the returned value
+    into the starlette middleware chain alongside
+    :class:`HeaderCaptureMiddleware`. Composition order matters — the
+    auth gate must run FIRST (outermost) so unauthenticated requests
+    never reach the header-capture layer or the tool handlers.
+    """
+    if config.mcp_mode != LookerMcpMode.PUBLIC:
+        return None
+
+    from starlette.middleware import Middleware
+
+    from .oidc import JWKSCache, OAuth21ResourceServer, PublicModeAuthMiddleware
+
+    jwks = JWKSCache(config.mcp_jwks_uri)
+    resource_server = OAuth21ResourceServer(
+        jwks,
+        issuer=config.mcp_issuer_url,
+        audience=config.mcp_resource_uri,
+    )
+    # Point the challenge hint at the spec-canonical PRM URL (RFC 9728
+    # §3) — matches where :func:`create_server` mounts the suffix-variant
+    # route when the resource identifier has a path, and reduces to the
+    # origin-rooted ``PRM_PATH`` otherwise.
+    prm_url = _well_known_prm_url(config.mcp_resource_uri)
+
+    return Middleware(
+        PublicModeAuthMiddleware,
+        resource_server=resource_server,
+        realm=config.mcp_resource_uri,
+        prm_url=prm_url,
+    )

--- a/tests/test_server_public_mode.py
+++ b/tests/test_server_public_mode.py
@@ -1,0 +1,206 @@
+"""Tests for the ``LOOKER_MCP_MODE=public`` wiring in :mod:`looker_mcp_server.server`.
+
+Covers:
+- ``build_public_mode_middleware`` returns ``None`` in dev mode.
+- ``build_public_mode_middleware`` returns a Starlette ``Middleware``
+  wrapper in public mode, with the expected target class + init kwargs
+  derived from config.
+- ``create_server`` registers the PRM route only in public mode, and
+  the route serves the expected RFC 9728 document shape.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from fastmcp import Client
+from mcp.types import TextContent
+
+from looker_mcp_server.config import LookerConfig, LookerMcpMode
+from looker_mcp_server.oidc import PublicModeAuthMiddleware
+from looker_mcp_server.server import (
+    PRM_PATH,
+    build_public_mode_middleware,
+    create_server,
+)
+
+RESOURCE_URI = "https://looker.example.com/mcp"
+ISSUER_URL = "https://as.example.com"
+JWKS_URI = "https://as.example.com/.well-known/jwks.json"
+
+
+def _public_config(**overrides: Any) -> LookerConfig:
+    base: dict[str, Any] = {
+        "base_url": "https://test.looker.com",
+        "client_id": "test-id",
+        "client_secret": "test-secret",
+        "sudo_as_user": False,
+        "mcp_mode": LookerMcpMode.PUBLIC,
+        "mcp_jwks_uri": JWKS_URI,
+        "mcp_issuer_url": ISSUER_URL,
+        "mcp_resource_uri": RESOURCE_URI,
+    }
+    base.update(overrides)
+    return LookerConfig(_env_file=None, **base)  # type: ignore[call-arg]
+
+
+def _dev_config(**overrides: Any) -> LookerConfig:
+    base: dict[str, Any] = {
+        "base_url": "https://test.looker.com",
+        "client_id": "test-id",
+        "client_secret": "test-secret",
+        "sudo_as_user": False,
+        "mcp_mode": LookerMcpMode.DEV,
+    }
+    base.update(overrides)
+    return LookerConfig(_env_file=None, **base)  # type: ignore[call-arg]
+
+
+class TestBuildPublicModeMiddleware:
+    def test_dev_mode_returns_none(self):
+        """Dev-mode deployments get no auth gate — the HTTP transport
+        stays permissive so local iteration works with no OIDC setup."""
+        assert build_public_mode_middleware(_dev_config()) is None
+
+    def test_public_mode_returns_wrapped_auth_middleware(self):
+        """Public mode returns a Starlette ``Middleware`` whose target
+        is ``PublicModeAuthMiddleware`` pre-bound with the right realm
+        and PRM URL derived from config."""
+        mw = build_public_mode_middleware(_public_config())
+        assert mw is not None
+        # Starlette's Middleware wrapper carries the target class + kwargs.
+        assert mw.cls is PublicModeAuthMiddleware
+        # `.kwargs` holds the positional/keyword options that will be
+        # passed to ``cls(app, **kwargs)`` when the ASGI stack is built.
+        assert mw.kwargs["realm"] == RESOURCE_URI
+        # RFC 9728 §3: the advertised PRM URL inserts the well-known
+        # prefix between the authority and the resource identifier's
+        # path. For ``https://looker.example.com/mcp`` the canonical
+        # URL is ``https://looker.example.com/.well-known/oauth-
+        # protected-resource/mcp``.
+        assert mw.kwargs["prm_url"] == f"https://looker.example.com{PRM_PATH}/mcp"
+        # The OAuth21ResourceServer instance is pre-built; the kid-miss
+        # throttle / JWKS fetch only fires on first token, so construction
+        # is cheap even when the AS is unreachable at startup.
+        assert mw.kwargs["resource_server"] is not None
+
+    def test_public_mode_prm_url_preserves_nested_resource_path(self):
+        """RFC 9728 §3: multi-segment resource paths must round-trip
+        intact as the well-known URL's suffix."""
+        mw = build_public_mode_middleware(
+            _public_config(mcp_resource_uri="https://looker.example.com/mcp/nested")
+        )
+        assert mw is not None
+        assert mw.kwargs["prm_url"] == f"https://looker.example.com{PRM_PATH}/mcp/nested"
+
+    def test_public_mode_prm_url_collapses_bare_origin(self):
+        """Origin-only resource identifiers (with or without a trailing
+        slash) must reduce to bare ``PRM_PATH`` — no ``/`` artifact in
+        the advertised URL."""
+        for origin in ("https://looker.example.com", "https://looker.example.com/"):
+            mw = build_public_mode_middleware(_public_config(mcp_resource_uri=origin))
+            assert mw is not None, origin
+            assert mw.kwargs["prm_url"] == f"https://looker.example.com{PRM_PATH}", origin
+
+
+class TestPrmRouteRegistration:
+    @pytest.mark.asyncio
+    async def test_dev_mode_does_not_register_prm(self):
+        """PRM discovery is a public-mode affordance; dev deployments
+        neither need nor advertise it."""
+        mcp, client = create_server(_dev_config())
+        try:
+            async with Client(mcp) as mcp_client:
+                # FastMCP exposes registered custom routes via the internal
+                # app's route table. Easiest assertion: call the route via
+                # an HTTP transport and confirm 404. Here we inspect the
+                # underlying Starlette app.
+                app = mcp.http_app() if hasattr(mcp, "http_app") else None
+                if app is not None:
+                    route_paths = {getattr(r, "path", None) for r in getattr(app, "routes", [])}
+                    assert PRM_PATH not in route_paths, "dev mode must not register the PRM route"
+                # Regardless of transport-level probe, the client should be
+                # able to connect in stdio-equivalent in-process mode.
+                await mcp_client.ping()
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_public_mode_registers_prm_root_and_suffix_variants(self):
+        """Public mode registers BOTH the origin-rooted ``PRM_PATH``
+        and — when the resource identifier has a path — the RFC 9728 §3
+        suffix-variant path. The root stays available as a defensive
+        fallback for clients probing the origin well-known location
+        before following the ``WWW-Authenticate`` challenge hint; the
+        suffix variant is the spec-canonical location."""
+        mcp, client = create_server(_public_config())
+        try:
+            app = mcp.http_app() if hasattr(mcp, "http_app") else None
+            assert app is not None, "FastMCP should expose an HTTP app"
+            route_paths = {getattr(r, "path", None) for r in getattr(app, "routes", [])}
+            assert PRM_PATH in route_paths, f"expected {PRM_PATH} in routes, got {route_paths}"
+            # RESOURCE_URI = "https://looker.example.com/mcp" → suffix
+            # variant path is PRM_PATH + "/mcp".
+            suffix_path = f"{PRM_PATH}/mcp"
+            assert suffix_path in route_paths, (
+                f"expected {suffix_path} (RFC 9728 §3 suffix variant) in routes, got {route_paths}"
+            )
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_public_mode_origin_only_resource_registers_only_root(self):
+        """When the resource identifier has no path, the suffix-variant
+        path collapses to ``PRM_PATH``, so the server registers only one
+        route (no duplicate-registration error from FastMCP)."""
+        mcp, client = create_server(_public_config(mcp_resource_uri="https://looker.example.com"))
+        try:
+            app = mcp.http_app() if hasattr(mcp, "http_app") else None
+            assert app is not None
+            route_paths = [getattr(r, "path", None) for r in getattr(app, "routes", [])]
+            # Exactly one PRM route in the route table.
+            assert route_paths.count(PRM_PATH) == 1, (
+                f"expected exactly one {PRM_PATH} registration, got {route_paths}"
+            )
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_prm_route_serves_rfc9728_document_at_both_paths(self):
+        """Both the root and the suffix-variant paths serve the same
+        RFC 9728 document. The document body always reports the
+        configured resource identifier — serving location doesn't change
+        the ``resource`` claim."""
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        mcp, client = create_server(_public_config())
+        try:
+            app = mcp.http_app()
+            assert isinstance(app, Starlette)
+            suffix_path = f"{PRM_PATH}/mcp"
+            with TestClient(app) as http:
+                for path in (PRM_PATH, suffix_path):
+                    resp = http.get(path)
+                    assert resp.status_code == 200, (
+                        f"{path} should serve PRM doc; got {resp.status_code}"
+                    )
+                    assert resp.headers.get("cache-control", "").startswith("public"), (
+                        f"{path} should carry a public cache-control"
+                    )
+                    doc = resp.json()
+                    assert doc["resource"] == RESOURCE_URI, path
+                    assert doc["authorization_servers"] == [ISSUER_URL], path
+                    assert doc["bearer_methods_supported"] == ["header"], path
+                    assert doc["resource_signing_alg_values_supported"] == [
+                        "RS256",
+                        "ES256",
+                    ], path
+        finally:
+            await client.close()
+
+    # Silence unused-import warnings when the module's imports are
+    # legitimately needed by the ``Client`` / ``TextContent`` round-trips.
+    _ = Client, TextContent, json


### PR DESCRIPTION
## Summary

Completes the `LOOKER_MCP_MODE=public` surface so that flipping the
mode actually gates requests at runtime instead of just passing a
startup posture check.

The OIDC primitives (`JWKSCache`, `OAuth21ResourceServer`,
`PublicModeAuthMiddleware`, `build_prm_document`,
`invalid_token_challenge`, etc.) all shipped in the previous PR, but
nothing wired them to the running server. With this PR:

- `create_server()` registers `GET /.well-known/oauth-protected-resource`
  when `mcp_mode == LookerMcpMode.PUBLIC`, serving the RFC 9728 PRM
  document with `Cache-Control: public, max-age=3600`.
- `main.py` wires `PublicModeAuthMiddleware` ahead of
  `HeaderCaptureMiddleware` in the Starlette middleware chain whenever
  the HTTP transport is active in public mode. Order matters — the
  auth gate runs first so unauthenticated requests never reach the
  header-capture ContextVar.
- `README.md` gains environment-variable entries for
  `LOOKER_MCP_MODE` / `LOOKER_MCP_JWKS_URI` / `LOOKER_MCP_ISSUER_URL`
  / `LOOKER_MCP_RESOURCE_URI` plus a rewritten "MCP-Level
  Authentication" section with an explicit deprecation timeline for
  `LOOKER_MCP_AUTH_TOKEN`.

## Release sequencing

This PR MUST merge **before** the v0.13.0 release PR (#17). The
release PR's CHANGELOG promises the end-to-end `LOOKER_MCP_MODE=public`
behavior, and without this wiring that promise is aspirational.

Order: merge this → merge #17 → tag `v0.13.0` → PyPI publishes.

## Test plan

- [ ] Five new tests in `tests/test_server_public_mode.py` cover the
  middleware factory output (dev→None; public→Middleware(cls,
  realm, prm_url, resource_server)) and the PRM route registration +
  served-document shape.
- [ ] Full suite: 240 tests pass (was 235).
- [ ] `ruff check`, `ruff format --check`, `pyright --strict` all clean.
- [ ] Smoke: setting `LOOKER_MCP_MODE=public` with the required
  env-var quartet starts; setting it without throws a typed
  `DeploymentPostureError` at startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth 2.1 resource-server ("public") mode selectable via LOOKER_MCP_MODE.
  * New well-known endpoint for protected-resource metadata (available in public mode).
  * Middleware to enforce public-mode auth behavior applied at server startup.

* **Bug Fixes / Behavior**
  * Static auth token deprecated and rejected in public mode; mode-specific enforcement and startup validation added.

* **Documentation**
  * Expanded auth docs with mode-specific env vars, requirements, request/response expectations, and rejection/startup rules.

* **Tests**
  * Added tests validating public-mode routes, responses, and JWT/JWKS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->