### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
         with:
           enable-cache: true
 
@@ -34,10 +34,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
         with:
           enable-cache: true
 
@@ -58,10 +58,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## Summary

The Ultrathink-Solutions org policy now requires every GitHub Actions reference to be pinned to a full-length commit SHA. The existing \`.github/workflows/ci.yml\` uses tag refs (\`actions/checkout@v4\`, \`astral-sh/setup-uv@v6\`) which the runner rejects at job startup:

> The actions actions/checkout@v4 and astral-sh/setup-uv@v6 are not allowed in Ultrathink-Solutions/looker-mcp-server because all actions must be pinned to a full-length commit SHA.

This blocks **every** CI run on **every** branch (including main on the next push). The last green CI was 2026-04-17 — the policy was tightened since.

## Pins

| Action | SHA | Tag |
|---|---|---|
| \`actions/checkout\` | \`34e114876b0b11c390a56381ad16ebd13914f8d5\` | v4.3.1 |
| \`astral-sh/setup-uv\` | \`d0cc045d04ccac9d8b7881df0226f9e82c39688e\` | v6.8.0 |

Both are the latest releases of their major versions (preserves \`actions/checkout@v4\` and \`astral-sh/setup-uv@v6\` semantics). Tag names are kept as inline comments beside each SHA so version bumps remain human-reviewable.

## Test plan

- [x] Workflow syntax preserved — diff is purely the action ref string
- [ ] CI green on this PR (will validate the fix end-to-end)
- [ ] Once merged, the 5 in-flight feature PRs (#19–#23) need a rebase off main to pick up the fixed workflow

## Why this is urgent

All 5 feature PRs in flight (\`feat(connection)\`, \`feat(git)\`, \`feat(admin)\` ×2, \`feat(credentials)\`) are blocked on this — their CI cannot run until the workflow is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to use pinned dependencies for enhanced stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->