### PR TITLE
feat(admin): full WriteScheduledPlan surface on create/update_schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `recipients` parameters use `is not None` semantics rather than
   truthy checks, so an explicit empty list is detected as
   "argument supplied" rather than silently dropped.
+- Both `create_schedule` and `update_schedule` now reject the
+  `crontab` + `datagroup` combination up front (the two are mutually
+  exclusive trigger modes per the WriteScheduledPlan spec). Previously
+  the request would have been forwarded to Looker, which returns a
+  less actionable error.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `list_group_groups` — enumerate sub-groups under a parent.
   - `list_group_users` — enumerate direct user members of a group
     (visibility companion to `add_group_user` / `remove_group_user`).
+- **Full `WriteScheduledPlan` field surface on `create_schedule` and
+  `update_schedule`.** Every writable field of Looker's
+  `WriteScheduledPlan` schema is now reachable, so all delivery
+  configurations are setable from an MCP client:
+  - **Targets**: `lookml_dashboard_id` and `query_id` join the
+    existing `look_id` / `dashboard_id` (exactly one is required).
+  - **Destinations**: a new `destinations` parameter accepts the full
+    `ScheduledPlanDestination` array — supports `email`, `webhook`,
+    `s3`, and `sftp` types, with `format`, `apply_formatting`,
+    `apply_vis`, `parameters` (JSON string), `secret_parameters`
+    (write-only JSON for credentials), and `message`. The pre-existing
+    `recipients` shorthand still builds an email-only destinations
+    array; the two are mutually exclusive.
+  - **Conditional delivery**: `require_results`, `require_no_results`,
+    `require_change`, `send_all_results`.
+  - **Trigger options**: `enabled`, `run_once`, `datagroup`,
+    `timezone`, plus `user_id` for delegated ownership.
+  - **PDF/render options**: `pdf_paper_size`, `pdf_landscape`,
+    `long_tables`, `inline_table_width`, `color_theme`, `embed`.
+  - **Branded URLs**: `show_custom_url`, `custom_url_base`,
+    `custom_url_params`, `custom_url_label`.
+  - **Filters**: `filters_string`.
 
 ### Changed
 
@@ -70,6 +92,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `update_user` returns an actionable error when no fields are
   provided (matching the pattern already used by `update_schedule`),
   rather than issuing an empty PATCH.
+- `create_schedule` now validates that **exactly one** of `look_id`,
+  `dashboard_id`, `lookml_dashboard_id`, or `query_id` is provided —
+  returns an actionable error otherwise (previously, omitting all four
+  was silently accepted and rejected later by Looker).
+- `update_schedule` and `create_schedule`'s `destinations` and
+  `recipients` parameters use `is not None` semantics rather than
+  truthy checks, so an explicit empty list is detected as
+  "argument supplied" rather than silently dropped.
 
 ### Removed
 

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -1121,6 +1121,42 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                     },
                     indent=2,
                 )
+            # Trigger required: a schedule with neither crontab nor datagroup
+            # has no way to fire. Reject up front rather than letting Looker
+            # 422 with a less actionable message.
+            if crontab is None and datagroup is None:
+                return json.dumps(
+                    {
+                        "error": "No trigger provided.",
+                        "hint": (
+                            "Pass either ``crontab`` (time-based) or "
+                            "``datagroup`` (data-refresh-based)."
+                        ),
+                    },
+                    indent=2,
+                )
+            # Destination required: a schedule with no destinations cannot
+            # deliver. Resolve destinations vs. recipients shorthand once and
+            # reject if the resolved list is empty (handles destinations=[]
+            # with no fallback recipients, and the both-None case).
+            resolved_destinations: list[dict[str, Any]] | None = None
+            if destinations is not None:
+                resolved_destinations = destinations
+            elif recipients is not None:
+                resolved_destinations = [{"type": "email", "address": addr} for addr in recipients]
+            if not resolved_destinations:
+                return json.dumps(
+                    {
+                        "error": "No destinations provided.",
+                        "hint": (
+                            "Pass at least one entry via ``destinations`` "
+                            "(full ScheduledPlanDestination shape) or "
+                            "``recipients`` (email shorthand). A schedule "
+                            "with no destinations cannot deliver."
+                        ),
+                    },
+                    indent=2,
+                )
 
             async with client.session(ctx) as session:
                 body: dict[str, Any] = {"name": name}
@@ -1152,15 +1188,9 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                 _set_if(body, "custom_url_params", custom_url_params)
                 _set_if(body, "custom_url_label", custom_url_label)
 
