### PR TITLE
chore: release v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-04-28
+
+This release adds end-to-end agentic management of Looker installations:
+every writable field on `DBConnection`, `WriteScheduledPlan`, and the user
+schemas is now reachable; the git, scheduling, and credential lifecycles
+are fully covered with deploy-key rotation, connection diagnostics,
+delegated ownership, conditional delivery, and TOTP enrollment. Every
+tool that builds a request body validates preflight (multiple-target
+guards, mutual-exclusion guards, required-field guards) so misconfigured
+calls return actionable errors instead of opaque Looker 422s.
+
 ### Added
 
 - **Git deploy-key management** for LookML projects:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.13.0"
+version = "0.14.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Cuts v0.14.0 from the accumulated `[Unreleased]` block on main. Bumps `pyproject.toml` (and the matching entry in `uv.lock`) from `0.13.0` → `0.14.0` and converts the `[Unreleased]` CHANGELOG section into the dated v0.14.0 release section (2026-04-28). A fresh empty `[Unreleased]` heading is left in place so the next round of work has somewhere to land.

## What's in v0.14.0

The release covers five merged feature PRs (#19, #20, #21, #22, #23) plus the CI infrastructure fix (#24).

**Theme**: end-to-end agentic management of Looker installations. Every writable field on the `DBConnection`, `WriteScheduledPlan`, and user/group/credential schemas is now reachable from the MCP tool surface, and every body-building tool validates preflight so misconfigured calls return actionable errors instead of opaque Looker 422s.

### Highlights

| Area | What landed |
|---|---|
| **DBConnection** | All 46 writable fields on `create_connection`/`update_connection` (key-pair, OAuth/ADC, SSH tunnel, TNS, `user_attribute_fields`, `pdt_context_override`, BigQuery routing). New `clear_fields` escape hatch for explicit JSON-null clearing. |
| **Git** | Deploy-key get/rotate, connection diagnostics, `delete_git_branch`, `get_git_branch_by_name`, `branch`/`ref` on `deploy_to_production`. Full `_path_seg` rollout for safe URL encoding. New `LookerSession.get_text`/`post_text` for `text/plain` endpoints. |
| **Schedule** | Full `WriteScheduledPlan` surface (all 30 writable fields). `email_format` default of `wysiwyg_pdf`. Preflight guards: at-most-one target, trigger required, destination required, crontab vs datagroup mutual exclusion. Empty destination arrays rejected up front per Looker spec. |
| **User/group** | Full `User` writable surface; `update_group` (was missing); `add_group_to_group` / `remove_group_from_group` / `list_group_groups` / `list_group_users`. `email` is now optional on `create_user` for SSO-only setups. |
| **Credentials** | Email lifecycle (`get`/`update`/`delete` + `forced_password_reset_at_next_login` on create); TOTP `get`/`create`/`delete`; `update_credentials_api3` for the `purpose` field. Curated response shapes prevent accidental leakage of one-time `password_reset_url` and `account_setup_url` tokens. |
| **Internal** | Shared `_raise_for_status` helper on `LookerSession`. `WRITABLE_DBCONNECTION_FIELDS` exported as the canonical contract for runtime validation + regression tests. CI workflow now SHA-pins all GitHub Actions to satisfy the org policy. |

### Removed (safe — were no-ops)

- `pdts_enabled` and `uses_oauth` are no longer accepted as `create_connection` / `update_connection` parameters. Both are spec-readOnly; sending them was silently ignored.
- `update_user` no longer accepts the undocumented `email` parameter. Email is set via the email-credentials object, not directly on the user.

No observable behavior change for any caller — the API never honored these fields.

## Test plan

- [x] `uv lock` — updates `looker-mcp-server` to 0.14.0 in lockfile
- [x] `uv run ruff check .` — passes
- [x] `uv run ruff format --check .` — passes
- [x] `uv run pyright` — 0 errors, 0 warnings
- [x] `uv run pytest tests/ -q` — **302 passed** (up from 245 at v0.13.0 — 57 new tests across the 5 feature PRs lock in the new contracts)
- [ ] CI green on this PR
- [ ] Tag `v0.14.0` after merge (release.yml workflow handles this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded writable-field coverage across database connections, scheduled plans, and user schemas.
  * Added support for deploy-key rotation, diagnostics, delegated ownership, conditional delivery, and TOTP enrollment.
  * Enhanced request validation with clearer, actionable error messages instead of generic responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->