### PR TITLE
feat(connection): expose full DBConnection field surface on create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     set its `purpose` field (free-form description used to identify
     what an API key is for during audits).
 
+- **Full `DBConnection` field surface on `create_connection` and
+  `update_connection`.** The connection-management tools now expose every
+  writable field of Looker's `DBConnection` schema, so connections can be
+  configured end-to-end from an MCP client without falling back to the
+  Looker admin UI. New fields include:
+  - **Key-pair authentication** (Snowflake, BigQuery service-account
+    keys): `uses_key_pair_auth`, `certificate` (write-only, base64), and
+    `file_type` (`.json` / `.p8` / `.p12`).
+  - **OAuth / Application Default Credentials**:
+    `oauth_application_id`, `uses_application_default_credentials`,
+    `impersonated_service_account`.
+  - **Per-user / user-attribute scoping**: `user_db_credentials` and
+    `user_attribute_fields` — the explicit allowlist of connection
+    fields that draw their values from Looker user attributes at query
+    time.
+  - **SSH tunneling**: `tunnel_id`, `custom_local_port`.
+  - **Oracle TNS**: `uses_tns`, `service_name`.
+  - **PDT controls**: `tmp_db_host`, `pdt_concurrency`,
+    `pdt_api_control_enabled`, `always_retry_failed_builds`,
+    `maintenance_cron`, and `pdt_context_override` (the
+    `DBConnectionOverride` block, accepted as a pass-through dict so
+    PDT builds can run against a separate write-capable role).
+  - **SQL governance**: `max_queries`, `max_queries_per_user`,
+    `max_billing_gigabytes` (BigQuery), `cost_estimate_enabled`,
+    `query_holding_disabled`, `disable_context_comment`,
+    `query_timezone`, `db_timezone`, `after_connect_statements`,
+    `connection_pooling`, `sql_runner_precache_tables`,
+    `sql_writing_with_info_schema`.
+  - **JDBC**: `named_driver_version_requested`.
+  - **BigQuery**: `bq_storage_project_id`, `bq_roles_verified`.
+
+- **MCP-tool-schema regression tests.** The connection test suite now
+  asserts the registered tool's input schema against the canonical set
+  of writable `DBConnection` fields, catching silent drops on future
+  refactors.
+
+- **Field-clearing escape hatch on `update_connection`.** New
+  `clear_fields: list[str]` parameter explicitly nulls a previously-set
+  field on the wire (`oauth_application_id`, `service_name`,
+  `tunnel_id`, `after_connect_statements`, `user_attribute_fields`,
+  `pdt_context_override`, `impersonated_service_account`, etc.). The
+  prior `_set_if`-based body builder dropped explicit `None`, so
+  callers had no way to revert a field to its dialect default.
+  Validates entries against the canonical writable-field set and
+  refuses the `set + clear same field` contradiction.
+  `WRITABLE_DBCONNECTION_FIELDS` is exported as a single source of
+  truth shared by the runtime validator and the regression tests.
+
 ### Changed
 
 - `deploy_to_production` now accepts optional `branch` and `ref`
@@ -138,6 +186,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `password_reset_url` and `account_setup_url` tokens that Looker
   may include in `GET /credentials_email` responses but that should
   never round-trip through the tool surface.
+- `get_connection`'s description now enumerates the read-only metadata
+  it surfaces (`pdts_enabled`, `uses_oauth`, `managed`, `last_regen_at`,
+  …) so callers know they can read these fields even though they are
+  not settable.
 
 ### Removed
 
@@ -145,6 +197,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Email address is not a writable field on the User schema in Looker
   4.0 — it is set by replacing the user's `credentials_email` object
   via the credentials tool group.
+- `pdts_enabled` and `uses_oauth` are no longer accepted as
+  `create_connection` / `update_connection` parameters. Both fields are
+  marked `readOnly` on the Looker 4.0 spec — sending them was silently
+  ignored by the API. PDTs are enabled implicitly by setting
+  `tmp_db_name` and granting the appropriate database permissions;
+  OAuth is enabled by setting `oauth_application_id`.
 
 ### Internal
 

--- a/src/looker_mcp_server/tools/connection.py
+++ b/src/looker_mcp_server/tools/connection.py
@@ -4,6 +4,18 @@ Covers full CRUD for Looker database connections plus the ``test`` endpoint
 that validates connectivity and PDT permissions.  These tools require admin
 permission in Looker and are disabled by default.  Enable with
 ``--groups connection`` (or ``all``).