-                # Match update_schedule's `is not None` semantics so an
-                # explicit empty list serializes as scheduled_plan_destination=[]
-                # rather than being silently dropped.
-                if destinations is not None:
-                    body["scheduled_plan_destination"] = destinations
-                elif recipients is not None:
-                    body["scheduled_plan_destination"] = [
-                        {"type": "email", "address": addr} for addr in recipients
-                    ]
+                # The resolved destinations list was computed and validated
+                # in the preflight above; reuse it directly.
+                body["scheduled_plan_destination"] = resolved_destinations
 
                 schedule = await session.post("/scheduled_plans", body=body)
                 return json.dumps(
@@ -1292,6 +1322,25 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                         "hint": (
                             "Use ``crontab`` for time-based delivery, ``datagroup`` "
                             "for delivery on data refresh."
+                        ),
+                    },
+                    indent=2,
+                )
+            # Mirror create_schedule's at-most-one-target guard. A schedule
+            # has exactly one source (look / dashboard / lookml_dashboard /
+            # query) — retargeting to multiple at once is ambiguous and
+            # would push an avoidable validation error to Looker.
+            update_target_count = sum(
+                1 for v in (look_id, dashboard_id, lookml_dashboard_id, query_id) if v is not None
+            )
+            if update_target_count > 1:
+                return json.dumps(
+                    {
+                        "error": "Multiple targets provided.",
+                        "hint": (
+                            "Pass at most one of look_id, dashboard_id, "
+                            "lookml_dashboard_id, query_id when retargeting an "
+                            "existing schedule."
                         ),
                     },
                     indent=2,

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -930,29 +930,212 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
-            "Create a scheduled delivery plan for a Look or dashboard. "
-            "Supports email, webhook, S3, SFTP, and other destinations."
+            "Create a scheduled delivery plan for a Look, dashboard, LookML "
+            "dashboard, or query. Exposes every writable ``WriteScheduledPlan`` "
+            "field, so all delivery types (email, webhook, S3, SFTP), conditional "
+            "delivery (require_results / require_no_results / require_change), "
+            "PDF/render options, custom branded URLs, datagroup triggers, and "
+            "delegated ownership are reachable.\n\n"
+            "Targeting: pass exactly one of ``look_id``, ``dashboard_id``, "
+            "``lookml_dashboard_id``, or ``query_id`` to choose what gets "
+            "delivered.\n\n"
+            "Destinations: prefer ``destinations`` (full ``ScheduledPlanDestination`` "
+            "shape, supports email/webhook/s3/sftp). ``recipients`` is a "
+            "shorthand that builds an email-only destinations array — useful "
+            "for simple cases. Pass at most one."
         ),
     )
     async def create_schedule(
         name: Annotated[str, "Schedule name"],
-        crontab: Annotated[str, "Cron expression (e.g. '0 9 * * 1' for Mondays at 9am)"],
+        crontab: Annotated[
+            str | None,
+            (
+                "Cron expression (e.g. '0 9 * * 1' for Mondays at 9am). "
+                "Mutually exclusive with ``datagroup`` — pass exactly one."
+            ),
+        ] = None,
+        # ── Target (pick one) ────────────────────────────────────────
         look_id: Annotated[str | None, "Look ID to schedule"] = None,
         dashboard_id: Annotated[str | None, "Dashboard ID to schedule"] = None,
-        recipients: Annotated[list[str] | None, "Email recipients"] = None,
+        lookml_dashboard_id: Annotated[str | None, "LookML dashboard ID to schedule"] = None,
+        query_id: Annotated[str | None, "Query ID to schedule"] = None,
+        # ── Destinations ─────────────────────────────────────────────
+        recipients: Annotated[
+            list[str] | None,
+            "Email-only shorthand: each address becomes an email destination",
+        ] = None,
+        destinations: Annotated[
+            list[dict[str, Any]] | None,
+            (
+                "Full ``ScheduledPlanDestination`` array. Each entry accepts: "
+                "``type`` ('email'|'webhook'|'s3'|'sftp'), ``address``, "
+                "``format``, ``apply_formatting``, ``apply_vis``, ``message``, "
+                "``parameters`` (JSON string for s3/sftp/webhook), and "
+                "``secret_parameters`` (write-only JSON string for credentials)."
+            ),
+        ] = None,
+        # ── Ownership ────────────────────────────────────────────────
+        user_id: Annotated[
+            str | None,
+            (
+                "Owner user id (defaults to the calling user). Lets admins "
+                "schedule on behalf of others."
+            ),
+        ] = None,
+        run_as_recipient: Annotated[
+            bool | None,
+            "Run as each recipient — only applies to email destinations",
+        ] = None,
+        # ── Trigger options ──────────────────────────────────────────
+        enabled: Annotated[bool | None, "Whether the plan is active"] = None,
+        run_once: Annotated[
+            bool | None,
+            "Run only one time, then disable (good for tests)",
+        ] = None,
+        datagroup: Annotated[
+            str | None,
+            (
+                "Datagroup name — runs when the datagroup triggers. "
+                "Mutually exclusive with ``crontab``."
+            ),
+        ] = None,
+        timezone: Annotated[
+            str | None,
+            "Timezone for the crontab (default: Looker instance timezone)",
+        ] = None,
+        # ── Conditional delivery ─────────────────────────────────────
+        require_results: Annotated[
+            bool | None,
+            "Only deliver when the dashboard/look returns rows",
+        ] = None,
+        require_no_results: Annotated[
+            bool | None,
+            "Only deliver when the dashboard/look returns NO rows (alerting on empty)",
+        ] = None,
+        require_change: Annotated[
+            bool | None,
+            "Only deliver when results changed since the last run",
+        ] = None,
+        send_all_results: Annotated[
+            bool | None,
+            "Run an unlimited query and send all results (overrides default row caps)",
+        ] = None,
+        # ── Filters ──────────────────────────────────────────────────
+        filters_string: Annotated[
+            str | None,
+            "Query string applied to the look/dashboard at delivery time",
+        ] = None,
+        # ── Render / PDF options ─────────────────────────────────────
+        include_links: Annotated[
+            bool | None,
+            "Include links back to Looker in the delivered content",
+        ] = None,
+        pdf_paper_size: Annotated[
+            str | None,
+            "PDF paper size: 'letter', 'legal', 'tabloid', 'a0'..'a4'",
+        ] = None,
+        pdf_landscape: Annotated[bool | None, "PDF landscape orientation"] = None,
+        long_tables: Annotated[
+            bool | None,
+            "Expand table visualizations to full length (no row caps in PDF)",
+        ] = None,
+        inline_table_width: Annotated[
+            int | None,
+            "Pixel width for inline table visualizations",
+        ] = None,
+        color_theme: Annotated[
+            str | None,
+            "Color scheme name applied to the dashboard at delivery time",
+        ] = None,
+        embed: Annotated[bool | None, "Treat as an embed-context schedule"] = None,
+        # ── Branded / custom URLs ────────────────────────────────────
+        show_custom_url: Annotated[
+            bool | None,
+            "Show the custom link instead of the Looker link",
+        ] = None,
+        custom_url_base: Annotated[str | None, "Custom URL domain for the scheduled entity"] = None,
+        custom_url_params: Annotated[
+            str | None,
+            "Custom URL path and query params for the scheduled entity",
+        ] = None,
+        custom_url_label: Annotated[str | None, "Custom URL label text"] = None,
     ) -> str:
         ctx = client.build_context("create_schedule", "admin")
         try:
+            if recipients and destinations:
+                return json.dumps(
+                    {
+                        "error": "Pass either ``recipients`` or ``destinations``, not both.",
+                        "hint": (
+                            "``recipients`` is a shorthand that builds an email-only "
+                            "destinations array — pass it OR ``destinations``."
+                        ),
+                    },
+                    indent=2,
+                )
+            target_count = sum(
+                1 for v in (look_id, dashboard_id, lookml_dashboard_id, query_id) if v is not None
+            )
+            if target_count == 0:
+                return json.dumps(
+                    {
+                        "error": "No target provided.",
+                        "hint": (
+                            "Pass exactly one of look_id, dashboard_id, "
+                            "lookml_dashboard_id, query_id."
+                        ),
+                    },
+                    indent=2,
+                )
+            if target_count > 1:
+                return json.dumps(
+                    {
+                        "error": "Multiple targets provided.",
+                        "hint": (
+                            "Pass exactly one of look_id, dashboard_id, "
+                            "lookml_dashboard_id, query_id."
+                        ),
+                    },
+                    indent=2,
+                )
+
             async with client.session(ctx) as session:
-                body: dict[str, Any] = {"name": name, "crontab": crontab}
-                if look_id:
-                    body["look_id"] = look_id
-                if dashboard_id:
-                    body["dashboard_id"] = dashboard_id
-                if recipients:
+                body: dict[str, Any] = {"name": name}
+                _set_if(body, "crontab", crontab)
+                _set_if(body, "look_id", look_id)
+                _set_if(body, "dashboard_id", dashboard_id)
+                _set_if(body, "lookml_dashboard_id", lookml_dashboard_id)
+                _set_if(body, "query_id", query_id)
+                _set_if(body, "user_id", user_id)
+                _set_if(body, "run_as_recipient", run_as_recipient)
+                _set_if(body, "enabled", enabled)
+                _set_if(body, "run_once", run_once)
+                _set_if(body, "datagroup", datagroup)
+                _set_if(body, "timezone", timezone)
+                _set_if(body, "require_results", require_results)
+                _set_if(body, "require_no_results", require_no_results)
+                _set_if(body, "require_change", require_change)
+                _set_if(body, "send_all_results", send_all_results)
+                _set_if(body, "filters_string", filters_string)
+                _set_if(body, "include_links", include_links)
+                _set_if(body, "pdf_paper_size", pdf_paper_size)
+                _set_if(body, "pdf_landscape", pdf_landscape)
+                _set_if(body, "long_tables", long_tables)
+                _set_if(body, "inline_table_width", inline_table_width)
+                _set_if(body, "color_theme", color_theme)
+                _set_if(body, "embed", embed)
+                _set_if(body, "show_custom_url", show_custom_url)
+                _set_if(body, "custom_url_base", custom_url_base)
+                _set_if(body, "custom_url_params", custom_url_params)
+                _set_if(body, "custom_url_label", custom_url_label)
+
+                if destinations:
+                    body["scheduled_plan_destination"] = destinations
+                elif recipients:
                     body["scheduled_plan_destination"] = [
                         {"type": "email", "address": addr} for addr in recipients
                     ]
