### PR TITLE
feat(git): deploy-key rotation, connection diagnostics, branch delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the spec for `POST /projects/{id}/deploy_ref_to_production`.
   Omitting both preserves the previous default of deploying the
   current dev ref.
-- `delete_git_branch`, `get_git_branch_by_name`, and the deploy-key
-  / connection-test tools URL-encode `project_id` and `branch_name`
-  with the shared `_path_seg` helper, so branch names containing
-  `/` (e.g. `feature/foo`) route to the correct endpoint.
+- **All git tools now URL-encode `project_id` and `branch_name`**
+  via the shared `_path_seg` helper, finishing the rollout
+  (previously only the new tools did). Branch names containing `/`
+  (e.g. `feature/foo`) and project ids with reserved characters now
+  route to the correct endpoint regardless of which git tool is
+  invoked.
+- **Deploy-key endpoints now use the new
+  `LookerSession.get_text` / `post_text` helpers**. Looker's
+  `/projects/{id}/git/deploy_key` returns a raw SSH public key as
+  `text/plain`, not JSON; the previous `session.get` / `session.post`
+  call path would have raised on `response.json()` in production.
+  Tests mock the response with `text=` and the correct content-type.
+
+### Internal
+
+- New `LookerSession.get_text` and `post_text` methods for endpoints
+  that return `text/plain` (currently the deploy-key endpoints; future
+  text-returning endpoints can reuse this).
 
 ## [0.13.0] - 2026-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Git deploy-key management** for LookML projects:
+  - `get_git_deploy_key` — fetch the public SSH deploy key Looker uses
+    to authenticate to the project's git remote.
+  - `create_git_deploy_key` — generate or rotate the deploy key.
+    Returns the new public key for registration on GitHub / GitLab /
+    Bitbucket. Closes the gap on credential-rotation workflows that
+    previously required manual UI clicks per tenant.
+- **Git connection diagnostics**:
+  - `list_git_connection_tests` — enumerate available diagnostic
+    tests for a project's git remote.
+  - `run_git_connection_test` — run a single test, returning
+    pass/fail status with a human-readable failure cause. Supports
+    the `remote_url` and `use_production` query params for testing
+    remote dependencies and production credentials.
+- **Branch management**:
+  - `get_git_branch_by_name` — get a specific branch's full state
+    (ref, remote, ahead/behind, error) by name.
+  - `delete_git_branch` — delete a local branch (sweeps abandoned
+    dev branches that accumulated during iterative LookML work).
+
+### Changed
+
+- `deploy_to_production` now accepts optional `branch` and `ref`
+  query params to deploy a specific named branch or commit, matching
+  the spec for `POST /projects/{id}/deploy_ref_to_production`.
+  Omitting both preserves the previous default of deploying the
+  current dev ref.
+- `delete_git_branch`, `get_git_branch_by_name`, and the deploy-key
+  / connection-test tools URL-encode `project_id` and `branch_name`
+  with the shared `_path_seg` helper, so branch names containing
+  `/` (e.g. `feature/foo`) route to the correct endpoint.
+
 ## [0.13.0] - 2026-04-17
 
 ### Added

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -103,6 +103,26 @@ class LookerSession:
         """POST to an endpoint that returns ``text/plain`` (deploy-key rotation)."""
         return await self._request_text("POST", path, params=params)
 
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        """Raise ``LookerApiError`` with the best-available detail string.
+
+        Looker error bodies are JSON ``{"message": ..., "errors": ...}`` in
+        most cases but can be plain text for some endpoints (notably the
+        text/plain ones). Try JSON first; fall back to a 500-char text
+        truncation. Shared by both the JSON and text request paths so
+        their error parsing can never drift.
+        """
+        if response.status_code < 400:
+            return
+        detail = ""
+        try:
+            body = response.json()
+            detail = body.get("message", "") or body.get("error", "")
+        except Exception:
+            detail = response.text[:500]
+        raise LookerApiError(response.status_code, response.reason_phrase, detail)
+
     async def _request(
         self,
         method: str,
@@ -117,14 +137,7 @@ class LookerSession:
             params=params,
             json=json,
         )
-        if response.status_code >= 400:
-            detail = ""
-            try:
-                body = response.json()
-                detail = body.get("message", "") or body.get("error", "")
-            except Exception:
-                detail = response.text[:500]
-            raise LookerApiError(response.status_code, response.reason_phrase, detail)
+        self._raise_for_status(response)
 
         if response.status_code == 204 or not response.content:
             return None
@@ -142,14 +155,7 @@ class LookerSession:
             headers=self._headers,
             params=params,
         )
-        if response.status_code >= 400:
-            detail = ""
-            try:
-                body = response.json()
-                detail = body.get("message", "") or body.get("error", "")
-            except Exception:
-                detail = response.text[:500]
-            raise LookerApiError(response.status_code, response.reason_phrase, detail)
+        self._raise_for_status(response)
         return response.text
 
 

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -81,6 +81,28 @@ class LookerSession:
     ) -> None:
         await self._request("DELETE", path, params=params)
 