+
+The ``create_connection`` and ``update_connection`` signatures expose every
+writable field of Looker's ``DBConnection`` schema, so connections can be
+configured end-to-end from an MCP client without falling back to the Looker
+admin UI — including key-pair auth (Snowflake), OAuth / Application Default
+Credentials (BigQuery), SSH tunnels, Oracle TNS, per-user attribute mapping,
+PDT overrides, and BigQuery storage project routing.
+
+Read-only fields returned by Looker (``has_password``, ``snippets``,
+``pdts_enabled``, ``uses_oauth``, ``managed``, ``last_regen_at``, …) are
+surfaced verbatim by ``get_connection`` and are not accepted as inputs:
+sending them in a request body is a no-op on Looker's side.
 """
 
 from __future__ import annotations
@@ -23,9 +35,13 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "Get full configuration for a specific database connection, including "
-            "dialect, host, database, PDT settings, and usage attributes. For a "
-            "trimmed summary of all connections, use ``list_connections`` in the "
-            "explore group instead."
+            "dialect, host, database, PDT settings, usage attributes, and all "
+            "read-only metadata (``has_password``, ``snippets``, ``pdts_enabled``, "
+            "``uses_oauth``, ``managed``, ``last_regen_at``, ``last_reap_at``, "
+            "``created_at``, ``user_id``, ``p4sa_name``, ``default_bq_connection``, "
+            "etc.). Write-only fields like ``password`` and ``certificate`` are "
+            "never returned by Looker. For a trimmed summary of all connections, "
+            "use ``list_connections`` in the explore group instead."
         ),
     )
     async def get_connection(
@@ -70,47 +86,248 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
         description=(
             "Create a new database connection. After creation, call "
             "``test_connection`` to verify reachability and PDT permissions. "
-            "Call ``list_connection_dialects`` first if you need valid dialect names."
+            "Call ``list_connection_dialects`` first if you need valid dialect names. "
+            "All optional fields default to Looker's dialect-level defaults when "
+            "omitted; pass only the fields you intend to set."
         ),
     )
     async def create_connection(
+        # ── Identity ────────────────────────────────────────────────
         name: Annotated[str, "Unique connection name (used by LookML ``connection:`` param)"],
         dialect_name: Annotated[str, "Database dialect, e.g. 'snowflake', 'bigquery_standard_sql'"],
+        # ── Connection target ───────────────────────────────────────
         host: Annotated[str | None, "Database host or endpoint"] = None,
         port: Annotated[int | None, "Database port"] = None,
         database: Annotated[str | None, "Default database name"] = None,
+        schema: Annotated[str | None, "Default schema"] = None,
+        service_name: Annotated[
+            str | None,
+            "Oracle TNS service name (only meaningful when ``uses_tns`` is true)",
+        ] = None,
+        uses_tns: Annotated[
+            bool | None,
+            "Enable Oracle Transparent Network Substrate (TNS) connections",
+        ] = None,
+        named_driver_version_requested: Annotated[
+            str | None,
+            "Pin a specific JDBC driver version name (omit to use the dialect default)",
+        ] = None,
+        # ── Authentication: username / password ─────────────────────
         username: Annotated[str | None, "Database username"] = None,
         password: Annotated[str | None, "Database password (write-only)"] = None,
-        schema: Annotated[str | None, "Default schema"] = None,
-        tmp_db_name: Annotated[str | None, "Scratch schema/database for PDTs"] = None,
-        jdbc_additional_params: Annotated[
-            str | None, "Extra JDBC parameters, semicolon-separated"
+        # ── Authentication: key-pair (Snowflake, BigQuery service-account keys) ──
+        uses_key_pair_auth: Annotated[
+            bool | None,
+            "Enable key-pair authentication (Snowflake et al.)",
         ] = None,
+        certificate: Annotated[
+            str | None,
+            "Base64-encoded keyfile/certificate body (write-only)",
+        ] = None,
+        file_type: Annotated[
+            str | None,
+            "Keyfile type for ``certificate``: '.json', '.p8', or '.p12'",
+        ] = None,
+        # ── Authentication: OAuth / Application Default Credentials ─
+        oauth_application_id: Annotated[
+            str | None,
+            "External OAuth Application id used for authenticating to the database",
+        ] = None,
+        uses_application_default_credentials: Annotated[
+            bool | None,
+            "Authenticate using the host environment's Application Default Credentials (GCP)",
+        ] = None,
+        impersonated_service_account: Annotated[
+            str | None,
+            "Service account email to impersonate when querying datasets (used with ADC)",
+        ] = None,
+        # ── Per-user / user-attribute scoping ───────────────────────
+        user_db_credentials: Annotated[
+            bool | None,
+            (
+                "Enable per-user database credentials. Enabling clears any previously "
+                "set ``username`` / ``password`` on the connection. Limited-access feature."
+            ),
+        ] = None,
+        user_attribute_fields: Annotated[
+            list[str] | None,
+            (
+                "Connection fields whose values are sourced from Looker user attributes "
+                "(e.g. ['username', 'database', 'schema']). Acts as the per-user "
+                "allowlist for runtime substitution."
+            ),
+        ] = None,
+        # ── Connection pool / SSL ───────────────────────────────────
         ssl: Annotated[bool | None, "Use SSL/TLS for the connection"] = None,
         verify_ssl: Annotated[bool | None, "Verify the server's SSL certificate"] = None,
         max_connections: Annotated[int | None, "Maximum pool size"] = None,
+        max_queries: Annotated[
+            int | None,
+            "Maximum number of concurrent queries to begin on this connection",
+        ] = None,
+        max_queries_per_user: Annotated[
+            int | None,
+            "Maximum number of concurrent queries per user on this connection",
+        ] = None,
         pool_timeout: Annotated[int | None, "Pool checkout timeout in seconds"] = None,
-        pdts_enabled: Annotated[bool | None, "Enable persistent derived tables"] = None,
-        uses_oauth: Annotated[bool | None, "Connection authenticates via OAuth"] = None,
+        connection_pooling: Annotated[bool | None, "Enable database connection pooling"] = None,
+        # ── SQL governance ──────────────────────────────────────────
+        max_billing_gigabytes: Annotated[
+            str | None,
+            (
+                "Maximum query size in GB (BigQuery only). May be a literal number "
+                "or the name of a Looker user attribute."
+            ),
+        ] = None,
+        cost_estimate_enabled: Annotated[
+            bool | None,
+            "Show query cost estimate in Explore",
+        ] = None,
+        query_holding_disabled: Annotated[
+            bool | None,
+            "Disable query holding for this connection",
+        ] = None,
+        disable_context_comment: Annotated[
+            bool | None,
+            "Suppress Looker's context comment on emitted SQL",
+        ] = None,
+        query_timezone: Annotated[str | None, "Timezone applied at query time"] = None,
+        db_timezone: Annotated[str | None, "Timezone of the database"] = None,
+        after_connect_statements: Annotated[
+            str | None,
+            (
+                "SQL statements (semicolon-separated) to run after connecting. "
+                "Requires the ``custom_after_connect_statements`` Looker permission."
+            ),
+        ] = None,
+        jdbc_additional_params: Annotated[
+            str | None,
+            "Extra JDBC parameters, semicolon-separated",
+        ] = None,
+        sql_runner_precache_tables: Annotated[
+            bool | None,
+            "Pre-cache tables in the SQL Runner",
+        ] = None,
+        sql_writing_with_info_schema: Annotated[
+            bool | None,
+            "Use information_schema when authoring SQL",
+        ] = None,
+        # ── PDTs (persistent derived tables) ────────────────────────
+        tmp_db_name: Annotated[str | None, "Scratch schema/database for PDTs"] = None,
+        tmp_db_host: Annotated[
+            str | None,
+            "Scratch host for PDTs (when separate from the primary host)",
+        ] = None,
+        maintenance_cron: Annotated[
+            str | None,
+            "Cron expression scheduling PDT trigger checks and drops",
+        ] = None,
+        pdt_concurrency: Annotated[
+            int | None,
+            "Maximum number of threads used to build PDTs in parallel",
+        ] = None,
+        pdt_api_control_enabled: Annotated[
+            bool | None,
+            "Allow PDT builds to be kicked off and cancelled via API",
+        ] = None,
+        always_retry_failed_builds: Annotated[
+            bool | None,
+            "Retry errored PDTs every regenerator cycle",
+        ] = None,
+        pdt_context_override: Annotated[
+            dict[str, Any] | None,
+            (
+                "Per-PDT-context override block (DBConnectionOverride). Accepts the "
+                "keys: ``context`` (must be 'pdt'), plus any of ``host``, ``port``, "
+                "``username``, ``password``, ``certificate``, ``file_type``, "
+                "``database``, ``schema``, ``jdbc_additional_params``, "
+                "``after_connect_statements``, ``service_name`` (each may also be "
+                "given with a ``pdt_`` prefix). Lets PDT builds run against a "
+                "separate write-capable role/host without affecting query traffic."
+            ),
+        ] = None,
+        # ── SSH tunnel ──────────────────────────────────────────────
+        tunnel_id: Annotated[
+            str | None,
+            "Id of an existing Looker SSH tunnel definition to route the connection through",
+        ] = None,
+        custom_local_port: Annotated[
+            int | None,
+            "Local port mapped by the SSH tunnel (only meaningful when ``tunnel_id`` is set)",
+        ] = None,
+        # ── BigQuery ────────────────────────────────────────────────
+        bq_storage_project_id: Annotated[
+            str | None,
+            "Default BigQuery storage project id (BigQuery dialects only)",
+        ] = None,
+        bq_roles_verified: Annotated[
+            bool | None,
+            "Mark all BigQuery project roles as verified",
+        ] = None,
     ) -> str:
         ctx = client.build_context("create_connection", "connection", {"name": name})
         try:
             async with client.session(ctx) as session:
                 body: dict[str, Any] = {"name": name, "dialect_name": dialect_name}
+                # Connection target
                 _set_if(body, "host", host)
                 _set_if(body, "port", port)
                 _set_if(body, "database", database)
+                _set_if(body, "schema", schema)
+                _set_if(body, "service_name", service_name)
+                _set_if(body, "uses_tns", uses_tns)
+                _set_if(body, "named_driver_version_requested", named_driver_version_requested)
+                # Username / password
                 _set_if(body, "username", username)
                 _set_if(body, "password", password)
-                _set_if(body, "schema", schema)
-                _set_if(body, "tmp_db_name", tmp_db_name)
-                _set_if(body, "jdbc_additional_params", jdbc_additional_params)
+                # Key-pair
+                _set_if(body, "uses_key_pair_auth", uses_key_pair_auth)
+                _set_if(body, "certificate", certificate)
+                _set_if(body, "file_type", file_type)
+                # OAuth / ADC
+                _set_if(body, "oauth_application_id", oauth_application_id)
+                _set_if(
+                    body,
+                    "uses_application_default_credentials",
+                    uses_application_default_credentials,
+                )
+                _set_if(body, "impersonated_service_account", impersonated_service_account)
+                # Per-user / user-attribute scoping
+                _set_if(body, "user_db_credentials", user_db_credentials)
+                _set_if(body, "user_attribute_fields", user_attribute_fields)
+                # Pool / SSL
                 _set_if(body, "ssl", ssl)
                 _set_if(body, "verify_ssl", verify_ssl)
                 _set_if(body, "max_connections", max_connections)
+                _set_if(body, "max_queries", max_queries)
+                _set_if(body, "max_queries_per_user", max_queries_per_user)
                 _set_if(body, "pool_timeout", pool_timeout)
-                _set_if(body, "pdts_enabled", pdts_enabled)
-                _set_if(body, "uses_oauth", uses_oauth)
+                _set_if(body, "connection_pooling", connection_pooling)
+                # SQL governance
+                _set_if(body, "max_billing_gigabytes", max_billing_gigabytes)
+                _set_if(body, "cost_estimate_enabled", cost_estimate_enabled)
+                _set_if(body, "query_holding_disabled", query_holding_disabled)
+                _set_if(body, "disable_context_comment", disable_context_comment)
+                _set_if(body, "query_timezone", query_timezone)
+                _set_if(body, "db_timezone", db_timezone)
+                _set_if(body, "after_connect_statements", after_connect_statements)
+                _set_if(body, "jdbc_additional_params", jdbc_additional_params)
+                _set_if(body, "sql_runner_precache_tables", sql_runner_precache_tables)
+                _set_if(body, "sql_writing_with_info_schema", sql_writing_with_info_schema)
+                # PDTs
+                _set_if(body, "tmp_db_name", tmp_db_name)
+                _set_if(body, "tmp_db_host", tmp_db_host)
+                _set_if(body, "maintenance_cron", maintenance_cron)
+                _set_if(body, "pdt_concurrency", pdt_concurrency)
+                _set_if(body, "pdt_api_control_enabled", pdt_api_control_enabled)
+                _set_if(body, "always_retry_failed_builds", always_retry_failed_builds)
+                _set_if(body, "pdt_context_override", pdt_context_override)
+                # SSH tunnel
+                _set_if(body, "tunnel_id", tunnel_id)
+                _set_if(body, "custom_local_port", custom_local_port)
+                # BigQuery
+                _set_if(body, "bq_storage_project_id", bq_storage_project_id)
+                _set_if(body, "bq_roles_verified", bq_roles_verified)
 
                 conn = await session.post("/connections", body=body)
                 return json.dumps(
@@ -131,53 +348,217 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
-            "Update an existing database connection.  Only provided fields are "
-            "changed — omitted fields are preserved.  After updating credentials "
-            "or host, call ``test_connection`` to verify the change is healthy."
+            "Update an existing database connection. Only provided fields are "
+            "changed — omitted fields are preserved. After updating credentials, "
+            "host, or auth mode, call ``test_connection`` to verify the change. "
+            "``name`` and ``dialect_name`` are write-once at create time and are "
+            "intentionally not accepted here. ``pdts_enabled`` and ``uses_oauth`` "
+            "are read-only on the API and are derived from other fields "
+            "(``tmp_db_name`` + permissions, and ``oauth_application_id`` "
+            "respectively)."
         ),
     )
     async def update_connection(
         name: Annotated[str, "Connection name to update"],
+        # ── Connection target ───────────────────────────────────────
         host: Annotated[str | None, "New host"] = None,
         port: Annotated[int | None, "New port"] = None,
         database: Annotated[str | None, "New database name"] = None,
+        schema: Annotated[str | None, "New default schema"] = None,
+        service_name: Annotated[
+            str | None,
+            "New Oracle TNS service name (only meaningful when ``uses_tns`` is true)",
+        ] = None,
+        uses_tns: Annotated[bool | None, "Toggle Oracle TNS connection mode"] = None,
+        named_driver_version_requested: Annotated[
+            str | None,
+            "Change the requested JDBC driver version name",
+        ] = None,
+        # ── Authentication: username / password ─────────────────────
         username: Annotated[str | None, "New username"] = None,
         password: Annotated[str | None, "New password (write-only)"] = None,
-        schema: Annotated[str | None, "New default schema"] = None,
-        tmp_db_name: Annotated[str | None, "New scratch schema/database for PDTs"] = None,
-        jdbc_additional_params: Annotated[str | None, "New extra JDBC parameters"] = None,
+        # ── Authentication: key-pair ────────────────────────────────
+        uses_key_pair_auth: Annotated[
+            bool | None,
+            "Toggle key-pair authentication",
+        ] = None,
+        certificate: Annotated[
+            str | None,
+            "New base64-encoded keyfile/certificate body (write-only)",
+        ] = None,
+        file_type: Annotated[
+            str | None,
+            "Keyfile type for ``certificate``: '.json', '.p8', or '.p12'",
+        ] = None,
+        # ── Authentication: OAuth / ADC ─────────────────────────────
+        oauth_application_id: Annotated[
+            str | None,
+            "External OAuth Application id (set/clear). Drives the read-only ``uses_oauth`` flag.",
+        ] = None,
+        uses_application_default_credentials: Annotated[
+            bool | None,
+            "Toggle Application Default Credentials authentication (GCP)",
+        ] = None,
+        impersonated_service_account: Annotated[
+            str | None,
+            "Service account email to impersonate (used with ADC)",
+        ] = None,
+        # ── Per-user / user-attribute scoping ───────────────────────
+        user_db_credentials: Annotated[
+            bool | None,
+            (
+                "Toggle per-user database credentials. Enabling clears any "
+                "previously set ``username`` / ``password``."
+            ),
+        ] = None,
+        user_attribute_fields: Annotated[
+            list[str] | None,
+            "Connection fields sourced from Looker user attributes (replaces the existing list)",
+        ] = None,
+        # ── Connection pool / SSL ───────────────────────────────────
         ssl: Annotated[bool | None, "Toggle SSL/TLS"] = None,
         verify_ssl: Annotated[bool | None, "Toggle SSL certificate verification"] = None,
         max_connections: Annotated[int | None, "New maximum pool size"] = None,
+        max_queries: Annotated[int | None, "New max concurrent queries on this connection"] = None,
+        max_queries_per_user: Annotated[
+            int | None,
+            "New max concurrent queries per user",
+        ] = None,
         pool_timeout: Annotated[int | None, "New pool checkout timeout"] = None,
-        pdts_enabled: Annotated[bool | None, "Toggle persistent derived tables"] = None,
+        connection_pooling: Annotated[bool | None, "Toggle database connection pooling"] = None,
+        # ── SQL governance ──────────────────────────────────────────
+        max_billing_gigabytes: Annotated[
+            str | None,
+            "New BigQuery query-size cap (literal GB or user-attribute name)",
+        ] = None,
+        cost_estimate_enabled: Annotated[
+            bool | None,
+            "Toggle Explore cost estimates",
+        ] = None,
+        query_holding_disabled: Annotated[bool | None, "Toggle query holding"] = None,
+        disable_context_comment: Annotated[bool | None, "Toggle context comments on SQL"] = None,
+        query_timezone: Annotated[str | None, "New query timezone"] = None,
+        db_timezone: Annotated[str | None, "New database timezone"] = None,
+        after_connect_statements: Annotated[
+            str | None,
+            (
+                "SQL statements (semicolon-separated) to run after connecting. "
+                "Requires the ``custom_after_connect_statements`` Looker permission."
+            ),
+        ] = None,
+        jdbc_additional_params: Annotated[str | None, "New extra JDBC parameters"] = None,
+        sql_runner_precache_tables: Annotated[
+            bool | None,
+            "Toggle SQL Runner table precaching",
+        ] = None,
+        sql_writing_with_info_schema: Annotated[
+            bool | None,
+            "Toggle use of information_schema when authoring SQL",
+        ] = None,
+        # ── PDTs ────────────────────────────────────────────────────
+        tmp_db_name: Annotated[str | None, "New scratch schema/database for PDTs"] = None,
+        tmp_db_host: Annotated[str | None, "New scratch host for PDTs"] = None,
+        maintenance_cron: Annotated[
+            str | None,
+            "New cron expression for PDT maintenance",
+        ] = None,
+        pdt_concurrency: Annotated[int | None, "New maximum PDT-build thread count"] = None,
+        pdt_api_control_enabled: Annotated[bool | None, "Toggle API control of PDT builds"] = None,
+        always_retry_failed_builds: Annotated[
+            bool | None,
+            "Toggle automatic retry of errored PDTs",
+        ] = None,
+        pdt_context_override: Annotated[
+            dict[str, Any] | None,
+            (
+                "Replace the per-PDT-context override block (DBConnectionOverride). "
+                "See ``create_connection`` for the accepted shape."
+            ),
+        ] = None,
+        # ── SSH tunnel ──────────────────────────────────────────────
+        tunnel_id: Annotated[str | None, "New SSH tunnel id (or empty string to clear)"] = None,
+        custom_local_port: Annotated[int | None, "New SSH-tunnel local port"] = None,
+        # ── BigQuery ────────────────────────────────────────────────
+        bq_storage_project_id: Annotated[
+            str | None,
+            "New default BigQuery storage project id",
+        ] = None,
+        bq_roles_verified: Annotated[
+            bool | None,
+            "Mark all BigQuery project roles as verified",
+        ] = None,
     ) -> str:
         ctx = client.build_context("update_connection", "connection", {"name": name})
         try:
             async with client.session(ctx) as session:
                 body: dict[str, Any] = {}
+                # Connection target
                 _set_if(body, "host", host)
                 _set_if(body, "port", port)
                 _set_if(body, "database", database)
+                _set_if(body, "schema", schema)
+                _set_if(body, "service_name", service_name)
+                _set_if(body, "uses_tns", uses_tns)
+                _set_if(body, "named_driver_version_requested", named_driver_version_requested)
+                # Username / password
                 _set_if(body, "username", username)
                 _set_if(body, "password", password)
-                _set_if(body, "schema", schema)
-                _set_if(body, "tmp_db_name", tmp_db_name)
-                _set_if(body, "jdbc_additional_params", jdbc_additional_params)
+                # Key-pair
+                _set_if(body, "uses_key_pair_auth", uses_key_pair_auth)
+                _set_if(body, "certificate", certificate)
+                _set_if(body, "file_type", file_type)
+                # OAuth / ADC
+                _set_if(body, "oauth_application_id", oauth_application_id)
+                _set_if(
+                    body,
+                    "uses_application_default_credentials",
+                    uses_application_default_credentials,
+                )
+                _set_if(body, "impersonated_service_account", impersonated_service_account)
+                # Per-user / user-attribute scoping
+                _set_if(body, "user_db_credentials", user_db_credentials)
+                _set_if(body, "user_attribute_fields", user_attribute_fields)
+                # Pool / SSL
                 _set_if(body, "ssl", ssl)
                 _set_if(body, "verify_ssl", verify_ssl)
                 _set_if(body, "max_connections", max_connections)
+                _set_if(body, "max_queries", max_queries)
+                _set_if(body, "max_queries_per_user", max_queries_per_user)
                 _set_if(body, "pool_timeout", pool_timeout)
-                _set_if(body, "pdts_enabled", pdts_enabled)
+                _set_if(body, "connection_pooling", connection_pooling)
+                # SQL governance
+                _set_if(body, "max_billing_gigabytes", max_billing_gigabytes)
+                _set_if(body, "cost_estimate_enabled", cost_estimate_enabled)
+                _set_if(body, "query_holding_disabled", query_holding_disabled)
+                _set_if(body, "disable_context_comment", disable_context_comment)
+                _set_if(body, "query_timezone", query_timezone)
+                _set_if(body, "db_timezone", db_timezone)
+                _set_if(body, "after_connect_statements", after_connect_statements)
+                _set_if(body, "jdbc_additional_params", jdbc_additional_params)
+                _set_if(body, "sql_runner_precache_tables", sql_runner_precache_tables)
+                _set_if(body, "sql_writing_with_info_schema", sql_writing_with_info_schema)
+                # PDTs
+                _set_if(body, "tmp_db_name", tmp_db_name)
+                _set_if(body, "tmp_db_host", tmp_db_host)
+                _set_if(body, "maintenance_cron", maintenance_cron)
+                _set_if(body, "pdt_concurrency", pdt_concurrency)
+                _set_if(body, "pdt_api_control_enabled", pdt_api_control_enabled)
+                _set_if(body, "always_retry_failed_builds", always_retry_failed_builds)
+                _set_if(body, "pdt_context_override", pdt_context_override)
+                # SSH tunnel
+                _set_if(body, "tunnel_id", tunnel_id)
+                _set_if(body, "custom_local_port", custom_local_port)
+                # BigQuery
+                _set_if(body, "bq_storage_project_id", bq_storage_project_id)
+                _set_if(body, "bq_roles_verified", bq_roles_verified)
 
                 if not body:
                     return json.dumps(
                         {
                             "error": "No fields provided to update.",
                             "hint": (
-                                "Pass at least one of: host, port, database, username, "
-                                "password, schema, tmp_db_name, jdbc_additional_params, "
-                                "ssl, verify_ssl, max_connections, pool_timeout, pdts_enabled."
+                                "Pass at least one settable DBConnection field. "
+                                "See the tool description for the full list."
                             ),
                         },
                         indent=2,

--- a/src/looker_mcp_server/tools/connection.py
+++ b/src/looker_mcp_server/tools/connection.py
@@ -28,6 +28,70 @@ from fastmcp import FastMCP
 from ..client import LookerClient, format_api_error
 from ._helpers import _path_seg, _set_if
 
+# Single source of truth for the settable subset of Looker's DBConnection
+# schema. Used by ``update_connection`` to validate ``clear_fields`` entries
+# (so users can't ask to clear a non-existent field), and re-imported by the
+# test suite to assert the registered tool surface matches the spec.
+WRITABLE_DBCONNECTION_FIELDS: frozenset[str] = frozenset(
+    {
+        # Connection target
+        "host",
+        "port",
+        "database",
+        "schema",
+        "service_name",
+        "uses_tns",
+        "named_driver_version_requested",
+        # Auth: username/password
+        "username",
+        "password",
+        # Auth: key-pair
+        "uses_key_pair_auth",
+        "certificate",
+        "file_type",
+        # Auth: OAuth / ADC
+        "oauth_application_id",
+        "uses_application_default_credentials",
+        "impersonated_service_account",
+        # Per-user / user-attribute scoping
+        "user_db_credentials",
+        "user_attribute_fields",
+        # Pool / SSL
+        "ssl",
+        "verify_ssl",
+        "max_connections",
+        "max_queries",
+        "max_queries_per_user",
+        "pool_timeout",
+        "connection_pooling",
+        # SQL governance
+        "max_billing_gigabytes",
+        "cost_estimate_enabled",
+        "query_holding_disabled",
+        "disable_context_comment",
+        "query_timezone",
+        "db_timezone",
+        "after_connect_statements",
+        "jdbc_additional_params",
+        "sql_runner_precache_tables",
+        "sql_writing_with_info_schema",
+        # PDTs
+        "tmp_db_name",
+        "tmp_db_host",
+        "maintenance_cron",
+        "pdt_concurrency",
+        "pdt_api_control_enabled",
+        "always_retry_failed_builds",
+        "pdt_context_override",
+        # SSH tunnel
+        "tunnel_id",
+        "custom_local_port",
+        # BigQuery
+        "bq_storage_project_id",
+        "bq_roles_verified",
+    }
+)
+
 
 def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
     # ── Read ─────────────────────────────────────────────────────────
@@ -355,7 +419,15 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
             "intentionally not accepted here. ``pdts_enabled`` and ``uses_oauth`` "
             "are read-only on the API and are derived from other fields "
             "(``tmp_db_name`` + permissions, and ``oauth_application_id`` "
-            "respectively)."
+            "respectively).\n\n"
+            "Setting a parameter to its non-None value writes that value. "
+            "**Clearing** a previously-set field (so Looker reverts it to the "
+            "dialect default) requires naming it in ``clear_fields`` — that "
+            "sends an explicit JSON ``null`` for the field. Useful for fields "
+            "like ``oauth_application_id``, ``service_name``, ``tunnel_id``, "
+            "``after_connect_statements``, ``user_attribute_fields``, "
+            "``pdt_context_override``, and ``impersonated_service_account``, "
+            "which can be set, then later need to be unset."
         ),
     )
     async def update_connection(
@@ -487,6 +559,20 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
             bool | None,
             "Mark all BigQuery project roles as verified",
         ] = None,
+        # ── Explicit field clearing ─────────────────────────────────
+        clear_fields: Annotated[
+            list[str] | None,
+            (
+                "Field names to send as JSON ``null`` so Looker reverts them "
+                "to the dialect default. Set parameters above and name "
+                "additional fields here only when you need to clear "
+                "previously-set values (e.g. ``['oauth_application_id']`` to "
+                "remove an OAuth binding). Each entry must be a settable "
+                "DBConnection field; ``name`` and ``dialect_name`` cannot be "
+                "cleared. A field listed here AND set via its parameter is "
+                "rejected — that combination is contradictory."
+            ),
+        ] = None,
     ) -> str:
         ctx = client.build_context("update_connection", "connection", {"name": name})
         try:
@@ -552,12 +638,44 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
                 _set_if(body, "bq_storage_project_id", bq_storage_project_id)
                 _set_if(body, "bq_roles_verified", bq_roles_verified)
 
+                # ── Explicit clearing ─────────────────────────────────
+                if clear_fields:
+                    invalid = [f for f in clear_fields if f not in WRITABLE_DBCONNECTION_FIELDS]
+                    if invalid:
+                        return json.dumps(
+                            {
+                                "error": "Invalid field name(s) in clear_fields.",
+                                "invalid": sorted(invalid),
+                                "hint": (
+                                    "Each entry must be a settable DBConnection field. "
+                                    "name/dialect_name cannot be cleared (write-once)."
+                                ),
+                            },
+                            indent=2,
+                        )
+                    conflicts = [f for f in clear_fields if f in body]
+                    if conflicts:
+                        return json.dumps(
+                            {
+                                "error": ("Cannot both set and clear the same field(s)."),
+                                "conflicts": sorted(conflicts),
+                                "hint": (
+                                    "Pass either the field's value parameter OR the "
+                                    "field name in clear_fields, not both."
+                                ),
+                            },
+                            indent=2,
+                        )
+                    for f in clear_fields:
+                        body[f] = None
+
                 if not body:
                     return json.dumps(
                         {
                             "error": "No fields provided to update.",
                             "hint": (
-                                "Pass at least one settable DBConnection field. "
+                                "Pass at least one settable DBConnection field, or use "
+                                "``clear_fields`` to null out a previously-set value. "
                                 "See the tool description for the full list."
                             ),
                         },

--- a/src/looker_mcp_server/tools/connection.py
+++ b/src/looker_mcp_server/tools/connection.py
@@ -548,7 +548,15 @@ def register_connection_tools(server: FastMCP, client: LookerClient) -> None:
             ),
         ] = None,
         # ── SSH tunnel ──────────────────────────────────────────────
-        tunnel_id: Annotated[str | None, "New SSH tunnel id (or empty string to clear)"] = None,
+        tunnel_id: Annotated[
+            str | None,
+            (
+                "New SSH tunnel id. To remove an existing tunnel binding, list "
+                "``tunnel_id`` in ``clear_fields`` (sends JSON null) — do not "
+                "pass an empty string here. Setting ``tunnel_id`` and also "
+                "listing it in ``clear_fields`` is rejected as contradictory."
+            ),
+        ] = None,
         custom_local_port: Annotated[int | None, "New SSH-tunnel local port"] = None,
         # ── BigQuery ────────────────────────────────────────────────
         bq_storage_project_id: Annotated[

--- a/tests/test_connection_tools.py
+++ b/tests/test_connection_tools.py
@@ -5,11 +5,14 @@ import json
 import httpx
 import pytest
 import respx
+from fastmcp import Client
+from mcp.types import TextContent
 
 from looker_mcp_server.client import LookerApiError, LookerClient, format_api_error
 from looker_mcp_server.config import LookerConfig
 from looker_mcp_server.identity import ApiKeyIdentityProvider
 from looker_mcp_server.server import create_server
+from looker_mcp_server.tools.connection import WRITABLE_DBCONNECTION_FIELDS
 
 
 @pytest.fixture
@@ -51,66 +54,11 @@ class TestServerRegistration:
         assert "connection" in ALL_GROUPS
 
 
-# Every writable field on the Looker DBConnection schema must be reachable
-# from the MCP tool surface. These three sets are the contract — a regression
-# (a field silently dropped on a refactor) must fail loudly here.
-WRITABLE_DBCONNECTION_FIELDS = {
-    # Connection target
-    "host",
-    "port",
-    "database",
-    "schema",
-    "service_name",
-    "uses_tns",
-    "named_driver_version_requested",
-    # Auth: username/password
-    "username",
-    "password",
-    # Auth: key-pair
-    "uses_key_pair_auth",
-    "certificate",
-    "file_type",
-    # Auth: OAuth / ADC
-    "oauth_application_id",
-    "uses_application_default_credentials",
-    "impersonated_service_account",
-    # Per-user / user-attribute scoping
-    "user_db_credentials",
-    "user_attribute_fields",
-    # Pool / SSL
-    "ssl",
-    "verify_ssl",
-    "max_connections",
-    "max_queries",
-    "max_queries_per_user",
-    "pool_timeout",
-    "connection_pooling",
-    # SQL governance
-    "max_billing_gigabytes",
-    "cost_estimate_enabled",
-    "query_holding_disabled",
-    "disable_context_comment",
-    "query_timezone",
-    "db_timezone",
-    "after_connect_statements",
-    "jdbc_additional_params",
-    "sql_runner_precache_tables",
-    "sql_writing_with_info_schema",
-    # PDTs
-    "tmp_db_name",
-    "tmp_db_host",
-    "maintenance_cron",
-    "pdt_concurrency",
-    "pdt_api_control_enabled",
-    "always_retry_failed_builds",
-    "pdt_context_override",
-    # SSH tunnel
-    "tunnel_id",
-    "custom_local_port",
-    # BigQuery
-    "bq_storage_project_id",
-    "bq_roles_verified",
-}
+# WRITABLE_DBCONNECTION_FIELDS is imported from
+# ``looker_mcp_server.tools.connection`` — a single source of truth so the
+# runtime ``clear_fields`` validator and the schema-contract tests can never
+# drift. A regression (a field silently dropped on a refactor) must fail
+# loudly in the tests below.
 
 # Fields the Looker spec marks readOnly. Sending them is a no-op on Looker's
 # side, so we must NOT advertise them as writable inputs (avoids false-success
@@ -143,41 +91,46 @@ class TestCreateConnectionToolSchema:
     """
 
     @pytest.mark.asyncio
