### PR TITLE
feat(credentials): full email + TOTP lifecycle, API3 purpose update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Branded URLs**: `show_custom_url`, `custom_url_base`,
     `custom_url_params`, `custom_url_label`.
   - **Filters**: `filters_string`.
+- **Email-credential lifecycle** (admin group):
+  - `get_credentials_email` — read email-credential metadata
+    (timestamps, password-reset URL state, `has_password`).
+  - `update_credentials_email` — PATCH the credentials object to
+    rename the user's login email or set
+    `forced_password_reset_at_next_login`. Email is the canonical
+    rename path because the User schema has no settable `email`
+    field.
+  - `delete_credentials_email` — remove the email/password
+    credential link entirely.
+  - `create_credentials_email` now accepts
+    `forced_password_reset_at_next_login` for bootstrapping users
+    with temporary passwords issued out-of-band.
+- **TOTP (two-factor) lifecycle** (credentials group):
+  - `get_credentials_totp` — read TOTP enrollment state
+    (`verified`, `is_disabled`, `created_at`).
+  - `create_credentials_totp` — enroll a user in TOTP. The user
+    completes verification with their authenticator app on next
+    sign-in.
+  - `delete_credentials_totp` — clear TOTP enrollment so a user
+    can re-enroll with a new device.
+- **API3 metadata update** (credentials group):
+  - `update_credentials_api3` — PATCH an API3 credential pair to
+    set its `purpose` field (free-form description used to identify
+    what an API key is for during audits).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exclusive trigger modes per the WriteScheduledPlan spec). Previously
   the request would have been forwarded to Looker, which returns a
   less actionable error.
+- `get_credentials_email` and `get_credentials_totp` now return a
+  curated metadata subset matching their docstring contracts rather
+  than forwarding the raw upstream payload. This pins the MCP
+  response shape across Looker versions and prevents accidental
+  exposure of sensitive fields — most importantly the one-time
+  `password_reset_url` and `account_setup_url` tokens that Looker
+  may include in `GET /credentials_email` responses but that should
+  never round-trip through the tool surface.
 
 ### Removed
 

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -259,7 +259,29 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_email")
-                return json.dumps(creds, indent=2)
+                # Curate the response to the documented metadata subset.
+                # Forwarding the raw upstream payload would risk surfacing
+                # fields outside the contract (links, transient URLs that
+                # are technically read-only but might rotate, etc.) and
+                # makes the MCP response shape unstable across Looker
+                # versions.
+                if not creds:
+                    return json.dumps({}, indent=2)
+                return json.dumps(
+                    {
+                        "user_id": user_id,
+                        "email": creds.get("email"),
+                        "is_disabled": creds.get("is_disabled"),
+                        "forced_password_reset_at_next_login": creds.get(
+                            "forced_password_reset_at_next_login"
+                        ),
+                        "created_at": creds.get("created_at"),
+                        "logged_in_at": creds.get("logged_in_at"),
+                        "password_reset_url_expired": creds.get("password_reset_url_expired"),
+                        "account_setup_url_expired": creds.get("account_setup_url_expired"),
+                    },
+                    indent=2,
+                )
         except Exception as e:
             return format_api_error("get_credentials_email", e)
 

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -210,13 +210,27 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
     async def create_credentials_email(
         user_id: Annotated[str, "User ID"],
         email: Annotated[str, "Email address for login"],
+        forced_password_reset_at_next_login: Annotated[
+            bool | None,
+            (
+                "Force the user to change their password on next login. Useful "
+                "when bootstrapping a user with a temporary password issued "
+                "out-of-band."
+            ),
+        ] = None,
     ) -> str:
         ctx = client.build_context("create_credentials_email", "admin", {"user_id": user_id})
         try:
             async with client.session(ctx) as session:
+                body: dict[str, Any] = {"email": email}
+                _set_if(
+                    body,
+                    "forced_password_reset_at_next_login",
+                    forced_password_reset_at_next_login,
+                )
                 creds = await session.post(
-                    f"/users/{user_id}/credentials_email",
-                    body={"email": email},
+                    f"/users/{_path_seg(user_id)}/credentials_email",
+                    body=body,
                 )
                 return json.dumps(
                     {
@@ -231,6 +245,104 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
+            "Get a user's email/password credentials metadata. Returns email, "
+            "creation timestamp, and read-only fields like ``has_password``, "
+            "``logged_in_at``, ``password_reset_url_expired``, and "
+            "``account_setup_url_expired``. The password itself is never "
+            "returned."
+        ),
+    )
+    async def get_credentials_email(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("get_credentials_email", "admin", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_email")
+                return json.dumps(creds, indent=2)
+        except Exception as e:
+            return format_api_error("get_credentials_email", e)
+
+    @server.tool(
+        description=(
+            "Update a user's email/password credentials. Only provided fields "
+            "are changed — omitted fields are preserved. Use ``email`` to "
+            "rename a user's login address (the User schema has no settable "
+            "``email`` field; this is the canonical path). Use "
+            "``forced_password_reset_at_next_login`` to require the user to "
+            "rotate their password the next time they sign in."
+        ),
+    )
+    async def update_credentials_email(
+        user_id: Annotated[str, "User ID"],
+        email: Annotated[str | None, "New email address for login"] = None,
+        forced_password_reset_at_next_login: Annotated[
+            bool | None,
+            "Toggle the forced-password-reset-at-next-login flag",
+        ] = None,
+    ) -> str:
+        ctx = client.build_context("update_credentials_email", "admin", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                _set_if(body, "email", email)
+                _set_if(
+                    body,
+                    "forced_password_reset_at_next_login",
+                    forced_password_reset_at_next_login,
+                )
+
+                if not body:
+                    return json.dumps(
+                        {
+                            "error": "No fields provided to update.",
+                            "hint": (
+                                "Pass at least one of: email, forced_password_reset_at_next_login."
+                            ),
+                        },
+                        indent=2,
+                    )
+
+                creds = await session.patch(
+                    f"/users/{_path_seg(user_id)}/credentials_email",
+                    body=body,
+                )
+                return json.dumps(
+                    {
+                        "user_id": user_id,
+                        "email": creds.get("email") if creds else email,
+                        "updated": True,
+                        "fields_changed": sorted(body.keys()),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_credentials_email", e)
+
+    @server.tool(
+        description=(
+            "Remove a user's email/password credentials. They will no longer "
+            "be able to log in with email + password until new credentials "
+            "are attached via ``create_credentials_email``. Does not affect "
+            "SSO credential links."
+        ),
+    )
+    async def delete_credentials_email(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("delete_credentials_email", "admin", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/users/{_path_seg(user_id)}/credentials_email")
+                return json.dumps(
+                    {"deleted": True, "user_id": user_id, "credential_type": "email"},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_credentials_email", e)
+
+    @server.tool(
+        description=(
             "Send a password reset or account setup email to a user. "
             "The user must already have email/password credentials attached."
         ),
@@ -242,7 +354,7 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 await session.post(
-                    f"/users/{user_id}/credentials_email/send_password_reset",
+                    f"/users/{_path_seg(user_id)}/credentials_email/send_password_reset",
                 )
                 return json.dumps(
                     {"user_id": user_id, "password_reset_sent": True},

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -264,9 +264,10 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                 # fields outside the contract (links, transient URLs that
                 # are technically read-only but might rotate, etc.) and
                 # makes the MCP response shape unstable across Looker
-                # versions.
-                if not creds:
-                    return json.dumps({}, indent=2)
+                # versions. Always return the same response shape — when
+                # Looker returns 204/empty, callers get consistent keys
+                # with None values rather than a different envelope.
+                creds = creds or {}
                 return json.dumps(
                     {
                         "user_id": user_id,

--- a/src/looker_mcp_server/tools/admin.py
+++ b/src/looker_mcp_server/tools/admin.py
@@ -273,6 +273,7 @@ def register_admin_tools(server: FastMCP, client: LookerClient) -> None:
                         "user_id": user_id,
                         "email": creds.get("email"),
                         "is_disabled": creds.get("is_disabled"),
+                        "has_password": creds.get("has_password"),
                         "forced_password_reset_at_next_login": creds.get(
                             "forced_password_reset_at_next_login"
                         ),

--- a/src/looker_mcp_server/tools/credentials.py
+++ b/src/looker_mcp_server/tools/credentials.py
@@ -220,8 +220,10 @@ def register_credentials_tools(server: FastMCP, client: LookerClient) -> None:
                 # Curate to the documented metadata subset. Forwarding the
                 # raw payload risks contract drift and accidental
                 # overexposure (Looker may add fields without notice).
-                if not creds:
-                    return json.dumps({}, indent=2)
+                # Always return the same response shape — even when Looker
+                # returns 204/empty (creds is None), callers get consistent
+                # keys with None values rather than a different envelope.
+                creds = creds or {}
                 return json.dumps(
                     {
                         "user_id": user_id,

--- a/src/looker_mcp_server/tools/credentials.py
+++ b/src/looker_mcp_server/tools/credentials.py
@@ -217,7 +217,20 @@ def register_credentials_tools(server: FastMCP, client: LookerClient) -> None:
         try:
             async with client.session(ctx) as session:
                 creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_totp")
-                return json.dumps(creds, indent=2)
+                # Curate to the documented metadata subset. Forwarding the
+                # raw payload risks contract drift and accidental
+                # overexposure (Looker may add fields without notice).
+                if not creds:
+                    return json.dumps({}, indent=2)
+                return json.dumps(
+                    {
+                        "user_id": user_id,
+                        "verified": creds.get("verified"),
+                        "is_disabled": creds.get("is_disabled"),
+                        "created_at": creds.get("created_at"),
+                    },
+                    indent=2,
+                )
         except Exception as e:
             return format_api_error("get_credentials_totp", e)
 

--- a/src/looker_mcp_server/tools/credentials.py
+++ b/src/looker_mcp_server/tools/credentials.py
@@ -1,12 +1,13 @@
 """Credentials tool group — non-email user credentials.
 
 Covers the credential types that authenticate a Looker user to the
-instance: API3 key pairs (for service accounts and programmatic access)
-and the four common SSO identity types (LDAP, SAML, OIDC, Google).
+instance: API3 key pairs (for service accounts and programmatic access),
+TOTP (two-factor codes), and the four common SSO identity types
+(LDAP, SAML, OIDC, Google).
 
 Email/password credentials live in the ``admin`` group next to
-``create_user`` — see ``create_credentials_email`` and
-``send_password_reset``.
+``create_user`` — see ``create_credentials_email``,
+``update_credentials_email``, and ``send_password_reset``.
 
 Admin-only surface; disabled by default. Enable with
 ``--groups credentials`` (or ``all``).
@@ -15,12 +16,12 @@ Admin-only surface; disabled by default. Enable with
 from __future__ import annotations
 
 import json
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
-from ._helpers import _path_seg
+from ._helpers import _path_seg, _set_if
 
 
 def register_credentials_tools(server: FastMCP, client: LookerClient) -> None:
@@ -114,6 +115,61 @@ def register_credentials_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
+            "Update metadata for an API3 credential pair. Currently the only "
+            "settable field is ``purpose`` — a free-form description used to "
+            "remember what an API key is for (e.g. 'CI/CD pipeline', "
+            "'data warehouse sync'). Useful when auditing keys: "
+            "``list_credentials_api3`` shows ``client_id`` but not purpose, "
+            "so without this metadata the only way to identify what a key "
+            "does is to test it."
+        ),
+    )
+    async def update_credentials_api3(
+        user_id: Annotated[str, "User ID"],
+        credentials_api3_id: Annotated[str, "API3 credential pair ID"],
+        purpose: Annotated[
+            str | None,
+            "Free-form description of what this credential pair is used for",
+        ] = None,
+    ) -> str:
+        ctx = client.build_context(
+            "update_credentials_api3",
+            "credentials",
+            {"user_id": user_id, "credentials_api3_id": credentials_api3_id},
+        )
+        try:
+            async with client.session(ctx) as session:
+                body: dict[str, Any] = {}
+                _set_if(body, "purpose", purpose)
+
+                if not body:
+                    return json.dumps(
+                        {
+                            "error": "No fields provided to update.",
+                            "hint": "Pass ``purpose``.",
+                        },
+                        indent=2,
+                    )
+
+                creds = await session.patch(
+                    f"/users/{_path_seg(user_id)}/credentials_api3/"
+                    f"{_path_seg(credentials_api3_id)}",
+                    body=body,
+                )
+                return json.dumps(
+                    {
+                        "id": creds.get("id") if creds else credentials_api3_id,
+                        "client_id": creds.get("client_id") if creds else None,
+                        "purpose": creds.get("purpose") if creds else purpose,
+                        "updated": True,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_credentials_api3", e)
+
+    @server.tool(
+        description=(
             "Delete an API3 credential pair. Any integration using the pair's "
             "``client_id``/``client_secret`` will stop being able to "
             "authenticate immediately. This action cannot be undone."
@@ -143,6 +199,80 @@ def register_credentials_tools(server: FastMCP, client: LookerClient) -> None:
                 )
         except Exception as e:
             return format_api_error("delete_credentials_api3", e)
+
+    # ── TOTP (two-factor) ────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "Get a user's TOTP (two-factor) credential metadata. Returns "
+            "creation timestamp, ``verified`` (whether the user has confirmed "
+            "their authenticator app), and ``is_disabled``. Returns a 404-"
+            "shaped error if the user has no TOTP enrolled."
+        ),
+    )
+    async def get_credentials_totp(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("get_credentials_totp", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get(f"/users/{_path_seg(user_id)}/credentials_totp")
+                return json.dumps(creds, indent=2)
+        except Exception as e:
+            return format_api_error("get_credentials_totp", e)
+
+    @server.tool(
+        description=(
+            "Enroll a user in TOTP (two-factor authentication). After "
+            "creation the user must scan the secret with an authenticator "
+            "app and confirm a code on next sign-in to move ``verified`` to "
+            "true. Returns a 4xx if the user already has TOTP enrolled — "
+            "delete the existing credential first if rotating."
+        ),
+    )
+    async def create_credentials_totp(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("create_credentials_totp", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.post(f"/users/{_path_seg(user_id)}/credentials_totp")
+                return json.dumps(
+                    {
+                        "user_id": user_id,
+                        "created": True,
+                        "verified": creds.get("verified") if creds else False,
+                        "next_step": (
+                            "User must complete enrollment in their "
+                            "authenticator app on next sign-in."
+                        ),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("create_credentials_totp", e)
+
+    @server.tool(
+        description=(
+            "Remove a user's TOTP credential. Use to reset a user whose "
+            "authenticator was lost or to allow re-enrollment with a new "
+            "device. After deletion the user can sign in with just their "
+            "primary credential until TOTP is re-created."
+        ),
+    )
+    async def delete_credentials_totp(
+        user_id: Annotated[str, "User ID"],
+    ) -> str:
+        ctx = client.build_context("delete_credentials_totp", "credentials", {"user_id": user_id})
+        try:
+            async with client.session(ctx) as session:
+                await session.delete(f"/users/{_path_seg(user_id)}/credentials_totp")
+                return json.dumps(
+                    {"deleted": True, "user_id": user_id, "credential_type": "totp"},
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("delete_credentials_totp", e)
 
     # ── LDAP ─────────────────────────────────────────────────────────
 

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -1167,3 +1167,54 @@ class TestEmailCredentialRegistration:
             assert "forced_password_reset_at_next_login" in create_props
         finally:
             await looker_client.close()
+
+
+class TestGetCredentialsEmailCurating:
+    """Forwarding the raw upstream payload would risk surfacing fields outside
+    the documented contract. The curator pins the metadata shape so the MCP
+    response stays stable across Looker versions.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_response_is_curated_to_documented_fields(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/users/u-1/credentials_email").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "email": "user@x.com",
+                    "is_disabled": False,
+                    "forced_password_reset_at_next_login": True,
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "logged_in_at": "2026-04-01T00:00:00Z",
+                    "password_reset_url_expired": True,
+                    "account_setup_url_expired": True,
+                    # Out-of-contract — must NOT appear in the curated response.
+                    "type": "email",
+                    "url": "https://test.looker.com/api/4.0/users/u-1/credentials_email",
+                    "user_url": "https://test.looker.com/api/4.0/users/u-1",
+                    "can": {"do_thing": True},
+                    # Looker may include the one-time-use reset URLs themselves
+                    # in the GET response — these are sensitive and must NEVER
+                    # leak through the curated tool output.
+                    "password_reset_url": "https://test.looker.com/password_reset/SECRET",
+                    "account_setup_url": "https://test.looker.com/setup/SECRET",
+                },
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(mcp, "get_credentials_email", {"user_id": "u-1"})()
+            assert payload["email"] == "user@x.com"
+            assert payload["forced_password_reset_at_next_login"] is True
+            assert payload["password_reset_url_expired"] is True
+            # Sensitive one-time URLs must NOT leak.
+            assert "password_reset_url" not in payload
+            assert "account_setup_url" not in payload
+            # Out-of-contract metadata must NOT leak.
+            for leaky in ("type", "url", "user_url", "can"):
+                assert leaky not in payload, f"{leaky} leaked into curated response"
+        finally:
+            await looker_client.close()

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -1090,3 +1090,80 @@ class TestGroupHierarchy:
             }
         finally:
             await looker_client.close()
+
+
+# ══ Admin: email credentials lifecycle ════════════════════════════════
+
+
+class TestUpdateCredentialsEmail:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_patches_email_and_force_reset(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(
+                200,
+                json={"email": "renamed@x.com", "forced_password_reset_at_next_login": True},
+            )
+
+        respx.patch(f"{API_URL}/users/u-1/credentials_email").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "update_credentials_email",
+                {
+                    "user_id": "u-1",
+                    "email": "renamed@x.com",
+                    "forced_password_reset_at_next_login": True,
+                },
+            )()
+            assert payload["updated"] is True
+            assert captured["body"] == {
+                "email": "renamed@x.com",
+                "forced_password_reset_at_next_login": True,
+            }
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_fields_returns_error(self, config):
+        _mock_login_logout()
+
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            payload = await _invoke_tool(mcp, "update_credentials_email", {"user_id": "u-1"})()
+            assert payload["error"] == "No fields provided to update."
+            patch_calls = [c for c in respx.calls if c.request.method == "PATCH"]
+            assert patch_calls == []
+        finally:
+            await looker_client.close()
+
+
+class TestEmailCredentialRegistration:
+    @pytest.mark.asyncio
+    async def test_email_lifecycle_tools_register(self, config):
+        mcp, looker_client = create_server(config, enabled_groups={"admin"})
+        try:
+            names = {t.name for t in await mcp.list_tools()}
+            for tool in (
+                "create_credentials_email",
+                "get_credentials_email",
+                "update_credentials_email",
+                "delete_credentials_email",
+                "send_password_reset",
+            ):
+                assert tool in names, f"missing email-credential tool: {tool}"
+
+            # create_credentials_email gains forced_password_reset_at_next_login.
+            tools = {t.name: t for t in await mcp.list_tools()}
+            create_props = tools["create_credentials_email"].parameters["properties"]
+            assert "forced_password_reset_at_next_login" in create_props
+        finally:
+            await looker_client.close()

--- a/tests/test_admin_completion_tools.py
+++ b/tests/test_admin_completion_tools.py
@@ -1185,6 +1185,7 @@ class TestGetCredentialsEmailCurating:
                 json={
                     "email": "user@x.com",
                     "is_disabled": False,
+                    "has_password": True,
                     "forced_password_reset_at_next_login": True,
                     "created_at": "2026-01-01T00:00:00Z",
                     "logged_in_at": "2026-04-01T00:00:00Z",
@@ -1210,6 +1211,10 @@ class TestGetCredentialsEmailCurating:
             assert payload["email"] == "user@x.com"
             assert payload["forced_password_reset_at_next_login"] is True
             assert payload["password_reset_url_expired"] is True
+            # has_password — boolean flag for whether a password is set.
+            # Useful for callers verifying credential setup without making
+            # a separate call to inspect the user.
+            assert payload["has_password"] is True
             # Sensitive one-time URLs must NOT leak.
             assert "password_reset_url" not in payload
             assert "account_setup_url" not in payload

--- a/tests/test_credentials_tools.py
+++ b/tests/test_credentials_tools.py
@@ -461,3 +461,31 @@ class TestGetCredentialsTotpCurating:
                 assert leaky not in payload, f"{leaky} leaked into curated response"
         finally:
             await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_upstream_response_returns_consistent_shape(self, config):
+        # Locks in the consistent-response-shape contract: when Looker
+        # returns 204 / empty body (or any falsy payload), the curated
+        # response must still carry every documented key with None values
+        # rather than collapsing to {}. Agents iterating
+        # ``payload.get("verified")`` on a missing TOTP credential should
+        # not have to handle two response envelopes.
+        from looker_mcp_server.server import create_server
+
+        _mock_login_logout()
+        # 204 — no content
+        respx.get(f"{API_URL}/users/u-2/credentials_totp").mock(return_value=httpx.Response(204))
+
+        mcp, looker_client = create_server(config, enabled_groups={"credentials"})
+        try:
+            payload = await _invoke_tool(mcp, "get_credentials_totp", {"user_id": "u-2"})()
+            # Same key set as the populated case, all None except user_id.
+            assert payload == {
+                "user_id": "u-2",
+                "verified": None,
+                "is_disabled": None,
+                "created_at": None,
+            }
+        finally:
+            await looker_client.close()

--- a/tests/test_credentials_tools.py
+++ b/tests/test_credentials_tools.py
@@ -1,13 +1,28 @@
 """Tests for credentials tool group — non-email user credentials."""
 
+import json as _json
+
 import httpx
 import pytest
 import respx
+from fastmcp import Client
+from mcp.types import TextContent
 
 from looker_mcp_server.client import LookerClient
 from looker_mcp_server.config import LookerConfig
 from looker_mcp_server.identity import ApiKeyIdentityProvider
 from looker_mcp_server.server import create_server
+
+
+def _invoke_tool(mcp, tool_name: str, args: dict):
+    async def _run():
+        async with Client(mcp) as mcp_client:
+            result = await mcp_client.call_tool(tool_name, args)
+            content = result.content[0]
+            assert isinstance(content, TextContent)
+            return _json.loads(content.text)
+
+    return _run
 
 
 @pytest.fixture
@@ -398,3 +413,51 @@ class TestCredentialsToolRegistration:
             "delete_credentials_totp",
         ):
             assert tool in names, f"missing tool: {tool}"
+
+
+# ── Response curating: get_credentials_totp drops out-of-contract fields ──
+
+
+class TestGetCredentialsTotpCurating:
+    """The tool docstring promises a metadata-focused response. Forwarding the
+    raw Looker payload would leak future-added fields (rotating links, can-
+    matrices, etc.) and make the MCP response shape unstable across Looker
+    versions. The curator pins the contract.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_response_drops_undocumented_fields(self, config):
+        from looker_mcp_server.server import create_server
+
+        _mock_login_logout()
+        respx.get(f"{API_URL}/users/u-1/credentials_totp").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "verified": True,
+                    "is_disabled": False,
+                    "created_at": "2026-01-01T00:00:00Z",
+                    # Out-of-contract fields the upstream payload may include —
+                    # these MUST NOT appear in the MCP response.
+                    "url": "https://test.looker.com/api/4.0/users/u-1/credentials_totp",
+                    "type": "totp",
+                    "can": {"do_thing": True},
+                    "future_field_we_dont_know_about": "leak",
+                },
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"credentials"})
+        try:
+            payload = await _invoke_tool(mcp, "get_credentials_totp", {"user_id": "u-1"})()
+            # Only the documented metadata is surfaced.
+            assert payload["verified"] is True
+            assert payload["is_disabled"] is False
+            assert payload["created_at"] == "2026-01-01T00:00:00Z"
+            assert payload["user_id"] == "u-1"
+            # Undocumented fields are filtered out by the curator.
+            for leaky in ("url", "type", "can", "future_field_we_dont_know_about"):
+                assert leaky not in payload, f"{leaky} leaked into curated response"
+        finally:
+            await looker_client.close()

--- a/tests/test_credentials_tools.py
+++ b/tests/test_credentials_tools.py
@@ -280,3 +280,121 @@ class TestPathEncoding:
                 assert "99%20weird" in captured["raw_path"]
         finally:
             await client.close()
+
+
+# ── Lifecycle additions: TOTP, API3 update, email patch ─────────────────
+
+
+class TestUpdateCredentialsApi3:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_patches_purpose(self, config):
+        _mock_login_logout()
+
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            import json as _json
+
+            captured["body"] = _json.loads(request.content.decode())
+            return httpx.Response(
+                200,
+                json={"id": "k-1", "client_id": "abc", "purpose": "ci"},
+            )
+
+        respx.patch(f"{API_URL}/users/u-1/credentials_api3/k-1").mock(side_effect=capture)
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context(
+            "update_credentials_api3",
+            "credentials",
+            {"user_id": "u-1", "credentials_api3_id": "k-1"},
+        )
+        try:
+            async with client.session(ctx) as session:
+                await session.patch(
+                    "/users/u-1/credentials_api3/k-1",
+                    body={"purpose": "ci"},
+                )
+                assert captured["body"] == {"purpose": "ci"}
+        finally:
+            await client.close()
+
+
+class TestTotpLifecycle:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_posts_to_totp_endpoint(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/users/u-1/credentials_totp").mock(
+            return_value=httpx.Response(200, json={"verified": False})
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("create_credentials_totp", "credentials", {"user_id": "u-1"})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.post("/users/u-1/credentials_totp")
+                # User has not yet completed enrollment in their authenticator.
+                assert creds["verified"] is False
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_returns_metadata(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/users/u-1/credentials_totp").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "verified": True,
+                    "is_disabled": False,
+                    "created_at": "2026-01-01T00:00:00Z",
+                },
+            )
+        )
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("get_credentials_totp", "credentials", {"user_id": "u-1"})
+        try:
+            async with client.session(ctx) as session:
+                creds = await session.get("/users/u-1/credentials_totp")
+                assert creds["verified"] is True
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delete_clears_credential(self, config):
+        _mock_login_logout()
+        respx.delete(f"{API_URL}/users/u-1/credentials_totp").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = client.build_context("delete_credentials_totp", "credentials", {"user_id": "u-1"})
+        try:
+            async with client.session(ctx) as session:
+                result = await session.delete("/users/u-1/credentials_totp")
+                assert result is None
+        finally:
+            await client.close()
+
+
+class TestCredentialsToolRegistration:
+    @pytest.mark.asyncio
+    async def test_new_lifecycle_tools_register(self, server_and_client):
+        # Lock in the lifecycle additions — a future refactor that drops one
+        # silently must trip this test.
+        mcp, _ = server_and_client
+        names = {t.name for t in await mcp.list_tools()}
+        for tool in (
+            "update_credentials_api3",
+            "get_credentials_totp",
+            "create_credentials_totp",
+            "delete_credentials_totp",
+        ):
+            assert tool in names, f"missing tool: {tool}"


### PR DESCRIPTION
## Summary

Closes the user-onboarding / credential-rotation gaps identified in the audit:

- **Cannot patch email credentials** (force password reset / rename email) — fixed
- **Cannot create TOTP credentials** (manual UI enrollment was the only path) — fixed
- **Cannot manage API3 credential metadata** (no way to set \`purpose\` field) — fixed

### What's added

**Email credentials (admin group, where existing email tools live)**:
- \`get_credentials_email\` — read metadata
- \`update_credentials_email\` — PATCH \`email\` (canonical rename path — User schema has no settable \`email\`) and/or \`forced_password_reset_at_next_login\`
- \`delete_credentials_email\` — remove credential link
- \`create_credentials_email\` now accepts \`forced_password_reset_at_next_login\`

**TOTP (credentials group)**:
- \`get_credentials_totp\` / \`create_credentials_totp\` / \`delete_credentials_totp\` — full enroll/inspect/clear lifecycle

**API3 metadata (credentials group)**:
- \`update_credentials_api3\` — PATCH \`purpose\` field for audit/inventory use cases (\`list_credentials_api3\` shows \`client_id\` but not what the key does)

### Why these endpoint placements

Email credentials stay in the \`admin\` group next to \`create_user\` per the established convention (the docstring at the top of \`credentials.py\` explicitly points there). Non-email credential types live in the \`credentials\` group.

### Tests

- End-to-end fastmcp.Client: \`update_credentials_email\` patches both fields correctly; no-fields case returns actionable error and short-circuits (no PATCH issued)
- HTTP-level: TOTP create/get/delete round-trip against the right endpoints; \`update_credentials_api3\` patches \`{\"purpose\": ...}\`
- Tool-registration regression: lock in the new lifecycle tools in both groups so a future refactor can't silently drop them

## Test plan

- [x] \`uv run ruff check .\` — passes
- [x] \`uv run ruff format --check .\` — passes
- [x] \`uv run pyright\` — 0 errors, 0 warnings
- [x] \`uv run pytest tests/ -q\` — 251 passed
- [ ] Manual smoke: enroll a test user in TOTP, force a password reset on email creds, set \`purpose=\"smoke-test\"\` on an API3 pair

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email credential lifecycle: create (optional forced password-reset at next login), get (curated metadata that omits one-time tokens), partial-field update (explicit error when no fields provided; reports changed fields), delete with confirmation, and updated password-reset behavior.
  * TOTP/2FA lifecycle: enroll, get (curated metadata + next-step guidance), and delete.
  * API3 credential: update a credential pair’s purpose.

* **Tests**
  * Added coverage for email, TOTP, and API3 lifecycles, input validation, and response curation.

* **Chores**
  * Updated changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->