### PR TITLE
ci: pin release.yml GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -39,10 +39,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
 
       - name: Build
         run: uv build


### PR DESCRIPTION
## Summary

Mirror the SHA-pinning fix from PR #24 (which only fixed `ci.yml`) over to `release.yml`.

Without this, pushing the `v0.14.0` tag would trigger `release.yml`, which would fail at startup with the org-policy error \"all actions must be pinned to a full-length commit SHA\" — leaving the release unpublished to PyPI.

## Pins

Same SHAs `ci.yml` already uses:

| Action | SHA | Tag |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `astral-sh/setup-uv` | `d0cc045d04ccac9d8b7881df0226f9e82c39688e` | v6.8.0 |

## Why this is urgent

`release.yml` triggers on `tags: v*` push. The last successful run was **v0.13.0 on 2026-04-17**, before the org's actions-pinning policy was enforced. v0.14.0 was just merged to main (PR #25) and is ready to tag — but pushing `v0.14.0` before this PR merges will cause the release workflow to fail and PyPI publish won't happen.

## Test plan

- [x] Diff is purely the action-ref string (4 lines × 2 actions × 2 jobs)
- [ ] CI green on this PR
- [ ] Once merged, push `v0.14.0` tag to trigger the release workflow under the new pinned config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to use pinned versions for improved reproducibility and security in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->