-    async def test_create_connection_exposes_all_writable_fields(self, server_and_client):
+    async def test_create_connection_exposes_exact_writable_fields(self, server_and_client):
+        # Exact-equality assertion: a refactor that *adds* an unexpected param
+        # (typo, leaked internal, mistake) must fail just as loudly as a
+        # refactor that drops a documented one.
         mcp, _ = server_and_client
         tools = {t.name: t for t in await mcp.list_tools()}
         assert "create_connection" in tools
 
         props = tools["create_connection"].parameters["properties"]
-        # Required identity fields
-        assert {"name", "dialect_name"} <= props.keys()
-        # Every writable DBConnection field must be present
-        missing = WRITABLE_DBCONNECTION_FIELDS - props.keys()
-        assert not missing, f"create_connection missing writable fields: {sorted(missing)}"
-        # Read-only fields must never leak into the writable surface
+        expected = WRITABLE_DBCONNECTION_FIELDS | {"name", "dialect_name"}
+        assert props.keys() == expected, (
+            f"create_connection surface drift — "
+            f"missing: {sorted(expected - props.keys())}, "
+            f"unexpected: {sorted(props.keys() - expected)}"
+        )
+        # Read-only fields must never leak (subsumed by the exact-equality
+        # check above, but kept as a more readable failure message).
         leaked = READONLY_DBCONNECTION_FIELDS & props.keys()
         assert not leaked, f"create_connection exposes read-only fields: {sorted(leaked)}"
 
     @pytest.mark.asyncio