+
                 schedule = await session.post("/scheduled_plans", body=body)
                 return json.dumps(
                     {"id": schedule.get("id"), "name": schedule.get("name")}, indent=2
@@ -975,10 +1158,14 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "Update a scheduled delivery plan. Only provided fields are "
-            "changed; omitted fields are preserved. Use to retarget the "
-            "recipient, change the cron schedule, or toggle enabled state "
-            "without rebuilding the plan. Returns an actionable error when "
-            "no fields are supplied."
+            "changed; omitted fields are preserved. Exposes every writable "
+            "``WriteScheduledPlan`` field, so any aspect of an existing plan "
+            "can be retargeted, rescheduled, re-routed, or reconfigured "
+            "without rebuilding it. Returns an actionable error when no "
+            "fields are supplied.\n\n"
+            "Destinations: ``destinations`` and ``recipients`` are mutually "
+            "exclusive. Setting either replaces the full destination list — "
+            "passing an empty list clears all destinations."
         ),
     )
     async def update_schedule(
@@ -987,29 +1174,133 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
         crontab: Annotated[
             str | None, "New cron expression (e.g. '0 9 * * *' for 9am daily)"
         ] = None,
-        enabled: Annotated[bool | None, "Enable or disable the schedule"] = None,
-        run_as_recipient: Annotated[
-            bool | None, "Run the schedule impersonating each recipient"
+        # ── Target (retarget the schedule's source) ─────────────────
+        look_id: Annotated[str | None, "New look_id"] = None,
+        dashboard_id: Annotated[str | None, "New dashboard_id"] = None,
+        lookml_dashboard_id: Annotated[str | None, "New lookml_dashboard_id"] = None,
+        query_id: Annotated[str | None, "New query_id"] = None,
+        # ── Destinations ─────────────────────────────────────────────
+        recipients: Annotated[
+            list[str] | None,
+            "Email-only shorthand that replaces the destinations list",
         ] = None,
+        destinations: Annotated[
+            list[dict[str, Any]] | None,
+            (
+                "Full ``ScheduledPlanDestination`` array that replaces the "
+                "existing destinations list. See ``create_schedule`` for the "
+                "accepted shape. Pass an empty list to clear all destinations."
+            ),
+        ] = None,
+        # ── Ownership ────────────────────────────────────────────────
+        user_id: Annotated[str | None, "Reassign owner user id"] = None,
+        run_as_recipient: Annotated[
+            bool | None,
+            "Run the schedule impersonating each recipient (email destinations only)",
+        ] = None,
+        # ── Trigger options ──────────────────────────────────────────
+        enabled: Annotated[bool | None, "Enable or disable the schedule"] = None,
+        run_once: Annotated[bool | None, "Toggle run-once mode"] = None,
+        datagroup: Annotated[
+            str | None,
+            "Datagroup name (mutually exclusive with crontab)",
+        ] = None,
+        timezone: Annotated[str | None, "New crontab timezone"] = None,
+        # ── Conditional delivery ─────────────────────────────────────
+        require_results: Annotated[
+            bool | None,
+            "Toggle delivery-only-when-results condition",
+        ] = None,
+        require_no_results: Annotated[
+            bool | None,
+            "Toggle delivery-only-when-no-results condition",
+        ] = None,
+        require_change: Annotated[
+            bool | None,
+            "Toggle delivery-only-when-results-changed condition",
+        ] = None,
+        send_all_results: Annotated[
+            bool | None,
+            "Toggle unlimited-result mode (no row caps)",
+        ] = None,
+        # ── Filters ──────────────────────────────────────────────────
+        filters_string: Annotated[str | None, "New filters_string"] = None,
+        # ── Render / PDF options ─────────────────────────────────────
         include_links: Annotated[bool | None, "Include links in the scheduled content"] = None,
+        pdf_paper_size: Annotated[str | None, "New PDF paper size"] = None,
+        pdf_landscape: Annotated[bool | None, "Toggle PDF landscape orientation"] = None,
+        long_tables: Annotated[bool | None, "Toggle long-table rendering"] = None,
+        inline_table_width: Annotated[int | None, "New inline-table pixel width"] = None,
+        color_theme: Annotated[str | None, "New dashboard color theme"] = None,
+        embed: Annotated[bool | None, "Toggle embed-context flag"] = None,
+        # ── Branded / custom URLs ────────────────────────────────────
+        show_custom_url: Annotated[bool | None, "Toggle custom-link visibility"] = None,
+        custom_url_base: Annotated[str | None, "New custom URL base"] = None,
+        custom_url_params: Annotated[str | None, "New custom URL params"] = None,
+        custom_url_label: Annotated[str | None, "New custom URL label"] = None,
     ) -> str:
         ctx = client.build_context("update_schedule", "admin", {"schedule_id": schedule_id})
         try:
+            if recipients is not None and destinations is not None:
+                return json.dumps(
+                    {
+                        "error": "Pass either ``recipients`` or ``destinations``, not both.",
+                        "hint": (
+                            "``recipients`` is a shorthand that builds an email-only "
+                            "destinations array — pass it OR ``destinations``."
+                        ),
+                    },
+                    indent=2,
+                )
+
             async with client.session(ctx) as session:
                 body: dict[str, Any] = {}
                 _set_if(body, "name", name)
                 _set_if(body, "crontab", crontab)
-                _set_if(body, "enabled", enabled)
+                _set_if(body, "look_id", look_id)
+                _set_if(body, "dashboard_id", dashboard_id)
+                _set_if(body, "lookml_dashboard_id", lookml_dashboard_id)
+                _set_if(body, "query_id", query_id)
+                _set_if(body, "user_id", user_id)
                 _set_if(body, "run_as_recipient", run_as_recipient)
+                _set_if(body, "enabled", enabled)
+                _set_if(body, "run_once", run_once)
+                _set_if(body, "datagroup", datagroup)
+                _set_if(body, "timezone", timezone)
+                _set_if(body, "require_results", require_results)
+                _set_if(body, "require_no_results", require_no_results)
+                _set_if(body, "require_change", require_change)
+                _set_if(body, "send_all_results", send_all_results)
+                _set_if(body, "filters_string", filters_string)
                 _set_if(body, "include_links", include_links)
+                _set_if(body, "pdf_paper_size", pdf_paper_size)
+                _set_if(body, "pdf_landscape", pdf_landscape)
+                _set_if(body, "long_tables", long_tables)
+                _set_if(body, "inline_table_width", inline_table_width)
+                _set_if(body, "color_theme", color_theme)
+                _set_if(body, "embed", embed)
+                _set_if(body, "show_custom_url", show_custom_url)
+                _set_if(body, "custom_url_base", custom_url_base)
+                _set_if(body, "custom_url_params", custom_url_params)
+                _set_if(body, "custom_url_label", custom_url_label)
+
+                # destinations / recipients use `is not None` (not `_set_if`) so an
+                # empty list is forwarded — that's how the Looker API clears
+                # all destinations.
+                if destinations is not None:
+                    body["scheduled_plan_destination"] = destinations
+                elif recipients is not None:
+                    body["scheduled_plan_destination"] = [
+                        {"type": "email", "address": addr} for addr in recipients
+                    ]
 
                 if not body:
                     return json.dumps(
                         {
                             "error": "No fields provided to update.",
                             "hint": (
-                                "Pass at least one of: name, crontab, enabled, "
-                                "run_as_recipient, include_links."
+                                "Pass at least one writable WriteScheduledPlan field. "
+                                "See the tool description for the full list."
                             ),
                         },
                         indent=2,

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -964,6 +964,17 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
             list[str] | None,
             "Email-only shorthand: each address becomes an email destination",
         ] = None,
+        email_format: Annotated[
+            str,
+            (
+                "Format for the ``recipients`` shorthand's email destinations. "
+                "Looker requires every destination to specify a format. Defaults "
+                "to ``wysiwyg_pdf`` (Looker UI's default for dashboard email "
+                "schedules). Other common values: ``csv``, ``xlsx``, ``html``, "
+                "``json_detail``, ``assembled_pdf``. Ignored when "
+                "``destinations`` is used (set ``format`` per destination there)."
+            ),
+        ] = "wysiwyg_pdf",
         destinations: Annotated[
             list[dict[str, Any]] | None,
             (
@@ -1143,7 +1154,10 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
             if destinations is not None:
                 resolved_destinations = destinations
             elif recipients is not None:
-                resolved_destinations = [{"type": "email", "address": addr} for addr in recipients]
+                resolved_destinations = [
+                    {"type": "email", "address": addr, "format": email_format}
+                    for addr in recipients
+                ]
             if not resolved_destinations:
                 return json.dumps(
                     {
@@ -1243,6 +1257,15 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
             list[str] | None,
             "Email-only shorthand that replaces the destinations list",
         ] = None,
+        email_format: Annotated[
+            str,
+            (
+                "Format for the ``recipients`` shorthand's email destinations. "
+                "Looker requires every destination to specify a format. Defaults "
+                "to ``wysiwyg_pdf``. See ``create_schedule`` for the full list "
+                "of supported values."
+            ),
+        ] = "wysiwyg_pdf",
         destinations: Annotated[
             list[dict[str, Any]] | None,
             (
@@ -1409,7 +1432,8 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                     body["scheduled_plan_destination"] = destinations
                 elif recipients is not None:
                     body["scheduled_plan_destination"] = [
-                        {"type": "email", "address": addr} for addr in recipients
+                        {"type": "email", "address": addr, "format": email_format}
+                        for addr in recipients
                     ]
 
                 if not body:

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -1062,13 +1062,36 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
     ) -> str:
         ctx = client.build_context("create_schedule", "admin")
         try:
-            if recipients and destinations:
+            # Use ``is not None`` semantics throughout so an explicit empty list
+            # (recipients=[] or destinations=[]) is detected as "the caller
+            # named this argument" rather than "the caller omitted it." Truthy
+            # checks let recipients=[] slip past the mutual-exclusion guard,
+            # which then writes the wrong destinations block.
+            if recipients is not None and destinations is not None:
                 return json.dumps(
                     {
                         "error": "Pass either ``recipients`` or ``destinations``, not both.",
                         "hint": (
                             "``recipients`` is a shorthand that builds an email-only "
                             "destinations array — pass it OR ``destinations``."
+                        ),
+                    },
+                    indent=2,
+                )
+            # crontab and datagroup are mutually exclusive trigger modes per
+            # the WriteScheduledPlan spec ("can't be used in combination with
+            # crontab"). Reject the combination up front rather than letting
+            # Looker return a less actionable 422.
+            if crontab is not None and datagroup is not None:
+                return json.dumps(
+                    {
+                        "error": (
+                            "``crontab`` and ``datagroup`` are mutually exclusive "
+                            "trigger modes — pass exactly one."
+                        ),
+                        "hint": (
+                            "Use ``crontab`` for time-based delivery, ``datagroup`` "
+                            "for delivery on data refresh."
                         ),
                     },
                     indent=2,
@@ -1129,9 +1152,12 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                 _set_if(body, "custom_url_params", custom_url_params)
                 _set_if(body, "custom_url_label", custom_url_label)
 
-                if destinations:
+                # Match update_schedule's `is not None` semantics so an
+                # explicit empty list serializes as scheduled_plan_destination=[]
+                # rather than being silently dropped.
+                if destinations is not None:
                     body["scheduled_plan_destination"] = destinations
-                elif recipients:
+                elif recipients is not None:
                     body["scheduled_plan_destination"] = [
                         {"type": "email", "address": addr} for addr in recipients
                     ]
@@ -1248,6 +1274,24 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                         "hint": (
                             "``recipients`` is a shorthand that builds an email-only "
                             "destinations array — pass it OR ``destinations``."
+                        ),
+                    },
+                    indent=2,
+                )
+            # crontab and datagroup are mutually exclusive trigger modes per
+            # the WriteScheduledPlan spec. On update either one can clear the
+            # other (the new value overrides), so reject only the case where
+            # both are explicitly provided in the same call.
+            if crontab is not None and datagroup is not None:
+                return json.dumps(
+                    {
+                        "error": (
+                            "``crontab`` and ``datagroup`` are mutually exclusive "
+                            "trigger modes — pass exactly one."
+                        ),
+                        "hint": (
+                            "Use ``crontab`` for time-based delivery, ``datagroup`` "
+                            "for delivery on data refresh."
                         ),
                     },
                     indent=2,

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -1220,8 +1220,11 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
             "without rebuilding it. Returns an actionable error when no "
             "fields are supplied.\n\n"
             "Destinations: ``destinations`` and ``recipients`` are mutually "
-            "exclusive. Setting either replaces the full destination list — "
-            "passing an empty list clears all destinations."
+            "exclusive. Setting either replaces the full destination list "
+            "with the provided entries. Looker requires every ScheduledPlan "
+            "to have at least one destination, so an empty list is rejected "
+            "up front; to leave existing destinations unchanged, omit both "
+            "arguments."
         ),
     )
     async def update_schedule(
@@ -1345,6 +1348,26 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                     },
                     indent=2,
                 )
+            # Looker requires every ScheduledPlan to have at least one
+            # destination — an empty array is rejected with a 422. Catch
+            # this preflight and return an actionable error.
+            if destinations == [] or (recipients == [] and destinations is None):
+                return json.dumps(
+                    {
+                        "error": (
+                            "Empty destination list is not allowed — "
+                            "Looker requires every ScheduledPlan to have "
+                            "at least one destination."
+                        ),
+                        "hint": (
+                            "To replace destinations, pass a non-empty "
+                            "list. To leave existing destinations "
+                            "unchanged, omit both ``destinations`` and "
+                            "``recipients`` from the call."
+                        ),
+                    },
+                    indent=2,
+                )
 
             async with client.session(ctx) as session:
                 body: dict[str, Any] = {}
@@ -1377,9 +1400,11 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                 _set_if(body, "custom_url_params", custom_url_params)
                 _set_if(body, "custom_url_label", custom_url_label)
 
-                # destinations / recipients use `is not None` (not `_set_if`) so an
-                # empty list is forwarded — that's how the Looker API clears
-                # all destinations.
+                # destinations / recipients use `is not None` (not
+                # `_set_if`) so a non-empty list explicitly replaces
+                # existing destinations. Omitting both leaves them
+                # untouched. (Empty-list rejection happens preflight
+                # because Looker rejects empty arrays.)
                 if destinations is not None:
                     body["scheduled_plan_destination"] = destinations
                 elif recipients is not None:

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -375,6 +375,24 @@ class TestUpdateScheduleAdvanced:
         finally:
             await looker_client.close()
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_update_rejects_multiple_targets(self, config):
+        # A schedule has exactly one source (look / dashboard / lookml /
+        # query). Retargeting to multiple at once is ambiguous and would
+        # 422 at Looker. Mirror create_schedule's at-most-one-target guard.
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "update_schedule",
+                {"schedule_id": "42", "look_id": "1", "dashboard_id": "2"},
+            )()
+            assert "Multiple targets" in payload["error"]
+            assert list(respx.calls) == []
+        finally:
+            await looker_client.close()
+
 
 class TestScheduleTriggerValidation:
     """`crontab` and `datagroup` are mutually exclusive trigger modes per the
@@ -459,22 +477,14 @@ class TestCreateScheduleEmptyListSemantics:
 
     @pytest.mark.asyncio
     @respx.mock
-    async def test_destinations_empty_list_creates_with_no_destinations(self, config):
-        # On create, destinations=[] is unusual but legitimate — schedules
-        # without destinations are valid (test-only stubs, etc).
-        _mock_login_logout()
-
-        captured: dict = {}
-
-        def capture(request: httpx.Request) -> httpx.Response:
-            captured["body"] = json.loads(request.content.decode())
-            return httpx.Response(201, json={"id": "9"})
-
-        respx.post(f"{API_URL}/scheduled_plans").mock(side_effect=capture)
-
+    async def test_create_with_empty_destinations_is_rejected(self, config):
+        # A schedule with no destinations cannot deliver. Reject up front
+        # rather than letting Looker 422 with a less actionable message.
+        # (On UPDATE, destinations=[] stays valid — that's how you clear
+        # a previously-set destinations list.)
         mcp, looker_client = create_server(config, enabled_groups={"admin"})
         try:
-            await _invoke_tool(
+            payload = await _invoke_tool(
                 mcp,
                 "create_schedule",
                 {
@@ -484,8 +494,48 @@ class TestCreateScheduleEmptyListSemantics:
                     "destinations": [],
                 },
             )()
-            # The empty list is forwarded — matches update_schedule's behavior.
-            assert captured["body"]["scheduled_plan_destination"] == []
+            assert "No destinations" in payload["error"]
+            # Short-circuited before any HTTP — proves the guard runs
+            # preflight rather than after burning a login round-trip.
+            assert list(respx.calls) == []
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_with_no_destinations_or_recipients_is_rejected(self, config):
+        # The both-None case (omitting recipients AND destinations) is
+        # equivalent to passing an empty list — same rejection path.
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {"name": "x", "crontab": "0 9 * * *", "dashboard_id": "1"},
+            )()
+            assert "No destinations" in payload["error"]
+            assert list(respx.calls) == []
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_with_no_trigger_is_rejected(self, config):
+        # A schedule with neither crontab nor datagroup has no way to
+        # fire. Reject up front.
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "x",
+                    "dashboard_id": "1",
+                    "recipients": ["a@x.com"],
+                },
+            )()
+            assert "No trigger" in payload["error"]
+            assert list(respx.calls) == []
         finally:
             await looker_client.close()
 

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -376,6 +376,120 @@ class TestUpdateScheduleAdvanced:
             await looker_client.close()
 
 
+class TestScheduleTriggerValidation:
+    """`crontab` and `datagroup` are mutually exclusive trigger modes per the
+    WriteScheduledPlan spec — Looker rejects requests that set both. The tool
+    catches this up front so callers see an actionable error attributing the
+    failure to the offending parameters, not a Looker 422.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_rejects_both_crontab_and_datagroup(self, config):
+        _mock_login_logout()
+        # No POST mock — guard must short-circuit before any HTTP.
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "x",
+                    "dashboard_id": "1",
+                    "crontab": "0 9 * * *",
+                    "datagroup": "daily_etl",
+                },
+            )()
+            assert "mutually exclusive" in payload["error"]
+            post_calls = [c for c in respx.calls if c.request.method == "POST"]
+            assert post_calls == []
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_update_rejects_both_crontab_and_datagroup(self, config):
+        _mock_login_logout()
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "update_schedule",
+                {"schedule_id": "42", "crontab": "0 9 * * *", "datagroup": "daily_etl"},
+            )()
+            assert "mutually exclusive" in payload["error"]
+            patch_calls = [c for c in respx.calls if c.request.method == "PATCH"]
+            assert patch_calls == []
+        finally:
+            await looker_client.close()
+
+
+class TestCreateScheduleEmptyListSemantics:
+    """`recipients=[]` and `destinations=[]` must be treated as "the caller
+    explicitly cleared the destination list," not as "the caller omitted
+    these arguments." Truthy checks would silently let recipients=[]
+    bypass the mutual-exclusion guard.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_recipients_and_destinations_both_provided_is_rejected(self, config):
+        _mock_login_logout()
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            # With truthy checks, empty lists fall through and BOTH are
+            # accepted. With `is not None`, this is a mutual-exclusion error.
+            payload = await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "x",
+                    "crontab": "0 9 * * *",
+                    "dashboard_id": "1",
+                    "recipients": [],
+                    "destinations": [],
+                },
+            )()
+            assert "not both" in payload["error"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_destinations_empty_list_creates_with_no_destinations(self, config):
+        # On create, destinations=[] is unusual but legitimate — schedules
+        # without destinations are valid (test-only stubs, etc).
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "9"})
+
+        respx.post(f"{API_URL}/scheduled_plans").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "x",
+                    "crontab": "0 9 * * *",
+                    "dashboard_id": "1",
+                    "destinations": [],
+                },
+            )()
+            # The empty list is forwarded — matches update_schedule's behavior.
+            assert captured["body"]["scheduled_plan_destination"] == []
+        finally:
+            await looker_client.close()
+
+
 class TestRunScheduleOnce:
     @pytest.mark.asyncio
     @respx.mock

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -197,8 +197,46 @@ class TestCreateScheduleSurface:
                 },
             )()
             assert captured["body"]["scheduled_plan_destination"] == [
-                {"type": "email", "address": "a@x.com"},
-                {"type": "email", "address": "b@x.com"},
+                # Recipients shorthand always sets format — Looker rejects
+                # destinations without one. Default is ``wysiwyg_pdf`` (Looker
+                # UI's default for dashboard email schedules).
+                {"type": "email", "address": "a@x.com", "format": "wysiwyg_pdf"},
+                {"type": "email", "address": "b@x.com", "format": "wysiwyg_pdf"},
+            ]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_email_format_override_for_recipients_shorthand(self, config):
+        # Common scenario: emailing a Look's data as CSV instead of the
+        # default PDF. The email_format param overrides per-call so callers
+        # don't have to fall back to the full destinations shape.
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "1", "name": "weekly-csv"})
+
+        respx.post(f"{API_URL}/scheduled_plans").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "weekly-csv",
+                    "crontab": "0 9 * * 1",
+                    "look_id": "42",
+                    "recipients": ["a@x.com"],
+                    "email_format": "csv",
+                },
+            )()
+            assert captured["body"]["scheduled_plan_destination"] == [
+                {"type": "email", "address": "a@x.com", "format": "csv"},
             ]
         finally:
             await looker_client.close()

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -437,9 +437,9 @@ class TestScheduleTriggerValidation:
     @pytest.mark.asyncio
     @respx.mock
     async def test_create_rejects_both_crontab_and_datagroup(self, config):
-        _mock_login_logout()
-        # No POST mock — guard must short-circuit before any HTTP.
-
+        # No login or HTTP mocks of any kind — the preflight guard must
+        # short-circuit before opening a Looker session, so the entire
+        # respx.calls log should stay empty.
         mcp, looker_client = create_server(config, enabled_groups={"admin"})
         try:
             payload = await _invoke_tool(
@@ -453,16 +453,17 @@ class TestScheduleTriggerValidation:
                 },
             )()
             assert "mutually exclusive" in payload["error"]
-            post_calls = [c for c in respx.calls if c.request.method == "POST"]
-            assert post_calls == []
+            assert list(respx.calls) == [], (
+                "guard fired but a Looker session was still opened — "
+                "validation should run before client.session()"
+            )
         finally:
             await looker_client.close()
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_update_rejects_both_crontab_and_datagroup(self, config):
-        _mock_login_logout()
-
+        # Same zero-HTTP invariant as the create-side test above.
         mcp, looker_client = create_server(config, enabled_groups={"admin"})
         try:
             payload = await _invoke_tool(
@@ -471,8 +472,10 @@ class TestScheduleTriggerValidation:
                 {"schedule_id": "42", "crontab": "0 9 * * *", "datagroup": "daily_etl"},
             )()
             assert "mutually exclusive" in payload["error"]
-            patch_calls = [c for c in respx.calls if c.request.method == "PATCH"]
-            assert patch_calls == []
+            assert list(respx.calls) == [], (
+                "guard fired but a Looker session was still opened — "
+                "validation should run before client.session()"
+            )
         finally:
             await looker_client.close()
 

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -350,28 +350,23 @@ class TestCreateScheduleSurface:
 class TestUpdateScheduleAdvanced:
     @pytest.mark.asyncio
     @respx.mock
-    async def test_destinations_replace_supports_clearing(self, config):
-        # Passing destinations=[] (empty list) must reach Looker so it clears
-        # the existing destinations — _set_if would have stripped this, the
-        # tool uses `is not None` instead.
-        _mock_login_logout()
-
-        captured: dict = {}
-
-        def capture(request: httpx.Request) -> httpx.Response:
-            captured["body"] = json.loads(request.content.decode())
-            return httpx.Response(200, json={"id": "42"})
-
-        respx.patch(f"{API_URL}/scheduled_plans/42").mock(side_effect=capture)
-
+    async def test_update_rejects_empty_destinations(self, config):
+        # Looker requires every ScheduledPlan to always have at least one
+        # destination — an empty array is rejected with a 422. The tool
+        # catches this preflight and returns an actionable error instead.
+        # (Original test expected pass-through, which CodeRabbit's spec
+        # research showed is wrong — Looker rejects the request.)
         mcp, looker_client = create_server(config, enabled_groups={"admin"})
         try:
-            await _invoke_tool(
+            payload = await _invoke_tool(
                 mcp,
                 "update_schedule",
                 {"schedule_id": "42", "destinations": []},
             )()
-            assert captured["body"] == {"scheduled_plan_destination": []}
+            assert "Empty destination list is not allowed" in payload["error"]
+            assert list(respx.calls) == [], (
+                "empty-destinations path opened a Looker session — should short-circuit preflight"
+            )
         finally:
             await looker_client.close()
 

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -107,6 +107,275 @@ class TestUpdateSchedule:
             await looker_client.close()
 
 
+WRITABLE_SCHEDULE_FIELDS = {
+    "name",
+    "user_id",
+    "run_as_recipient",
+    "enabled",
+    "look_id",
+    "dashboard_id",
+    "lookml_dashboard_id",
+    "filters_string",
+    "require_results",
+    "require_no_results",
+    "require_change",
+    "send_all_results",
+    "crontab",
+    "datagroup",
+    "timezone",
+    "run_once",
+    "include_links",
+    "custom_url_base",
+    "custom_url_params",
+    "custom_url_label",
+    "show_custom_url",
+    "pdf_paper_size",
+    "pdf_landscape",
+    "embed",
+    "color_theme",
+    "long_tables",
+    "inline_table_width",
+    "query_id",
+    # Destinations are exposed as two flat params (recipients + destinations),
+    # not a single nested array — keeps the tool surface ergonomic.
+    "recipients",
+    "destinations",
+}
+
+
+class TestCreateScheduleSurface:
+    """The full WriteScheduledPlan surface must be reachable on create_schedule
+    so agents can configure conditional delivery, datagroup triggers,
+    custom URLs, PDF rendering, and non-email destinations end-to-end.
+    """
+
+    @pytest.mark.asyncio
+    async def test_create_schedule_exposes_all_writable_fields(self, config):
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            tools = {t.name: t for t in await mcp.list_tools()}
+            props = tools["create_schedule"].parameters["properties"]
+            missing = WRITABLE_SCHEDULE_FIELDS - props.keys()
+            assert not missing, f"create_schedule missing writable fields: {sorted(missing)}"
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_exposes_all_writable_fields(self, config):
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            tools = {t.name: t for t in await mcp.list_tools()}
+            props = tools["update_schedule"].parameters["properties"]
+            missing = WRITABLE_SCHEDULE_FIELDS - props.keys()
+            assert not missing, f"update_schedule missing writable fields: {sorted(missing)}"
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_recipients_shorthand_builds_email_destinations(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "1", "name": "weekly"})
+
+        respx.post(f"{API_URL}/scheduled_plans").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "weekly",
+                    "crontab": "0 9 * * 1",
+                    "dashboard_id": "42",
+                    "recipients": ["a@x.com", "b@x.com"],
+                },
+            )()
+            assert captured["body"]["scheduled_plan_destination"] == [
+                {"type": "email", "address": "a@x.com"},
+                {"type": "email", "address": "b@x.com"},
+            ]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_destinations_passes_through_full_shape(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "1", "name": "to-s3"})
+
+        respx.post(f"{API_URL}/scheduled_plans").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            destinations = [
+                {
+                    "type": "s3",
+                    "format": "csv",
+                    "address": "my-bucket/exports",
+                    "parameters": '{"region": "us-east-1"}',
+                    "secret_parameters": '{"access_key_id": "AKIA...", "secret_access_key": "..."}',
+                }
+            ]
+            await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "to-s3",
+                    "crontab": "0 0 * * *",
+                    "query_id": "Q123",
+                    "destinations": destinations,
+                },
+            )()
+            # Destinations are passed through unchanged so non-email types work.
+            assert captured["body"]["scheduled_plan_destination"] == destinations
+            # query_id is the target — look_id/dashboard_id absent.
+            assert captured["body"]["query_id"] == "Q123"
+            assert "look_id" not in captured["body"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    async def test_recipients_and_destinations_are_mutually_exclusive(self, config):
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            # No outbound HTTP mock — any leak would raise.
+            payload = await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "x",
+                    "crontab": "0 9 * * *",
+                    "dashboard_id": "42",
+                    "recipients": ["a@x.com"],
+                    "destinations": [{"type": "email", "address": "b@x.com"}],
+                },
+            )()
+            assert "not both" in payload["error"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    async def test_no_target_returns_actionable_error(self, config):
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {"name": "x", "crontab": "0 9 * * *"},
+            )()
+            assert "No target" in payload["error"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    async def test_multiple_targets_returns_actionable_error(self, config):
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "x",
+                    "crontab": "0 9 * * *",
+                    "look_id": "1",
+                    "dashboard_id": "2",
+                },
+            )()
+            assert "Multiple targets" in payload["error"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_advanced_fields_round_trip_through_body(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(201, json={"id": "9"})
+
+        respx.post(f"{API_URL}/scheduled_plans").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            await _invoke_tool(
+                mcp,
+                "create_schedule",
+                {
+                    "name": "advanced",
+                    "lookml_dashboard_id": "ml-99",
+                    "datagroup": "daily_etl",
+                    "timezone": "America/New_York",
+                    "require_change": True,
+                    "send_all_results": True,
+                    "filters_string": "f[date]=last 7 days",
+                    "pdf_landscape": True,
+                    "pdf_paper_size": "letter",
+                    "long_tables": True,
+                    "color_theme": "dark",
+                    "show_custom_url": True,
+                    "custom_url_base": "https://reports.example.com",
+                    "custom_url_label": "View in Reports",
+                    "destinations": [{"type": "email", "address": "ops@x.com"}],
+                },
+            )()
+            body = captured["body"]
+            # Key conditional / trigger fields make it on the wire.
+            assert body["datagroup"] == "daily_etl"
+            assert body["require_change"] is True
+            assert body["send_all_results"] is True
+            assert body["timezone"] == "America/New_York"
+            assert body["pdf_landscape"] is True
+            assert body["color_theme"] == "dark"
+            assert body["custom_url_base"] == "https://reports.example.com"
+            # crontab was NOT provided — must NOT be sent (would conflict with datagroup).
+            assert "crontab" not in body
+        finally:
+            await looker_client.close()
+
+
+class TestUpdateScheduleAdvanced:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_destinations_replace_supports_clearing(self, config):
+        # Passing destinations=[] (empty list) must reach Looker so it clears
+        # the existing destinations — _set_if would have stripped this, the
+        # tool uses `is not None` instead.
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"id": "42"})
+
+        respx.patch(f"{API_URL}/scheduled_plans/42").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            await _invoke_tool(
+                mcp,
+                "update_schedule",
+                {"schedule_id": "42", "destinations": []},
+            )()
+            assert captured["body"] == {"scheduled_plan_destination": []}
+        finally:
+            await looker_client.close()
+
+
 class TestRunScheduleOnce:
     @pytest.mark.asyncio
     @respx.mock


### PR DESCRIPTION
## Summary

The schedule-management tools previously surfaced ~6 fields out of 30 writable on Looker's \`WriteScheduledPlan\` schema, and only supported email destinations. This PR exposes the full field set and the full \`ScheduledPlanDestination\` shape, so agents can configure conditional delivery, datagroup triggers, S3/SFTP/webhook destinations, custom-branded URLs, and PDF render options end-to-end without falling back to the Looker UI.

### What's added

- **Targets**: \`lookml_dashboard_id\` and \`query_id\` join \`look_id\` / \`dashboard_id\`. \`create_schedule\` now validates that exactly one is provided.
- **Destinations**: new \`destinations\` parameter accepts the full \`ScheduledPlanDestination\` array (\`type\`, \`address\`, \`format\`, \`apply_formatting\`, \`apply_vis\`, \`parameters\`, \`secret_parameters\`, \`message\`). Supports \`email\`, \`webhook\`, \`s3\`, \`sftp\`. Mutually exclusive with the legacy \`recipients\` email-only shorthand.
- **Conditional delivery**: \`require_results\`, \`require_no_results\`, \`require_change\`, \`send_all_results\`.
- **Trigger options**: \`enabled\`, \`run_once\`, \`datagroup\`, \`timezone\`, \`user_id\` (delegated ownership).
- **Render / PDF**: \`pdf_paper_size\`, \`pdf_landscape\`, \`long_tables\`, \`inline_table_width\`, \`color_theme\`, \`embed\`.
- **Branded URLs**: \`show_custom_url\`, \`custom_url_base\`, \`custom_url_params\`, \`custom_url_label\`.
- **Filters**: \`filters_string\`.

### What's changed

- \`update_schedule\`'s \`destinations\` and \`recipients\` use \`is not None\` semantics rather than truthy checks. Passing \`destinations=[]\` now reaches Looker as an empty array (clearing all destinations) — previously \`_set_if\` silently dropped it.
- \`create_schedule\` returns actionable errors for \"no target provided\" and \"multiple targets provided\" instead of letting Looker reject the request later.

### Backward compatibility

- All previously-supported parameters keep their existing names and behaviors.
- \`recipients\` still works as the email-only shorthand.
- \`crontab\` is now optional (was required) because \`datagroup\` is a valid alternative trigger.

### Tests

New \`TestCreateScheduleSurface\` and \`TestUpdateScheduleAdvanced\` classes cover:
- Schema-introspection regression: the registered tool surface contains every writable \`WriteScheduledPlan\` field
- \`recipients\` shorthand builds the email destinations array correctly
- \`destinations\` passes through the full S3/SFTP/etc shape unchanged
- \`recipients\` + \`destinations\` mutual-exclusion error
- Target validation: zero / multiple targets return actionable errors
- Advanced fields (datagroup, conditional delivery, PDF options, custom URLs) round-trip through the request body
- Empty-list destinations clears the destination list on update

## Test plan

- [x] \`uv run ruff check .\` — passes
- [x] \`uv run ruff format --check .\` — passes
- [x] \`uv run pyright\` — 0 errors, 0 warnings
- [x] \`uv run pytest tests/ -q\` — 252 passed
- [ ] Manual smoke against a live Looker instance: create an S3-destination schedule with \`require_change=True\` and a datagroup trigger, verify it shows up correctly in the Schedules admin page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded schedule create/update: support dashboard/look/query targets, full destination types (email/webhook/S3/SFTP) plus email-only shorthand, timezone, conditional delivery, PDF/rendering, custom URLs, ownership/retargeting, and explicit destination replacement/clearing.

* **Bug Fixes / Validation**
  * Early validation: require exactly one target, enforce mutual exclusions (recipients vs destinations, crontab vs datagroup), detect provided empty lists as explicit inputs.

* **Tests**
  * Added comprehensive tests for schema exposure, request shaping, validations, and empty-list semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->