+    async def get_text(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> str:
+        """GET an endpoint that returns ``text/plain`` rather than JSON.
+
+        Looker's git deploy-key endpoints return a raw SSH public key as
+        plain text; calling ``.json()`` on the response would raise.
+        Mirrors ``get()``'s error-handling so 4xx/5xx still raise
+        ``LookerApiError`` with a usable detail body.
+        """
+        return await self._request_text("GET", path, params=params)
+
+    async def post_text(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> str:
+        """POST to an endpoint that returns ``text/plain`` (deploy-key rotation)."""
+        return await self._request_text("POST", path, params=params)
+
     async def _request(
         self,
         method: str,
@@ -107,6 +129,28 @@ class LookerSession:
         if response.status_code == 204 or not response.content:
             return None
         return response.json()
+
+    async def _request_text(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> str:
+        response = await self._http.request(
+            method,
+            path,
+            headers=self._headers,
+            params=params,
+        )
+        if response.status_code >= 400:
+            detail = ""
+            try:
+                body = response.json()
+                detail = body.get("message", "") or body.get("error", "")
+            except Exception:
+                detail = response.text[:500]
+            raise LookerApiError(response.status_code, response.reason_phrase, detail)
+        return response.text
 
 
 class LookerClient:

--- a/src/looker_mcp_server/tools/git.py
+++ b/src/looker_mcp_server/tools/git.py
@@ -1,8 +1,10 @@
 """Git tool group — LookML version control and deployment.
 
-Tools for managing Git branches within LookML projects and deploying
-changes to production.  Separated from the ``modeling`` group so that
-LookML editing can be enabled without granting deployment access.
+Tools for managing Git branches within LookML projects, deploying
+changes to production, rotating SSH deploy keys for the LookML repo's
+git remote, and running Looker's built-in git-connection diagnostics.
+Separated from the ``modeling`` group so that LookML editing can be
+enabled without granting deployment access.
 """
 
 from __future__ import annotations
@@ -13,6 +15,7 @@ from typing import Annotated, Any
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
+from ._helpers import _path_seg
 
 
 def register_git_tools(server: FastMCP, client: LookerClient) -> None:
@@ -71,6 +74,32 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
+            "Get a specific Git branch by name for a LookML project, including "
+            "its full ref/remote/ahead/behind/error state. Use ``list_git_branches`` "
+            "to enumerate branches first; this tool is the right choice when you "
+            "already know the branch you want to inspect."
+        ),
+    )
+    async def get_git_branch_by_name(
+        project_id: Annotated[str, "LookML project ID"],
+        branch_name: Annotated[str, "Name of the branch to inspect"],
+    ) -> str:
+        ctx = client.build_context(
+            "get_git_branch_by_name",
+            "git",
+            {"project_id": project_id, "branch_name": branch_name},
+        )
+        try:
+            async with client.session(ctx) as session:
+                branch = await session.get(
+                    f"/projects/{_path_seg(project_id)}/git_branch/{_path_seg(branch_name)}"
+                )
+                return json.dumps(branch, indent=2)
+        except Exception as e:
+            return format_api_error("get_git_branch_by_name", e)
+
+    @server.tool(
+        description=(
             "Create a new Git branch in a LookML project. "
             "The branch is created from the current ref."
         ),
@@ -122,20 +151,73 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
-            "Deploy the current dev branch to production. This makes all "
-            "LookML changes in dev mode visible to all users. "
-            "Ensure the project validates cleanly before deploying."
+            "Delete a local Git branch in a LookML project. Does NOT delete the "
+            "branch on the remote. Will fail if the branch is currently checked "
+            "out — switch to a different branch first via ``switch_git_branch``. "
+            "Useful for sweeping abandoned dev branches accumulated during "
+            "iterative LookML work."
+        ),
+    )
+    async def delete_git_branch(
+        project_id: Annotated[str, "LookML project ID"],
+        branch_name: Annotated[str, "Name of the branch to delete"],
+    ) -> str:
+        ctx = client.build_context(
+            "delete_git_branch",
+            "git",
+            {"project_id": project_id, "branch_name": branch_name},
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(
+                    f"/projects/{_path_seg(project_id)}/git_branch/{_path_seg(branch_name)}"
+                )
+                return json.dumps(
+                    {"deleted": True, "project_id": project_id, "branch_name": branch_name},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_git_branch", e)
+
+    @server.tool(
+        description=(
+            "Deploy LookML to production. By default deploys the project's "
+            "current dev ref; pass ``branch`` or ``ref`` to deploy a specific "
+            "named branch or commit. Ensure the project validates cleanly before "
+            "deploying — this makes all changes visible to all users."
         ),
     )
     async def deploy_to_production(
         project_id: Annotated[str, "LookML project ID to deploy"],
+        branch: Annotated[
+            str | None,
+            "Specific branch to deploy (defaults to current dev ref)",
+        ] = None,
+        ref: Annotated[
+            str | None,
+            "Specific commit ref to deploy (mutually informative with ``branch``)",
+        ] = None,
     ) -> str:
         ctx = client.build_context("deploy_to_production", "git", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                result = await session.post(f"/projects/{project_id}/deploy_ref_to_production")
+                params: dict[str, Any] = {}
+                if branch is not None:
+                    params["branch"] = branch
+                if ref is not None:
+                    params["ref"] = ref
+                result = await session.post(
+                    f"/projects/{_path_seg(project_id)}/deploy_ref_to_production",
+                    params=params or None,
+                )
                 return json.dumps(
-                    {"deployed": True, "project_id": project_id, "detail": result},
+                    {
+                        "deployed": True,
+                        "project_id": project_id,
+                        "branch": branch,
+                        "ref": ref,
+                        "detail": result,
+                    },
                     indent=2,
                 )
         except Exception as e:
@@ -160,3 +242,154 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
                 )
         except Exception as e:
             return format_api_error("reset_to_production", e)
+
+    # ── Deploy keys ──────────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get the public SSH deploy key Looker uses to authenticate to the "
+            "LookML project's git remote. Add this key to GitHub / GitLab / "
+            "Bitbucket as a deploy key (typically read+write) before configuring "
+            "the project's git connection. Returns 404 if no deploy key has "
+            "been generated yet — call ``create_git_deploy_key`` first."
+        ),
+    )
+    async def get_git_deploy_key(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context("get_git_deploy_key", "git", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                # Looker returns the public key as plain text, not JSON.
+                public_key = await session.get(f"/projects/{_path_seg(project_id)}/git/deploy_key")
+                return json.dumps(
+                    {"project_id": project_id, "public_key": public_key},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("get_git_deploy_key", e)
+
+    @server.tool(
+        description=(
+            "Generate a new SSH deploy key for the LookML project's git remote. "
+            "If a key already exists, this rotates it — invalidating the old "
+            "public key on the remote until you re-register the new one. Use "
+            "this for credential rotation; the new public key is returned in "
+            "the response and must be added to the git host (GitHub / GitLab / "
+            "Bitbucket) before the project's git connection will work again."
+        ),
+    )
+    async def create_git_deploy_key(
+        project_id: Annotated[str, "LookML project ID"],
+    ) -> str:
+        ctx = client.build_context("create_git_deploy_key", "git", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                public_key = await session.post(f"/projects/{_path_seg(project_id)}/git/deploy_key")
+                return json.dumps(
+                    {
+                        "project_id": project_id,
+                        "rotated": True,
+                        "public_key": public_key,
+                        "next_step": (
+                            "Add this public key to the git host as a deploy key "
+                            "with read+write access, then run "
+                            "``run_git_connection_test`` to verify connectivity."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_git_deploy_key", e)
+
+    # ── Connection tests / diagnostics ───────────────────────────────
+
+    @server.tool(
+        description=(
+            "List the git-connection diagnostic tests available for a LookML "
+            "project. Each entry has an ``id`` (used with ``run_git_connection_test``) "
+            "and a human-readable ``description``. Test types vary by remote git "
+            "provider and are dynamically generated by Looker based on the project's "
+            "git configuration."
+        ),
+    )
+    async def list_git_connection_tests(
+        project_id: Annotated[str, "LookML project ID"],
+        remote_url: Annotated[
+            str | None,
+            (
+                "Optional: remote URL for a remote dependency test. Leave blank to "
+                "list tests for the root project."
+            ),
+        ] = None,
+    ) -> str:
+        ctx = client.build_context("list_git_connection_tests", "git", {"project_id": project_id})
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] | None = (
+                    {"remote_url": remote_url} if remote_url is not None else None
+                )
+                tests = await session.get(
+                    f"/projects/{_path_seg(project_id)}/git_connection_tests",
+                    params=params,
+                )
+                result = [
+                    {"id": t.get("id"), "description": t.get("description")} for t in (tests or [])
+                ]
+                return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_git_connection_tests", e)
+
+    @server.tool(
+        description=(
+            "Run a single git-connection diagnostic test against a LookML "
+            "project's git remote. Returns ``status`` ('pass' or 'fail') with a "
+            "``message`` describing the failure cause when applicable. Common "
+            "diagnoses: missing deploy key registration on the remote, wrong "
+            "remote URL, no network egress to the git host, or stale SSH known-"
+            "hosts entry on the Looker instance. Call ``list_git_connection_tests`` "
+            "to discover valid ``test_id`` values for this project."
+        ),
+    )
+    async def run_git_connection_test(
+        project_id: Annotated[str, "LookML project ID"],
+        test_id: Annotated[str, "Test id from ``list_git_connection_tests``"],
+        remote_url: Annotated[
+            str | None,
+            "Optional: remote URL to test against (for remote-dependency tests)",
+        ] = None,
+        use_production: Annotated[
+            str | None,
+            (
+                "Optional: 'true' to use the project's production git credentials "
+                "instead of dev. Pass as a string (Looker query-param convention)."
+            ),
+        ] = None,
+    ) -> str:
+        ctx = client.build_context(
+            "run_git_connection_test",
+            "git",
+            {"project_id": project_id, "test_id": test_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] = {}
+                if remote_url is not None:
+                    params["remote_url"] = remote_url
+                if use_production is not None:
+                    params["use_production"] = use_production
+                result = await session.get(
+                    f"/projects/{_path_seg(project_id)}/git_connection_tests/{_path_seg(test_id)}",
+                    params=params or None,
+                )
+                return json.dumps(
+                    {
+                        "test_id": result.get("id") if result else test_id,
+                        "status": result.get("status") if result else None,
+                        "passed": (result.get("status") == "pass") if result else False,
+                        "message": result.get("message") if result else None,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("run_git_connection_test", e)

--- a/src/looker_mcp_server/tools/git.py
+++ b/src/looker_mcp_server/tools/git.py
@@ -28,7 +28,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("get_git_branch", "git", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                branch = await session.get(f"/projects/{project_id}/git_branch")
+                branch = await session.get(f"/projects/{_path_seg(project_id)}/git_branch")
                 return json.dumps(
                     {
                         "name": branch.get("name"),
@@ -56,7 +56,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("list_git_branches", "git", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                branches = await session.get(f"/projects/{project_id}/git_branches")
+                branches = await session.get(f"/projects/{_path_seg(project_id)}/git_branches")
                 result = [
                     {
                         "name": b.get("name"),
@@ -115,7 +115,9 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
                 body: dict[str, Any] = {"name": branch_name}
                 if ref:
                     body["ref"] = ref
-                branch = await session.post(f"/projects/{project_id}/git_branch", body=body)
+                branch = await session.post(
+                    f"/projects/{_path_seg(project_id)}/git_branch", body=body
+                )
                 return json.dumps(
                     {"name": branch.get("name"), "ref": branch.get("ref")},
                     indent=2,
@@ -136,7 +138,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 branch = await session.put(
-                    f"/projects/{project_id}/git_branch",
+                    f"/projects/{_path_seg(project_id)}/git_branch",
                     body={"name": branch_name},
                 )
                 return json.dumps(
@@ -235,7 +237,9 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("reset_to_production", "git", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                result = await session.post(f"/projects/{project_id}/reset_to_production")
+                result = await session.post(
+                    f"/projects/{_path_seg(project_id)}/reset_to_production"
+                )
                 return json.dumps(
                     {"reset": True, "project_id": project_id, "detail": result},
                     indent=2,
@@ -260,8 +264,11 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("get_git_deploy_key", "git", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                # Looker returns the public key as plain text, not JSON.
-                public_key = await session.get(f"/projects/{_path_seg(project_id)}/git/deploy_key")
+                # Looker returns the public key as text/plain, not JSON.
+                # Using session.get_text avoids tripping on response.json().
+                public_key = await session.get_text(
+                    f"/projects/{_path_seg(project_id)}/git/deploy_key"
+                )
                 return json.dumps(
                     {"project_id": project_id, "public_key": public_key},
                     indent=2,
@@ -285,7 +292,10 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         ctx = client.build_context("create_git_deploy_key", "git", {"project_id": project_id})
         try:
             async with client.session(ctx) as session:
-                public_key = await session.post(f"/projects/{_path_seg(project_id)}/git/deploy_key")
+                # Looker returns the rotated public key as text/plain.
+                public_key = await session.post_text(
+                    f"/projects/{_path_seg(project_id)}/git/deploy_key"
+                )
                 return json.dumps(
                     {
                         "project_id": project_id,

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -1,0 +1,268 @@
+"""Tests for git tool group — LookML version control, deploy keys, diagnostics."""
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.client import LookerClient
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.identity import ApiKeyIdentityProvider
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+def server_and_client(config):
+    mcp, client = create_server(config, enabled_groups={"git"})
+    return mcp, client
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout():
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+# Tools the git group must expose. Acts as a registration regression test —
+# a future refactor that drops a tool will fail loudly here.
+EXPECTED_GIT_TOOLS = {
+    "get_git_branch",
+    "list_git_branches",
+    "get_git_branch_by_name",
+    "create_git_branch",
+    "switch_git_branch",
+    "delete_git_branch",
+    "deploy_to_production",
+    "reset_to_production",
+    "get_git_deploy_key",
+    "create_git_deploy_key",
+    "list_git_connection_tests",
+    "run_git_connection_test",
+}
+
+
+class TestGitToolRegistration:
+    @pytest.mark.asyncio
+    async def test_all_git_tools_register(self, server_and_client):
+        mcp, _ = server_and_client
+        names = {t.name for t in await mcp.list_tools()}
+        missing = EXPECTED_GIT_TOOLS - names
+        assert not missing, f"git tool group missing tools: {sorted(missing)}"
+
+    @pytest.mark.asyncio
+    async def test_deploy_to_production_accepts_branch_and_ref(self, server_and_client):
+        # Looker spec: branch + ref are query params on POST
+        # /projects/{id}/deploy_ref_to_production. Without them the tool can
+        # only deploy the current dev ref.
+        mcp, _ = server_and_client
+        tools = {t.name: t for t in await mcp.list_tools()}
+        props = tools["deploy_to_production"].parameters["properties"]
+        assert {"project_id", "branch", "ref"} <= props.keys()
+
+
+class TestDeleteGitBranch:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_issues_delete_to_branch_path(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/projects/proj1/git_branch/feature_x").mock(
+            return_value=httpx.Response(204)
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_git_branch", "git", {"project_id": "proj1"})
+        try:
+            from urllib.parse import quote
+
+            async with client.session(ctx) as session:
+                await session.delete(
+                    f"/projects/{quote('proj1', safe='')}/git_branch/{quote('feature_x', safe='')}"
+                )
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_branch_name_with_slash_is_url_encoded(self, config):
+        # Looker branch names commonly contain '/' (e.g. 'feature/foo'). They
+        # MUST be percent-encoded so the path doesn't fan out into nested
+        # path segments and hit the wrong endpoint.
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["raw_path"] = request.url.raw_path.decode("ascii")
+            return httpx.Response(204)
+
+        respx.delete(url__regex=rf"{API_URL}/projects/.*/git_branch/.*").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_git_branch", "git", {"project_id": "proj1"})
+        try:
+            from urllib.parse import quote
+
+            async with client.session(ctx) as session:
+                await session.delete(
+                    f"/projects/{quote('proj1', safe='')}"
+                    f"/git_branch/{quote('feature/foo', safe='')}"
+                )
+                # The slash inside the branch name must be encoded as %2F so
+                # 'feature/foo' is not interpreted as a sub-resource.
+                assert "feature%2Ffoo" in captured["raw_path"]
+                assert "git_branch/feature/foo" not in captured["raw_path"]
+        finally:
+            await client.close()
+
+
+class TestDeployToProduction:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_passes_branch_and_ref_as_query_params(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json={})
+
+        respx.post(url__regex=rf"{API_URL}/projects/proj1/deploy_ref_to_production.*").mock(
+            side_effect=capture
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("deploy_to_production", "git", {"project_id": "proj1"})
+        try:
+            async with client.session(ctx) as session:
+                await session.post(
+                    "/projects/proj1/deploy_ref_to_production",
+                    params={"branch": "release/v2", "ref": "abc123"},
+                )
+                assert "branch=release" in captured["url"]
+                assert "ref=abc123" in captured["url"]
+        finally:
+            await client.close()
+
+
+class TestGitDeployKey:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_returns_public_key(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/proj1/git/deploy_key").mock(
+            return_value=httpx.Response(200, json="ssh-rsa AAAA...example")
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_git_deploy_key", "git", {"project_id": "proj1"})
+        try:
+            async with client.session(ctx) as session:
+                key = await session.get("/projects/proj1/git/deploy_key")
+                assert key == "ssh-rsa AAAA...example"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_rotates_key(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/projects/proj1/git/deploy_key").mock(
+            return_value=httpx.Response(200, json="ssh-rsa NEW...rotated")
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_git_deploy_key", "git", {"project_id": "proj1"})
+        try:
+            async with client.session(ctx) as session:
+                key = await session.post("/projects/proj1/git/deploy_key")
+                assert "NEW" in key
+        finally:
+            await client.close()
+
+
+class TestGitConnectionTest:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_returns_pass_or_fail(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/proj1/git_connection_tests/git_remote_check").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "git_remote_check",
+                    "status": "fail",
+                    "message": "Permission denied (publickey)",
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "run_git_connection_test",
+            "git",
+            {"project_id": "proj1", "test_id": "git_remote_check"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                result = await session.get("/projects/proj1/git_connection_tests/git_remote_check")
+                assert result["status"] == "fail"
+                assert "publickey" in result["message"]
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_passes_remote_url_and_use_production_query_params(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json={"id": "t", "status": "pass"})
+
+        respx.get(url__regex=rf"{API_URL}/projects/proj1/git_connection_tests/.*").mock(
+            side_effect=capture
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "run_git_connection_test",
+            "git",
+            {"project_id": "proj1", "test_id": "remote_dep"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.get(
+                    "/projects/proj1/git_connection_tests/remote_dep",
+                    params={
+                        "remote_url": "git@github.com:org/repo.git",
+                        "use_production": "true",
+                    },
+                )
+                assert "remote_url=" in captured["url"]
+                assert "use_production=true" in captured["url"]
+        finally:
+            await client.close()

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -1,12 +1,20 @@
-"""Tests for git tool group — LookML version control, deploy keys, diagnostics."""
+"""Tests for git tool group — LookML version control, deploy keys, diagnostics.
+
+All tests invoke through ``fastmcp.Client(mcp).call_tool`` so the MCP tool
+wrappers are actually exercised — argument plumbing, response shaping,
+and ``format_api_error`` handling are all under test, not just the
+underlying HTTP layer.
+"""
+
+import json
 
 import httpx
 import pytest
 import respx
+from fastmcp import Client
+from mcp.types import TextContent
 
-from looker_mcp_server.client import LookerClient
 from looker_mcp_server.config import LookerConfig
-from looker_mcp_server.identity import ApiKeyIdentityProvider
 from looker_mcp_server.server import create_server
 
 
@@ -21,12 +29,6 @@ def config():
     )
 
 
-@pytest.fixture
-def server_and_client(config):
-    mcp, client = create_server(config, enabled_groups={"git"})
-    return mcp, client
-
-
 API_URL = "https://test.looker.com/api/4.0"
 
 
@@ -35,6 +37,19 @@ def _mock_login_logout():
         return_value=httpx.Response(200, json={"access_token": "sess-token"})
     )
     respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+def _invoke_tool(mcp, tool_name: str, args: dict):
+    """Call a tool through the MCP server and return the parsed payload."""
+
+    async def _run():
+        async with Client(mcp) as mcp_client:
+            result = await mcp_client.call_tool(tool_name, args)
+            content = result.content[0]
+            assert isinstance(content, TextContent)
+            return json.loads(content.text)
+
+    return _run
 
 
 # Tools the git group must expose. Acts as a registration regression test —
@@ -57,44 +72,54 @@ EXPECTED_GIT_TOOLS = {
 
 class TestGitToolRegistration:
     @pytest.mark.asyncio
-    async def test_all_git_tools_register(self, server_and_client):
-        mcp, _ = server_and_client
-        names = {t.name for t in await mcp.list_tools()}
-        missing = EXPECTED_GIT_TOOLS - names
-        assert not missing, f"git tool group missing tools: {sorted(missing)}"
+    async def test_all_git_tools_register(self, config):
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            names = {t.name for t in await mcp.list_tools()}
+            missing = EXPECTED_GIT_TOOLS - names
+            assert not missing, f"git tool group missing tools: {sorted(missing)}"
+        finally:
+            await looker_client.close()
 
     @pytest.mark.asyncio
-    async def test_deploy_to_production_accepts_branch_and_ref(self, server_and_client):
+    async def test_deploy_to_production_accepts_branch_and_ref(self, config):
         # Looker spec: branch + ref are query params on POST
         # /projects/{id}/deploy_ref_to_production. Without them the tool can
         # only deploy the current dev ref.
-        mcp, _ = server_and_client
-        tools = {t.name: t for t in await mcp.list_tools()}
-        props = tools["deploy_to_production"].parameters["properties"]
-        assert {"project_id", "branch", "ref"} <= props.keys()
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            tools = {t.name: t for t in await mcp.list_tools()}
+            props = tools["deploy_to_production"].parameters["properties"]
+            assert {"project_id", "branch", "ref"} <= props.keys()
+        finally:
+            await looker_client.close()
 
 
 class TestDeleteGitBranch:
     @pytest.mark.asyncio
     @respx.mock
-    async def test_issues_delete_to_branch_path(self, config):
+    async def test_invokes_tool_and_returns_envelope(self, config):
+        # End-to-end through the MCP tool: argument plumbing, URL
+        # construction, response shaping all under test.
         _mock_login_logout()
         respx.delete(f"{API_URL}/projects/proj1/git_branch/feature_x").mock(
             return_value=httpx.Response(204)
         )
 
-        provider = ApiKeyIdentityProvider("test-id", "test-secret")
-        client = LookerClient(config, provider)
-        ctx = client.build_context("delete_git_branch", "git", {"project_id": "proj1"})
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
         try:
-            from urllib.parse import quote
-
-            async with client.session(ctx) as session:
-                await session.delete(
-                    f"/projects/{quote('proj1', safe='')}/git_branch/{quote('feature_x', safe='')}"
-                )
+            payload = await _invoke_tool(
+                mcp,
+                "delete_git_branch",
+                {"project_id": "proj1", "branch_name": "feature_x"},
+            )()
+            assert payload == {
+                "deleted": True,
+                "project_id": "proj1",
+                "branch_name": "feature_x",
+            }
         finally:
-            await client.close()
+            await looker_client.close()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -112,23 +137,19 @@ class TestDeleteGitBranch:
 
         respx.delete(url__regex=rf"{API_URL}/projects/.*/git_branch/.*").mock(side_effect=capture)
 
-        provider = ApiKeyIdentityProvider("test-id", "test-secret")
-        client = LookerClient(config, provider)
-        ctx = client.build_context("delete_git_branch", "git", {"project_id": "proj1"})
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
         try:
-            from urllib.parse import quote
-
-            async with client.session(ctx) as session:
-                await session.delete(
-                    f"/projects/{quote('proj1', safe='')}"
-                    f"/git_branch/{quote('feature/foo', safe='')}"
-                )
-                # The slash inside the branch name must be encoded as %2F so
-                # 'feature/foo' is not interpreted as a sub-resource.
-                assert "feature%2Ffoo" in captured["raw_path"]
-                assert "git_branch/feature/foo" not in captured["raw_path"]
+            await _invoke_tool(
+                mcp,
+                "delete_git_branch",
+                {"project_id": "proj1", "branch_name": "feature/foo"},
+            )()
+            # The slash inside the branch name must be encoded as %2F so
+            # 'feature/foo' is not interpreted as a sub-resource.
+            assert "feature%2Ffoo" in captured["raw_path"]
+            assert "git_branch/feature/foo" not in captured["raw_path"]
         finally:
-            await client.close()
+            await looker_client.close()
 
 
 class TestDeployToProduction:
@@ -147,57 +168,95 @@ class TestDeployToProduction:
             side_effect=capture
         )
 
-        provider = ApiKeyIdentityProvider("test-id", "test-secret")
-        client = LookerClient(config, provider)
-        ctx = client.build_context("deploy_to_production", "git", {"project_id": "proj1"})
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
         try:
-            async with client.session(ctx) as session:
-                await session.post(
-                    "/projects/proj1/deploy_ref_to_production",
-                    params={"branch": "release/v2", "ref": "abc123"},
-                )
-                assert "branch=release" in captured["url"]
-                assert "ref=abc123" in captured["url"]
+            payload = await _invoke_tool(
+                mcp,
+                "deploy_to_production",
+                {"project_id": "proj1", "branch": "release/v2", "ref": "abc123"},
+            )()
+            assert payload["deployed"] is True
+            assert payload["branch"] == "release/v2"
+            assert "branch=release" in captured["url"]
+            assert "ref=abc123" in captured["url"]
         finally:
-            await client.close()
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_omitting_branch_and_ref_sends_no_query_string(self, config):
+        # Default behavior — deploy current dev ref — must not put empty
+        # branch/ref params on the wire.
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json={})
+
+        respx.post(url__regex=rf"{API_URL}/projects/proj1/deploy_ref_to_production.*").mock(
+            side_effect=capture
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            await _invoke_tool(mcp, "deploy_to_production", {"project_id": "proj1"})()
+            assert "branch=" not in captured["url"]
+            assert "ref=" not in captured["url"]
+        finally:
+            await looker_client.close()
 
 
 class TestGitDeployKey:
+    """The deploy-key endpoints return text/plain (raw SSH public key), not
+    JSON. The session's text-aware methods (``get_text`` / ``post_text``)
+    handle this correctly; tests with JSON mocks would have hidden a real
+    production failure caused by ``response.json()`` raising on a
+    text/plain body.
+    """
+
     @pytest.mark.asyncio
     @respx.mock
-    async def test_get_returns_public_key(self, config):
+    async def test_get_returns_public_key_from_text_response(self, config):
         _mock_login_logout()
         respx.get(f"{API_URL}/projects/proj1/git/deploy_key").mock(
-            return_value=httpx.Response(200, json="ssh-rsa AAAA...example")
+            return_value=httpx.Response(
+                200,
+                text="ssh-rsa AAAA...example",
+                headers={"content-type": "text/plain; charset=utf-8"},
+            )
         )
 
-        provider = ApiKeyIdentityProvider("test-id", "test-secret")
-        client = LookerClient(config, provider)
-        ctx = client.build_context("get_git_deploy_key", "git", {"project_id": "proj1"})
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
         try:
-            async with client.session(ctx) as session:
-                key = await session.get("/projects/proj1/git/deploy_key")
-                assert key == "ssh-rsa AAAA...example"
+            payload = await _invoke_tool(mcp, "get_git_deploy_key", {"project_id": "proj1"})()
+            assert payload["project_id"] == "proj1"
+            assert payload["public_key"] == "ssh-rsa AAAA...example"
         finally:
-            await client.close()
+            await looker_client.close()
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_create_rotates_key(self, config):
+    async def test_create_rotates_and_returns_new_key(self, config):
         _mock_login_logout()
         respx.post(f"{API_URL}/projects/proj1/git/deploy_key").mock(
-            return_value=httpx.Response(200, json="ssh-rsa NEW...rotated")
+            return_value=httpx.Response(
+                200,
+                text="ssh-rsa NEW...rotated",
+                headers={"content-type": "text/plain; charset=utf-8"},
+            )
         )
 
-        provider = ApiKeyIdentityProvider("test-id", "test-secret")
-        client = LookerClient(config, provider)
-        ctx = client.build_context("create_git_deploy_key", "git", {"project_id": "proj1"})
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
         try:
-            async with client.session(ctx) as session:
-                key = await session.post("/projects/proj1/git/deploy_key")
-                assert "NEW" in key
+            payload = await _invoke_tool(mcp, "create_git_deploy_key", {"project_id": "proj1"})()
+            assert payload["rotated"] is True
+            assert "NEW" in payload["public_key"]
+            # Tool surfaces the registration next-step, useful for agents.
+            assert "next_step" in payload
         finally:
-            await client.close()
+            await looker_client.close()
 
 
 class TestGitConnectionTest:
@@ -216,20 +275,18 @@ class TestGitConnectionTest:
             )
         )
 
-        provider = ApiKeyIdentityProvider("test-id", "test-secret")
-        client = LookerClient(config, provider)
-        ctx = client.build_context(
-            "run_git_connection_test",
-            "git",
-            {"project_id": "proj1", "test_id": "git_remote_check"},
-        )
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
         try:
-            async with client.session(ctx) as session:
-                result = await session.get("/projects/proj1/git_connection_tests/git_remote_check")
-                assert result["status"] == "fail"
-                assert "publickey" in result["message"]
+            payload = await _invoke_tool(
+                mcp,
+                "run_git_connection_test",
+                {"project_id": "proj1", "test_id": "git_remote_check"},
+            )()
+            assert payload["status"] == "fail"
+            assert payload["passed"] is False
+            assert "publickey" in payload["message"]
         finally:
-            await client.close()
+            await looker_client.close()
 
     @pytest.mark.asyncio
     @respx.mock
@@ -246,23 +303,80 @@ class TestGitConnectionTest:
             side_effect=capture
         )
 
-        provider = ApiKeyIdentityProvider("test-id", "test-secret")
-        client = LookerClient(config, provider)
-        ctx = client.build_context(
-            "run_git_connection_test",
-            "git",
-            {"project_id": "proj1", "test_id": "remote_dep"},
-        )
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
         try:
-            async with client.session(ctx) as session:
-                await session.get(
-                    "/projects/proj1/git_connection_tests/remote_dep",
-                    params={
-                        "remote_url": "git@github.com:org/repo.git",
-                        "use_production": "true",
-                    },
-                )
-                assert "remote_url=" in captured["url"]
-                assert "use_production=true" in captured["url"]
+            await _invoke_tool(
+                mcp,
+                "run_git_connection_test",
+                {
+                    "project_id": "proj1",
+                    "test_id": "remote_dep",
+                    "remote_url": "git@github.com:org/repo.git",
+                    "use_production": "true",
+                },
+            )()
+            assert "remote_url=" in captured["url"]
+            assert "use_production=true" in captured["url"]
         finally:
-            await client.close()
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_returns_trimmed_test_descriptors(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/proj1/git_connection_tests").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "id": "git_remote_check",
+                        "description": "Verify the project can talk to its git remote.",
+                        "can": {"run": True},  # not surfaced — helps confirm the trim
+                    },
+                    {"id": "test_2", "description": "Second test."},
+                ],
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp, "list_git_connection_tests", {"project_id": "proj1"}
+            )()
+            assert payload == [
+                {
+                    "id": "git_remote_check",
+                    "description": "Verify the project can talk to its git remote.",
+                },
+                {"id": "test_2", "description": "Second test."},
+            ]
+        finally:
+            await looker_client.close()
+
+
+class TestProjectIdPathEncoding:
+    """The legacy git tools previously embedded raw ``project_id`` in URL
+    paths. After this PR, every git tool routes through ``_path_seg``;
+    pinning the encoding behavior here makes regressions visible.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_legacy_get_git_branch_encodes_project_id(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["raw_path"] = request.url.raw_path.decode("ascii")
+            return httpx.Response(200, json={"name": "main"})
+
+        respx.get(url__regex=rf"{API_URL}/projects/.*/git_branch").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            # Project id with a space would otherwise produce a malformed path.
+            await _invoke_tool(mcp, "get_git_branch", {"project_id": "my project"})()
+            assert "my%20project" in captured["raw_path"]
+        finally:
+            await looker_client.close()


### PR DESCRIPTION
## Summary

Closes the operational git surface needed for end-to-end LookML-deployment automation across multiple Looker tenants. Previously the git tool group could create/list/switch branches and deploy-to-production, but had no way to manage the SSH deploy key that authenticates Looker to the git remote, no way to diagnose connectivity failures, and no way to delete stale branches.

### What's added

- **Deploy-key lifecycle**:
  - `get_git_deploy_key` — fetch the public SSH key Looker uses to authenticate to the project's git remote
  - `create_git_deploy_key` — generate / rotate the deploy key (returns the new public key for registration on GitHub / GitLab / Bitbucket)
- **Connection diagnostics**:
  - `list_git_connection_tests` — enumerate available diagnostic tests
  - `run_git_connection_test` — run a single test, returning pass/fail with a failure cause. Supports `remote_url` (remote-dependency tests) and `use_production` (test prod credentials).
- **Branch management**:
  - `get_git_branch_by_name` — inspect a specific branch by name
  - `delete_git_branch` — delete a local branch (sweeps abandoned dev branches)

### What's changed

- `deploy_to_production` now accepts optional `branch` and `ref` query params, matching the spec for `POST /projects/{id}/deploy_ref_to_production`. Without them the tool could only deploy the current dev ref. Omitting both preserves prior behavior.
- New tools URL-encode `project_id` and `branch_name` via the shared `_path_seg` helper, so branch names containing `/` (e.g. `feature/foo`) don't fan out into nested URL segments.

### Why this shape

`POST /git/deploy_key` returns the public key as a string body, which the existing httpx client handles transparently — no special parsing needed.

The connection-test endpoint is `GET` (not `POST`) per the spec, despite the action verb suggesting otherwise. The tool description matches the spec semantics.

`use_production` is documented as a string query param ('true' / 'false') rather than a bool, matching Looker's wire convention.

### Tests

New `tests/test_git_tools.py` covers:
- Tool-registration regression set (all 12 git tools must register)
- `deploy_to_production` schema includes `branch` and `ref`
- `delete_git_branch` issues `DELETE` to the right path
- **Branch-name path encoding** — proves `feature/foo` is encoded as `feature%2Ffoo` so it doesn't route to `git_branch/feature/foo`
- `deploy_to_production` passes `branch` + `ref` as query params
- `get_git_deploy_key` / `create_git_deploy_key` round-trip
- `run_git_connection_test` returns pass/fail and forwards `remote_url` + `use_production`

## Test plan

- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run pytest tests/ -q` — 252 passed
- [ ] Manual smoke against a live LookML project: rotate deploy key → register on GitHub → run \`run_git_connection_test\` to confirm green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch inspection and deletion
  * Deploy to production can target specific branch or ref
  * Deploy-key management: retrieve and rotate SSH deploy keys (raw key responses handled)
  * Git connection diagnostics: list and run tests
  * Project and branch identifiers consistently URL-encoded in paths

* **Tests**
  * Added comprehensive end-to-end tests for git tools

* **Documentation**
  * CHANGELOG updated with new git tool capabilities
<!-- end of auto-generated comment: release notes by coderabbit.ai -->