-    async def test_update_connection_exposes_all_writable_fields_except_create_only(
-        self, server_and_client
-    ):
+    async def test_update_connection_exposes_exact_writable_fields(self, server_and_client):
         mcp, _ = server_and_client
         tools = {t.name: t for t in await mcp.list_tools()}
         assert "update_connection" in tools
 
         props = tools["update_connection"].parameters["properties"]
-        # name is required to address the connection in the URL path; dialect_name
-        # is write-once at create time and must not be re-settable here.
-        assert "name" in props
+        # update has: name (URL key) + every writable field + clear_fields
+        # (the field-clearing escape hatch for nulling previously-set values).
+        # No dialect_name — it's write-once at create.
+        expected = WRITABLE_DBCONNECTION_FIELDS | {"name", "clear_fields"}
+        assert props.keys() == expected, (
+            f"update_connection surface drift — "
+            f"missing: {sorted(expected - props.keys())}, "
+            f"unexpected: {sorted(props.keys() - expected)}"
+        )
         assert "dialect_name" not in props, (
             "dialect_name is write-once at create — exposing it on update implies "
             "it can be changed, which Looker does not support."
         )
-        # Every writable field must be present
-        missing = WRITABLE_DBCONNECTION_FIELDS - props.keys()
-        assert not missing, f"update_connection missing writable fields: {sorted(missing)}"
-        # Read-only fields must never leak
         leaked = READONLY_DBCONNECTION_FIELDS & props.keys()
         assert not leaked, f"update_connection exposes read-only fields: {sorted(leaked)}"
 
@@ -449,3 +402,143 @@ class TestErrorFormatting:
         result = json.loads(format_api_error("create_connection", error))
         assert result["status"] == 400
         assert "invalid" in result["error"].lower()
+
+
+# ── Field-clearing semantics on update_connection ───────────────────────
+
+
+def _invoke_tool(mcp, tool_name: str, args: dict):
+    """Call a tool through the MCP server and return the parsed payload."""
+
+    async def _run():
+        async with Client(mcp) as mcp_client:
+            result = await mcp_client.call_tool(tool_name, args)
+            content = result.content[0]
+            assert isinstance(content, TextContent)
+            return json.loads(content.text)
+
+    return _run
+
+
+class TestUpdateConnectionClearFields:
+    """The `_set_if` helper drops `None`, which means a plain
+    update_connection(host=None) call is "no-op" rather than "clear host."
+    `clear_fields` is the explicit escape hatch that puts a JSON `null` on
+    the wire so Looker reverts the field to its dialect default. Without
+    this, agents have no way to undo a previously-set oauth_application_id
+    / service_name / tunnel_id / etc.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_clear_fields_serialize_as_json_null(self, server_and_client):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            # Use the raw bytes so we can verify `null` survives serialization
+            # (json.loads decodes it back to Python None, which is the wire shape).
+            captured["body_bytes"] = request.content.decode()
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"name": "warehouse"})
+
+        respx.patch(f"{API_URL}/connections/warehouse").mock(side_effect=capture)
+
+        mcp, _ = server_and_client
+        payload = await _invoke_tool(
+            mcp,
+            "update_connection",
+            {
+                "name": "warehouse",
+                "host": "newhost.example.com",
+                "clear_fields": ["oauth_application_id", "service_name"],
+            },
+        )()
+        assert payload["updated"] is True
+        # The set field carries its value.
+        assert captured["body"]["host"] == "newhost.example.com"
+        # Cleared fields are present in the body as JSON null (not absent).
+        assert captured["body"]["oauth_application_id"] is None
+        assert captured["body"]["service_name"] is None
+        # Confirm null is on the wire — guards against silent stripping by
+        # any future serialization layer. (httpx serializes JSON compactly,
+        # so no space between key and value.)
+        assert '"oauth_application_id":null' in captured["body_bytes"]
+        # fields_changed in the response covers both set and cleared keys.
+        assert "oauth_application_id" in payload["fields_changed"]
+        assert "service_name" in payload["fields_changed"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_clear_fields_rejects_unknown_field(self, server_and_client):
+        # Catches typos before they reach Looker (which would 400 with a less
+        # actionable message). The error includes the offending names so the
+        # caller can see what to fix.
+        _mock_login_logout()
+        # No PATCH mock — validation must short-circuit before any PATCH.
+
+        mcp, _ = server_and_client
+        payload = await _invoke_tool(
+            mcp,
+            "update_connection",
+            {"name": "warehouse", "clear_fields": ["not_a_field", "host"]},
+        )()
+        assert "Invalid field name" in payload["error"]
+        assert "not_a_field" in payload["invalid"]
+        # 'host' is a valid writable field so it should NOT be flagged.
+        assert "host" not in payload["invalid"]
+        patch_calls = [c for c in respx.calls if c.request.method == "PATCH"]
+        assert patch_calls == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_clear_fields_rejects_set_and_clear_conflict(self, server_and_client):
+        # Setting host="x" AND asking to clear "host" is contradictory — the
+        # tool returns an actionable error rather than picking one and
+        # silently doing the wrong thing.
+        _mock_login_logout()
+
+        mcp, _ = server_and_client
+        payload = await _invoke_tool(
+            mcp,
+            "update_connection",
+            {"name": "warehouse", "host": "x.example.com", "clear_fields": ["host"]},
+        )()
+        assert "Cannot both set and clear" in payload["error"]
+        assert "host" in payload["conflicts"]
+        patch_calls = [c for c in respx.calls if c.request.method == "PATCH"]
+        assert patch_calls == []
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_clear_fields_alone_is_a_valid_update(self, server_and_client):
+        # An update that ONLY clears (no value parameters set) is still a
+        # legitimate operation — must NOT trip the "no fields" guard.
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"name": "warehouse"})
+
+        respx.patch(f"{API_URL}/connections/warehouse").mock(side_effect=capture)
+
+        mcp, _ = server_and_client
+        payload = await _invoke_tool(
+            mcp,
+            "update_connection",
+            {"name": "warehouse", "clear_fields": ["tunnel_id"]},
+        )()
+        assert payload["updated"] is True
+        assert captured["body"] == {"tunnel_id": None}
+
+    def test_writable_fields_constant_matches_test_expectation(self):
+        # If the source-of-truth set drifts, the test contract drifts with it.
+        # This guard makes the drift explicit.
+        assert "oauth_application_id" in WRITABLE_DBCONNECTION_FIELDS
+        assert "name" not in WRITABLE_DBCONNECTION_FIELDS  # write-once, URL key
+        assert "dialect_name" not in WRITABLE_DBCONNECTION_FIELDS  # write-once
+        assert "pdts_enabled" not in WRITABLE_DBCONNECTION_FIELDS  # readOnly
+        assert "uses_oauth" not in WRITABLE_DBCONNECTION_FIELDS  # readOnly

--- a/tests/test_connection_tools.py
+++ b/tests/test_connection_tools.py
@@ -51,6 +51,137 @@ class TestServerRegistration:
         assert "connection" in ALL_GROUPS
 
 
+# Every writable field on the Looker DBConnection schema must be reachable
+# from the MCP tool surface. These three sets are the contract — a regression
+# (a field silently dropped on a refactor) must fail loudly here.
+WRITABLE_DBCONNECTION_FIELDS = {
+    # Connection target
+    "host",
+    "port",
+    "database",
+    "schema",
+    "service_name",
+    "uses_tns",
+    "named_driver_version_requested",
+    # Auth: username/password
+    "username",
+    "password",
+    # Auth: key-pair
+    "uses_key_pair_auth",
+    "certificate",
+    "file_type",
+    # Auth: OAuth / ADC
+    "oauth_application_id",
+    "uses_application_default_credentials",
+    "impersonated_service_account",
+    # Per-user / user-attribute scoping
+    "user_db_credentials",
+    "user_attribute_fields",
+    # Pool / SSL
+    "ssl",
+    "verify_ssl",
+    "max_connections",
+    "max_queries",
+    "max_queries_per_user",
+    "pool_timeout",
+    "connection_pooling",
+    # SQL governance
+    "max_billing_gigabytes",
+    "cost_estimate_enabled",
+    "query_holding_disabled",
+    "disable_context_comment",
+    "query_timezone",
+    "db_timezone",
+    "after_connect_statements",
+    "jdbc_additional_params",
+    "sql_runner_precache_tables",
+    "sql_writing_with_info_schema",
+    # PDTs
+    "tmp_db_name",
+    "tmp_db_host",
+    "maintenance_cron",
+    "pdt_concurrency",
+    "pdt_api_control_enabled",
+    "always_retry_failed_builds",
+    "pdt_context_override",
+    # SSH tunnel
+    "tunnel_id",
+    "custom_local_port",
+    # BigQuery
+    "bq_storage_project_id",
+    "bq_roles_verified",
+}
+
+# Fields the Looker spec marks readOnly. Sending them is a no-op on Looker's
+# side, so we must NOT advertise them as writable inputs (avoids false-success
+# user expectations like "I set pdts_enabled=true but nothing happened").
+READONLY_DBCONNECTION_FIELDS = {
+    "pdts_enabled",
+    "uses_oauth",
+    "has_password",
+    "uses_instance_oauth",
+    "uses_service_auth",
+    "snippets",
+    "managed",
+    "example",
+    "supports_data_studio_link",
+    "named_driver_version_actual",
+    "created_at",
+    "user_id",
+    "last_regen_at",
+    "last_reap_at",
+    "default_bq_connection",
+    "p4sa_name",
+}
+
+
+class TestCreateConnectionToolSchema:
+    """The MCP tool surface is the contract — verify all DBConnection writable
+    fields are reachable, and no read-only fields are mistakenly accepted as
+    inputs. The surface is what an agent sees; tests on the HTTP layer alone
+    don't catch a missing tool parameter.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_connection_exposes_all_writable_fields(self, server_and_client):
+        mcp, _ = server_and_client
+        tools = {t.name: t for t in await mcp.list_tools()}
+        assert "create_connection" in tools
+
+        props = tools["create_connection"].parameters["properties"]
+        # Required identity fields
+        assert {"name", "dialect_name"} <= props.keys()
+        # Every writable DBConnection field must be present
+        missing = WRITABLE_DBCONNECTION_FIELDS - props.keys()
+        assert not missing, f"create_connection missing writable fields: {sorted(missing)}"
+        # Read-only fields must never leak into the writable surface
+        leaked = READONLY_DBCONNECTION_FIELDS & props.keys()
+        assert not leaked, f"create_connection exposes read-only fields: {sorted(leaked)}"
+
+    @pytest.mark.asyncio
+    async def test_update_connection_exposes_all_writable_fields_except_create_only(
+        self, server_and_client
+    ):
+        mcp, _ = server_and_client
+        tools = {t.name: t for t in await mcp.list_tools()}
+        assert "update_connection" in tools
+
+        props = tools["update_connection"].parameters["properties"]
+        # name is required to address the connection in the URL path; dialect_name
+        # is write-once at create time and must not be re-settable here.
+        assert "name" in props
+        assert "dialect_name" not in props, (
+            "dialect_name is write-once at create — exposing it on update implies "
+            "it can be changed, which Looker does not support."
+        )
+        # Every writable field must be present
+        missing = WRITABLE_DBCONNECTION_FIELDS - props.keys()
+        assert not missing, f"update_connection missing writable fields: {sorted(missing)}"
+        # Read-only fields must never leak
+        leaked = READONLY_DBCONNECTION_FIELDS & props.keys()
+        assert not leaked, f"update_connection exposes read-only fields: {sorted(leaked)}"
+
+
 class TestGetConnection:
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_connection_tools.py
+++ b/tests/test_connection_tools.py
@@ -407,17 +407,13 @@ class TestErrorFormatting:
 # ── Field-clearing semantics on update_connection ───────────────────────
 
 
-def _invoke_tool(mcp, tool_name: str, args: dict):
+async def _invoke_tool(mcp, tool_name: str, args: dict):
     """Call a tool through the MCP server and return the parsed payload."""
-
-    async def _run():
-        async with Client(mcp) as mcp_client:
-            result = await mcp_client.call_tool(tool_name, args)
-            content = result.content[0]
-            assert isinstance(content, TextContent)
-            return json.loads(content.text)
-
-    return _run
+    async with Client(mcp) as mcp_client:
+        result = await mcp_client.call_tool(tool_name, args)
+        content = result.content[0]
+        assert isinstance(content, TextContent)
+        return json.loads(content.text)
 
 
 class TestUpdateConnectionClearFields:
@@ -454,7 +450,7 @@ class TestUpdateConnectionClearFields:
                 "host": "newhost.example.com",
                 "clear_fields": ["oauth_application_id", "service_name"],
             },
-        )()
+        )
         assert payload["updated"] is True
         # The set field carries its value.
         assert captured["body"]["host"] == "newhost.example.com"
@@ -483,7 +479,7 @@ class TestUpdateConnectionClearFields:
             mcp,
             "update_connection",
             {"name": "warehouse", "clear_fields": ["not_a_field", "host"]},
-        )()
+        )
         assert "Invalid field name" in payload["error"]
         assert "not_a_field" in payload["invalid"]
         # 'host' is a valid writable field so it should NOT be flagged.
@@ -504,7 +500,7 @@ class TestUpdateConnectionClearFields:
             mcp,
             "update_connection",
             {"name": "warehouse", "host": "x.example.com", "clear_fields": ["host"]},
-        )()
+        )
         assert "Cannot both set and clear" in payload["error"]
         assert "host" in payload["conflicts"]
         patch_calls = [c for c in respx.calls if c.request.method == "PATCH"]
@@ -530,7 +526,7 @@ class TestUpdateConnectionClearFields:
             mcp,
             "update_connection",
             {"name": "warehouse", "clear_fields": ["tunnel_id"]},
-        )()
+        )
         assert payload["updated"] is True
         assert captured["body"] == {"tunnel_id": None}
 


### PR DESCRIPTION
## Summary

The `create_connection` and `update_connection` tools previously surfaced only ~16 fields out of the 65 properties on Looker's `DBConnection` schema, blocking end-to-end agentic management of database connections — most painfully, **key-pair authentication** (Snowflake, BigQuery service-account keys) and the **per-user `user_attribute_fields` allowlist** that maps connection params to Looker user attributes.

This PR exposes every writable `DBConnection` field on both tools so connections can be created, configured, and rotated entirely from an MCP client.

### What's added

- **Key-pair auth**: `uses_key_pair_auth`, `certificate` (write-only, base64-encoded keyfile body), `file_type` (`.json` / `.p8` / `.p12`)
- **OAuth / Application Default Credentials**: `oauth_application_id`, `uses_application_default_credentials`, `impersonated_service_account`
- **Per-user / user-attribute scoping**: `user_db_credentials`, `user_attribute_fields`
- **SSH tunneling**: `tunnel_id`, `custom_local_port`
- **Oracle TNS**: `uses_tns`, `service_name`
- **PDT controls**: `tmp_db_host`, `pdt_concurrency`, `pdt_api_control_enabled`, `always_retry_failed_builds`, `maintenance_cron`, `pdt_context_override` (the `DBConnectionOverride` block, accepted as a typed `dict` pass-through so PDT builds can run against a separate write-capable role)
- **SQL governance**: `max_queries`, `max_queries_per_user`, `max_billing_gigabytes` (BigQuery), `cost_estimate_enabled`, `query_holding_disabled`, `disable_context_comment`, `query_timezone`, `db_timezone`, `after_connect_statements`, `connection_pooling`, `sql_runner_precache_tables`, `sql_writing_with_info_schema`
- **JDBC**: `named_driver_version_requested`
- **BigQuery**: `bq_storage_project_id`, `bq_roles_verified`

### What's removed

- `pdts_enabled` and `uses_oauth` are no longer accepted as create/update parameters. Both are marked `readOnly` on the Looker 4.0 spec — sending them was silently ignored on the wire, which gave callers a false-success ("I set `pdts_enabled=true` but nothing changed"). PDTs are enabled implicitly via `tmp_db_name` plus DB permissions; OAuth is enabled by setting `oauth_application_id`.

### Why this shape

`pdt_context_override` is a 22-field nested object (`DBConnectionOverride`). Rather than fan its sub-fields into the parent signature, it's accepted as a typed `dict[str, Any] | None` pass-through with the accepted keys documented inline.

`port` stays `int | None` (the spec says `string`, but Looker accepts both and existing callers rely on int).

### Tests

Added `TestCreateConnectionToolSchema` / `TestUpdateConnectionToolSchema` introspection tests that assert the registered MCP tool input schema against the canonical set of writable `DBConnection` fields. These will fail loudly on a future refactor that silently drops a parameter, and they also lock in the read-only invariant (`pdts_enabled` / `uses_oauth` must NOT appear on the writable surface).

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run pytest tests/ -q` — 245 passed
- [x] Tool-schema regression tests cover both create and update surfaces
- [ ] Manual smoke test against a live Looker instance (Snowflake key-pair create + test_connection round-trip) — to be done by reviewer or in a follow-up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded connection create/update to support many additional connection options (drivers, multiple auth modes, per-user mapping, pooling/concurrency, SQL governance, PDT controls, SSH tunneling, BigQuery routing).
  * Added ability to explicitly clear fields on update; cleared fields are sent as JSON null.

* **Documentation**
  * Clarified which connection metadata are read-only; removed certain fields from accepted inputs.
  * Published a canonical writable-field list for tool/schema consistency.

* **Tests**
  * Added regression tests for tool input schema exposure and clear-fields validation/serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->