### PR TITLE
feat(git): add act_as_user for per-call admin impersonation (v0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,60 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-07
+
+This release adds **per-call admin impersonation** to the git tool
+group. The eight workspace-scoped git tools accept an optional
+`act_as_user` argument (numeric Looker user ID or email) that scopes
+the call to a sudo session targeting that user — closing the
+per-user dev-workspace cleanup gap that previously forced operators
+to leave the MCP for raw HTTP. Argument-driven sudo is gated by
+`LOOKER_SUDO_AS_USER` and refuses with a clear validation error
+when sudo is disabled, so the kill switch remains the single control
+point for sudo-capable behavior. Argument-driven impersonation emits
+a distinct INFO-level audit event (`looker.audit.act_as_user`) so
+downstream pipelines can scope on admin per-call sudo independently
+of header-driven gateway sudo.
+
+### Added
+
+- **Per-call admin impersonation via `act_as_user`** on every git
+  workspace-scoped tool: `get_git_branch`, `list_git_branches`,
+  `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`,
+  `delete_git_branch`, `deploy_to_production`, `reset_to_production`.
+  Looker dev mode is per-user-isolated, so admin cleanup of another
+  user's stuck dev-workspace state previously required leaving the MCP
+  for raw HTTP. The new argument accepts either a numeric Looker user ID
+  or an email address (resolved via Looker's user-search API) and
+  scopes the call to a sudo session targeting that user. Gated by
+  `LOOKER_SUDO_AS_USER` — that flag is the single kill switch for
+  sudo-capable behavior, and `act_as_user` respects it: passing the
+  argument with sudo disabled raises a validation error rather than
+  silently running the call under the configured identity. The
+  argument is validated up front (must be all-digits or contain `@`)
+  so malformed input fails before reaching Looker. Capability is
+  enforced server-side by Looker — `login_user` returns 403 if the
+  configured admin credentials cannot impersonate, and the MCP
+  surfaces the failure as a clean tool error. Email-lookup misses
+  raise rather than silently falling back to the configured identity,
+  so a typo'd email cannot run an action under the wrong user. See
+  *Per-Call Admin Impersonation* in the README for the full security
+  model and audit-log shape.
+- **`ArgumentSudoIdentityProvider`** in `looker_mcp_server.identity` —
+  wraps any inner `IdentityProvider` and reads `act_as_user` from
+  `RequestContext.arguments`. Wired automatically when the server is
+  constructed with default credentials; caller-supplied identity
+  providers are left untouched.
+- **`triggered_by` field on `LookerIdentity`** — discriminates
+  argument-driven sudo (`"argument"`) from gateway/header-driven sudo
+  (`"header"`) so audit consumers can tell admin per-call impersonation
+  from automatic gateway routing.
+- **`looker.audit.act_as_user` structlog event** — emitted at INFO
+  level on every argument-driven sudo with `tool`, `target_user_id`,
+  `target_user_email`, `triggered_by`, and `configured_user`. Distinct
+  from the existing trace-level `looker.session.sudo` debug line so
+  downstream pipelines can scope on audit-only events.
+
 ## [0.14.0] - 2026-04-28
 
 This release adds end-to-end agentic management of Looker installations:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **folder** | `list_folders`, `get_folder`, `create_folder`, `update_folder`, `delete_folder`, `get_folder_children`, `get_folder_ancestors`, `get_folder_looks`, `get_folder_dashboards` | Navigate and manage the folder hierarchy |
 | **health**\* | `health_pulse`, `health_analyze`, `health_vacuum` | Instance health checks and usage analysis |
 | **modeling** | `list_projects`, `get_project`, `create_project`, `update_project`, `delete_project`, `get_project_manifest`, `get_project_deploy_key`, `create_project_deploy_key`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project`, `list_datagroups`, `reset_datagroup` | LookML project lifecycle, file edits, syntax validation, and datagroup cache management |
-| **git** | `get_git_branch`, `list_git_branches`, `create_git_branch`, `switch_git_branch`, `deploy_to_production`, `reset_to_production` | Git operations and production deployment |
+| **git** | `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`, `delete_git_branch`, `deploy_to_production`, `reset_to_production`, `get_git_deploy_key`, `create_git_deploy_key`, `list_git_connection_tests`, `run_git_connection_test` | Git branch lifecycle, production deploy, SSH deploy-key rotation, and git-connection diagnostics |
 | **admin** | `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`, `create_credentials_email`, `send_password_reset`, `list_roles`, `get_role`, `create_role`, `update_role`, `delete_role`, `get_role_groups`, `get_role_users`, `list_permissions`, `list_permission_sets`, `create_permission_set`, `update_permission_set`, `delete_permission_set`, `list_model_sets`, `create_model_set`, `update_model_set`, `delete_model_set`, `list_groups`, `create_group`, `delete_group`, `add_group_user`, `remove_group_user`, `set_role_groups`, `set_role_users`, `set_user_roles`, `get_user_roles`, `list_schedules`, `create_schedule`, `update_schedule`, `delete_schedule`, `run_schedule_once` | User, role, RBAC, group, and schedule management |
 | **connection** | `get_connection`, `list_connection_dialects`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` | Database connection CRUD and health checks |
 | **user_attributes** | `list_user_attributes`, `get_user_attribute`, `create_user_attribute`, `update_user_attribute`, `delete_user_attribute`, `list_user_attribute_group_values`, `set_user_attribute_group_values`, `delete_user_attribute_group_value`, `list_user_attribute_values_for_user`, `set_user_attribute_user_value`, `delete_user_attribute_user_value` | User attribute definitions plus per-group and per-user value overrides (row-level security, per-developer credentials, filter defaults) |
@@ -212,6 +212,54 @@ When `LOOKER_SUDO_AS_USER=true` (the default), the server uses a `DualModeIdenti
 - **Self-hosted** → sudo (via `X-User-Email` header)
 - **Google Cloud core** → OAuth (via `X-User-Token` header)
 - **No identity headers** → service account fallback
+
+### Per-Call Admin Impersonation (`act_as_user`)
+
+Looker dev mode (`workspace_id=dev`) is **per-user-isolated by design**. Each user has their own dev workspace; uncommitted LookML changes, the active branch, and dev-mode local branches all live in the calling user's workspace. That means an admin running `delete_git_branch` against the *admin's* dev workspace does nothing about a stuck branch in *another user's* dev workspace.
+
+The git tools accept an optional `act_as_user` argument so an admin can perform the call as a different user — typically to clean up someone else's stuck dev-workspace state without leaving the MCP for raw HTTP. Accepts either a numeric user ID or an email address (resolved to an ID via Looker's user-search API).
+
+```jsonc
+// Example: admin sweeping a stale CI branch out of ci-bot's dev workspace
+{
+  "tool": "delete_git_branch",
+  "arguments": {
+    "project_id": "acme_analytics",
+    "branch_name": "tmp_ci_5bd8888773",
+    "act_as_user": "ci-bot@example.com"
+  }
+}
+```
+
+**Configuration.** Per-call admin impersonation is gated by `LOOKER_SUDO_AS_USER` — that flag is the single kill switch for sudo-capable behavior in the OSS server, and `act_as_user` respects it. Set `LOOKER_SUDO_AS_USER=true` (the default when admin credentials are configured) to enable. With `LOOKER_SUDO_AS_USER=false`, passing `act_as_user` raises a clear validation error rather than silently running the call under the configured identity — surfacing the misconfiguration at the call site instead of letting it route to the wrong user.
+
+**Security model.** The MCP forwards capability — it does not gate it. Sudo permission is enforced by Looker server-side: if the configured `LOOKER_CLIENT_ID` does not have sudo capability, `login_user` returns HTTP 403 and the tool fails. There is no MCP-side "who may impersonate whom" policy in the open-source server; layer one in via a wrapping `IdentityProvider` if you need it (see the next section).
+
+**Tool coverage (v1).** All eight git/workspace-scoped tools accept `act_as_user`: `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`, `delete_git_branch`, `deploy_to_production`, `reset_to_production`. Project-level tools (deploy keys, connection diagnostics) deliberately do not — they don't depend on per-user dev workspace state.
+
+**Audit log.** Every argument-driven sudo emits an INFO-level structlog line:
+
+```json
+{
+  "event": "looker.audit.act_as_user",
+  "tool": "delete_git_branch",
+  "target_user_id": "77",
+  "target_user_email": "ci-bot@example.com",
+  "triggered_by": "argument",
+  "configured_user": "admin-api3-client-id"
+}
+```
+
+This is independent of the trace-level `looker.session.sudo` debug line and is the right hook for downstream audit pipelines. Header-driven sudo (gateway pattern) is tagged `triggered_by="header"` on the debug line — `looker.audit.act_as_user` fires only for explicit per-call admin impersonation.
+
+**Mode interaction.** `act_as_user` overrides the inner identity, including OAuth and header-based sudo. This is intentional — an explicit admin override should win over implicit gateway routing — but the underlying credentials must still have sudo capability, which Looker enforces. On Google Cloud core only Embed-type users can be impersonated; for regular GCC users use Mode 3 (OAuth pass-through) instead.
+
+**Failure modes.**
+
+- `act_as_user` is neither all-digits nor an email (no `@`) → validation error rejected up front, before any Looker call. Avoids forwarding garbage to `/login/{value}` where it would surface as an opaque HTTP 400.
+- Email does not match any Looker user → validation error. Fail-loud is deliberate; silently falling back to the configured identity would let a typo'd email run the action under the wrong user.
+- `LOOKER_SUDO_AS_USER=false` and `act_as_user` is passed → validation error explaining how to fix (enable sudo or remove the argument).
+- Configured credentials lack sudo capability → Looker returns 403 on `login_user`, surfaced as `Permission denied — the current user lacks access.`
 
 ## Extending with Custom Identity Providers
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.14.0"
+version = "0.15.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -214,7 +214,28 @@ class LookerClient:
                         identity.target_user_id,
                         associative=self._config.sudo_associative,
                     )
-                    log.debug("looker.session.sudo", user_id=identity.target_user_id)
+                    log.debug(
+                        "looker.session.sudo",
+                        user_id=identity.target_user_id,
+                        triggered_by=identity.triggered_by,
+                    )
+                    # Argument-driven sudo is admin impersonation requested
+                    # explicitly by the caller (per-call ``act_as_user``
+                    # parameter). It MUST be auditable independently of
+                    # header-driven sudo (gateway pattern), so emit an
+                    # INFO-level audit line for it. ``configured_user`` is
+                    # the API3 client_id that performed the underlying
+                    # ``login_user`` — i.e. the admin identity backing the
+                    # impersonation.
+                    if identity.triggered_by == "argument":
+                        log.info(
+                            "looker.audit.act_as_user",
+                            tool=context.tool_name,
+                            target_user_id=identity.target_user_id,
+                            target_user_email=identity.user_email,
+                            triggered_by=identity.triggered_by,
+                            configured_user=identity.client_id,
+                        )
                     try:
                         yield LookerSession(self._http, sudo_token)
                     finally:
@@ -348,6 +369,13 @@ def format_api_error(tool_name: str, error: Exception) -> str:
         result = {"error": hint, "status": status}
         if error.detail:
             result["detail"] = error.detail
+    elif isinstance(error, ValueError):
+        # Validation errors raised by tools or identity providers
+        # (e.g. ``act_as_user`` rejecting a malformed value or an
+        # unresolvable email) carry a self-describing message — surface
+        # it directly instead of dressing it up as an "unexpected"
+        # error, which would mislead callers about whether to retry.
+        result = {"error": str(error)}
     else:
         result = {"error": f"Unexpected error in {tool_name}: {error}"}
     return json.dumps(result, indent=2)

--- a/src/looker_mcp_server/identity.py
+++ b/src/looker_mcp_server/identity.py
@@ -56,6 +56,12 @@ class LookerIdentity:
     user_email: str | None = None
     user_subject: str | None = None
 
+    # how the sudo target was selected — "argument" (per-call act_as_user
+    # parameter) or "header" (gateway-injected request header). ``None``
+    # for non-sudo identities. Surfaced in audit logs so operators can
+    # tell admin-driven impersonation from gateway-driven impersonation.
+    triggered_by: str | None = None
+
 
 # ── Protocol ─────────────────────────────────────────────────────────
 
@@ -148,7 +154,149 @@ class SudoIdentityProvider:
             client_secret=self._client_secret,
             target_user_id=user_id,
             user_email=email,
+            triggered_by="header",
         )
+
+
+class ArgumentSudoIdentityProvider:
+    """Per-call admin impersonation via the ``act_as_user`` tool argument.
+
+    Wraps an inner :class:`IdentityProvider`. When a tool invocation
+    includes a non-empty ``act_as_user`` argument, this provider returns
+    a sudo identity targeting that user — overriding whatever identity
+    the inner provider would have resolved. When ``act_as_user`` is
+    absent, the inner provider's resolution is returned unchanged.
+
+    The argument value may be either:
+
+    - a Looker user ID (e.g. ``"123"``)
+    - an email address (containing ``@``), resolved to a user ID via
+      ``user_lookup_fn``
+
+    Sudo capability is enforced by Looker server-side: if the
+    credentials backing the configured admin login cannot impersonate,
+    ``login_user`` fails with HTTP 403. This provider only forwards
+    capability — it does not gate it.
+
+    Both invalid input formats and email-lookup misses raise
+    ``ValueError`` rather than silently falling back to the inner
+    identity. A silent fallback would make a mistyped email or stray
+    string perform an action as the *configured* admin user instead of
+    refusing — a footgun. Fail loudly so the caller can fix the input.
+
+    Accepted forms: an email address (containing ``@``) or an
+    all-digits Looker user ID. Anything else (e.g. a username
+    fragment, a UUID, an empty-after-stripping string) is rejected up
+    front with a clear validation error rather than being forwarded to
+    Looker's ``/login/{value}`` endpoint where it would surface as an
+    opaque HTTP 400/404.
+
+    .. note::
+
+       On **Looker (Google Cloud core)** only Embed-type users can be
+       impersonated via sudo. For regular GCC users, configure
+       ``OAuthIdentityProvider`` and pass tokens via the configured
+       header instead.
+    """
+
+    def __init__(
+        self,
+        inner: IdentityProvider,
+        client_id: str,
+        client_secret: str,
+        user_lookup_fn: Any | None = None,
+        argument_name: str = "act_as_user",
+        sudo_enabled: bool = True,
+    ) -> None:
+        self._inner = inner
+        self._client_id = client_id
+        self._client_secret = client_secret
+        self._user_lookup_fn = user_lookup_fn
+        self._argument_name = argument_name
+        self._sudo_enabled = sudo_enabled
+        self._email_to_id_cache: dict[str, str] = {}
+
+    async def resolve(self, context: RequestContext) -> LookerIdentity:
+        raw = context.arguments.get(self._argument_name)
+        if not raw:
+            return await self._inner.resolve(context)
+
+        act_as = str(raw).strip()
+        if not act_as:
+            return await self._inner.resolve(context)
+
+        # Honor the deployment's sudo kill switch. We could skip
+        # installing the wrapper entirely when ``sudo_enabled=False``,
+        # but then ``act_as_user`` would silently route the call under
+        # the configured identity — making an operator who disabled
+        # sudo see calls succeed as the wrong user. Failing loudly is
+        # the safer carve-out (cf. "no half-baked PRs": silent-disable
+        # on opt-in is the failure mode to avoid).
+        if not self._sudo_enabled:
+            logger.warning(
+                "looker.act_as_user.sudo_disabled",
+                tool=context.tool_name,
+            )
+            raise ValueError(
+                "act_as_user requires LOOKER_SUDO_AS_USER=true. "
+                "Either enable sudo on the server or remove the "
+                "act_as_user argument from the call."
+            )
+
+        if "@" in act_as:
+            email = act_as
+            user_id = self._email_to_id_cache.get(email)
+            if user_id is None and self._user_lookup_fn is not None:
+                user_id = await self._user_lookup_fn(email)
+                if user_id is not None:
+                    self._email_to_id_cache[email] = user_id
+            if user_id is None:
+                logger.warning(
+                    "looker.act_as_user.lookup_miss",
+                    email=email,
+                    tool=context.tool_name,
+                )
+                raise ValueError(
+                    f"act_as_user: no Looker user found for email {email!r}. "
+                    "Verify the email or pass a numeric user ID instead."
+                )
+        elif act_as.isdigit():
+            email = None
+            user_id = act_as
+        else:
+            # Reject up front rather than forwarding to ``/login/{value}``
+            # where Looker would respond with an opaque 400/404. Same
+            # bad-input failure mode as a lookup miss.
+            logger.warning(
+                "looker.act_as_user.invalid_format",
+                value=act_as,
+                tool=context.tool_name,
+            )
+            raise ValueError(
+                f"act_as_user: {act_as!r} is not a valid Looker user reference. "
+                "Pass either a numeric Looker user ID (e.g. '42') or an email "
+                "address (e.g. 'user@example.com')."
+            )
+
+        return LookerIdentity(
+            mode="sudo",
+            client_id=self._client_id,
+            client_secret=self._client_secret,
+            target_user_id=user_id,
+            user_email=email,
+            triggered_by="argument",
+        )
+
+    def set_user_lookup(self, fn: Any) -> None:
+        """Inject the user-lookup function after the client is ready.
+
+        Propagates the same function to the wrapped inner provider when
+        it supports lookup injection, so a single call wires the whole
+        chain (e.g. ``ArgumentSudo`` wrapping ``DualMode``).
+        """
+        self._user_lookup_fn = fn
+        if hasattr(self._inner, "set_user_lookup"):
+            self._inner.set_user_lookup(fn)  # type: ignore[attr-defined]
 
 
 class OAuthIdentityProvider:

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -12,6 +12,7 @@ from .client import LookerClient
 from .config import ALL_GROUPS, DEFAULT_GROUPS, LookerConfig, LookerMcpMode
 from .identity import (
     ApiKeyIdentityProvider,
+    ArgumentSudoIdentityProvider,
     DualModeIdentityProvider,
     IdentityProvider,
 )
@@ -78,7 +79,13 @@ def create_server(
     identity_provider:
         Pluggable identity resolution.  Defaults to ``DualModeIdentityProvider``
         (uses sudo on self-hosted, OAuth on GC core) when ``sudo_as_user`` is
-        enabled, otherwise ``ApiKeyIdentityProvider``.
+        enabled, otherwise ``ApiKeyIdentityProvider``.  When ``sudo_as_user``
+        is enabled and admin credentials are configured, the resolved
+        provider is additionally wrapped in ``ArgumentSudoIdentityProvider``
+        so tools that accept ``act_as_user`` can perform per-call admin
+        impersonation. ``LOOKER_SUDO_AS_USER=false`` disables both
+        header-driven and argument-driven sudo. A caller-supplied
+        provider is left untouched.
     enabled_groups:
         Set of tool group names to enable.  Defaults to ``DEFAULT_GROUPS``.
     auth:
@@ -90,27 +97,50 @@ def create_server(
         The configured server and the client (caller manages client lifecycle).
     """
     # ── Identity provider ────────────────────────────────────────────
+    caller_provided_provider = identity_provider is not None
+
     if identity_provider is None:
         if config.sudo_as_user and config.client_id and config.client_secret:
-            provider = DualModeIdentityProvider(
+            identity_provider = DualModeIdentityProvider(
                 client_id=config.client_id,
                 client_secret=config.client_secret,
                 deployment_type=config.deployment_type,
                 user_email_header=config.user_email_header,
                 user_token_header=config.user_token_header,
             )
-            identity_provider = provider
         else:
             identity_provider = ApiKeyIdentityProvider(
                 config.client_id,
                 config.client_secret,
             )
 
+        # Wrap with argument-driven sudo so tools that accept ``act_as_user``
+        # can perform per-call admin impersonation. Gated by
+        # ``LOOKER_SUDO_AS_USER`` — that flag is the single kill switch
+        # for sudo-capable behavior, and per-call sudo respects it.
+        # The wrapper is still installed when sudo is disabled so the
+        # request fails *loudly* with a clear validation error instead
+        # of silently routing the call under the configured identity
+        # (the latter would be a footgun: an operator disabling sudo
+        # would then see ``act_as_user`` calls succeed as the wrong
+        # user). Transparent when ``act_as_user`` is absent; skipped
+        # entirely for caller-supplied providers (caller owns auth chain).
+        if config.client_id and config.client_secret:
+            identity_provider = ArgumentSudoIdentityProvider(
+                inner=identity_provider,
+                client_id=config.client_id,
+                client_secret=config.client_secret,
+                sudo_enabled=config.sudo_as_user,
+            )
+
     client = LookerClient(config, identity_provider)
 
     # Wire the user-lookup function for sudo after the client is ready.
-    if isinstance(identity_provider, DualModeIdentityProvider):
-        identity_provider.set_user_lookup(client.lookup_user_by_email)
+    # ``ArgumentSudoIdentityProvider.set_user_lookup`` propagates to its
+    # inner provider, so a single call wires the full chain when the
+    # default factory wraps a ``DualModeIdentityProvider``.
+    if not caller_provided_provider and hasattr(identity_provider, "set_user_lookup"):
+        identity_provider.set_user_lookup(client.lookup_user_by_email)  # type: ignore[attr-defined]
 
     # ── FastMCP server ───────────────────────────────────────────────
     mcp = FastMCP(

--- a/src/looker_mcp_server/tools/git.py
+++ b/src/looker_mcp_server/tools/git.py
@@ -17,6 +17,21 @@ from fastmcp import FastMCP
 from ..client import LookerClient, format_api_error
 from ._helpers import _path_seg
 
+# Per-call admin impersonation. The MCP forwards capability — Looker
+# enforces whether the configured admin credentials may impersonate
+# (HTTP 403 if not). Email values are resolved via Looker's user-search
+# API; numeric values are used directly. ``ArgumentSudoIdentityProvider``
+# in :mod:`..identity` notices this argument and rewrites the resolved
+# identity to a sudo session targeting ``act_as_user``.
+ACT_AS_USER_DESCRIPTION = (
+    "Optional Looker user ID or email to impersonate for this call. "
+    "Use to clean up another user's dev workspace (Looker dev mode is "
+    "per-user-isolated). Requires sudo capability on the configured "
+    "admin credentials. When omitted, the call uses the configured or "
+    "gateway-provided identity."
+)
+ActAsUser = Annotated[str | None, ACT_AS_USER_DESCRIPTION]
+
 
 def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
@@ -24,8 +39,13 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     )
     async def get_git_branch(
         project_id: Annotated[str, "LookML project ID"],
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("get_git_branch", "git", {"project_id": project_id})
+        ctx = client.build_context(
+            "get_git_branch",
+            "git",
+            {"project_id": project_id, "act_as_user": act_as_user},
+        )
         try:
             async with client.session(ctx) as session:
                 branch = await session.get(f"/projects/{_path_seg(project_id)}/git_branch")
@@ -52,8 +72,13 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     )
     async def list_git_branches(
         project_id: Annotated[str, "LookML project ID"],
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("list_git_branches", "git", {"project_id": project_id})
+        ctx = client.build_context(
+            "list_git_branches",
+            "git",
+            {"project_id": project_id, "act_as_user": act_as_user},
+        )
         try:
             async with client.session(ctx) as session:
                 branches = await session.get(f"/projects/{_path_seg(project_id)}/git_branches")
@@ -83,11 +108,16 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     async def get_git_branch_by_name(
         project_id: Annotated[str, "LookML project ID"],
         branch_name: Annotated[str, "Name of the branch to inspect"],
+        act_as_user: ActAsUser = None,
     ) -> str:
         ctx = client.build_context(
             "get_git_branch_by_name",
             "git",
-            {"project_id": project_id, "branch_name": branch_name},
+            {
+                "project_id": project_id,
+                "branch_name": branch_name,
+                "act_as_user": act_as_user,
+            },
         )
         try:
             async with client.session(ctx) as session:
@@ -108,8 +138,13 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         project_id: Annotated[str, "LookML project ID"],
         branch_name: Annotated[str, "Name for the new branch"],
         ref: Annotated[str | None, "Git ref to branch from (default: current HEAD)"] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("create_git_branch", "git", {"project_id": project_id})
+        ctx = client.build_context(
+            "create_git_branch",
+            "git",
+            {"project_id": project_id, "act_as_user": act_as_user},
+        )
         try:
             async with client.session(ctx) as session:
                 body: dict[str, Any] = {"name": branch_name}
@@ -133,8 +168,13 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     async def switch_git_branch(
         project_id: Annotated[str, "LookML project ID"],
         branch_name: Annotated[str, "Name of the branch to switch to"],
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("switch_git_branch", "git", {"project_id": project_id})
+        ctx = client.build_context(
+            "switch_git_branch",
+            "git",
+            {"project_id": project_id, "act_as_user": act_as_user},
+        )
         try:
             async with client.session(ctx) as session:
                 branch = await session.put(
@@ -163,11 +203,16 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     async def delete_git_branch(
         project_id: Annotated[str, "LookML project ID"],
         branch_name: Annotated[str, "Name of the branch to delete"],
+        act_as_user: ActAsUser = None,
     ) -> str:
         ctx = client.build_context(
             "delete_git_branch",
             "git",
-            {"project_id": project_id, "branch_name": branch_name},
+            {
+                "project_id": project_id,
+                "branch_name": branch_name,
+                "act_as_user": act_as_user,
+            },
         )
         try:
             async with client.session(ctx) as session:
@@ -199,8 +244,13 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
             str | None,
             "Specific commit ref to deploy (mutually informative with ``branch``)",
         ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("deploy_to_production", "git", {"project_id": project_id})
+        ctx = client.build_context(
+            "deploy_to_production",
+            "git",
+            {"project_id": project_id, "act_as_user": act_as_user},
+        )
         try:
             async with client.session(ctx) as session:
                 params: dict[str, Any] = {}
@@ -233,8 +283,13 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     )
     async def reset_to_production(
         project_id: Annotated[str, "LookML project ID to reset"],
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("reset_to_production", "git", {"project_id": project_id})
+        ctx = client.build_context(
+            "reset_to_production",
+            "git",
+            {"project_id": project_id, "act_as_user": act_as_user},
+        )
         try:
             async with client.session(ctx) as session:
                 result = await session.post(

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -11,6 +11,7 @@ import json
 import httpx
 import pytest
 import respx
+import structlog
 from fastmcp import Client
 from mcp.types import TextContent
 
@@ -20,6 +21,26 @@ from looker_mcp_server.server import create_server
 
 @pytest.fixture
 def config():
+    # ``sudo_as_user=True`` is the default for any deployment configured
+    # with admin credentials, and is also the gate for ``act_as_user``.
+    # Tests in TestActAsUser require the wrapper to be installed; tests
+    # that don't pass ``act_as_user`` are unaffected — with no email
+    # header and no argument, the wrapper falls through to its inner
+    # provider which falls through to api_key behavior.
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=True,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+@pytest.fixture
+def config_sudo_disabled():
+    # Used to verify the gate: ``act_as_user`` must fail loudly when
+    # the operator has explicitly disabled sudo, not silently route the
+    # call under the configured identity.
     return LookerConfig(
         base_url="https://test.looker.com",
         client_id="test-id",
@@ -350,6 +371,257 @@ class TestGitConnectionTest:
                 },
                 {"id": "test_2", "description": "Second test."},
             ]
+        finally:
+            await looker_client.close()
+
+
+class TestActAsUser:
+    """Per-call admin impersonation via ``act_as_user``.
+
+    These tests pin the integrated behavior of
+    ``ArgumentSudoIdentityProvider`` + ``LookerClient.session()`` — when a
+    git tool receives ``act_as_user`` we expect a sudo session to be
+    established (admin login → ``login_user`` → action → double-logout)
+    and an INFO-level audit line to be emitted.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_numeric_user_id_triggers_sudo(self, config):
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        sudo_route = respx.post(f"{API_URL}/login/42").mock(
+            return_value=httpx.Response(200, json={"access_token": "sudo-tok"})
+        )
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        delete_route = respx.delete(f"{API_URL}/projects/p1/git_branch/tmp_ci_abc").mock(
+            return_value=httpx.Response(204)
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "delete_git_branch",
+                {
+                    "project_id": "p1",
+                    "branch_name": "tmp_ci_abc",
+                    "act_as_user": "42",
+                },
+            )()
+            assert sudo_route.called, "login_user must be called for the target user"
+            assert delete_route.called
+            assert payload == {
+                "deleted": True,
+                "project_id": "p1",
+                "branch_name": "tmp_ci_abc",
+            }
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_email_resolves_via_lookup_then_sudo(self, config):
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        # ``GET /users?email=...&limit=1`` is what ``lookup_user_by_email``
+        # issues internally — the wrapper provider's lookup_fn is wired
+        # to that helper at bootstrap.
+        lookup_route = respx.get(f"{API_URL}/users").mock(
+            return_value=httpx.Response(200, json=[{"id": "77", "email": "ci-bot@example.com"}])
+        )
+        sudo_route = respx.post(f"{API_URL}/login/77").mock(
+            return_value=httpx.Response(200, json={"access_token": "sudo-tok"})
+        )
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        delete_route = respx.delete(f"{API_URL}/projects/p1/git_branch/tmp_ci_abc").mock(
+            return_value=httpx.Response(204)
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            await _invoke_tool(
+                mcp,
+                "delete_git_branch",
+                {
+                    "project_id": "p1",
+                    "branch_name": "tmp_ci_abc",
+                    "act_as_user": "ci-bot@example.com",
+                },
+            )()
+            assert lookup_route.called, "email must be resolved via /users lookup"
+            assert sudo_route.called, "sudo target must be the resolved user_id"
+            assert delete_route.called
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_email_lookup_miss_surfaces_clean_error(self, config):
+        # Fail-loud is deliberate: a typo'd email must NOT silently fall
+        # back to the configured admin identity (which would perform the
+        # action under the wrong user).
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        respx.get(f"{API_URL}/users").mock(return_value=httpx.Response(200, json=[]))
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "delete_git_branch",
+                {
+                    "project_id": "p1",
+                    "branch_name": "tmp_ci_abc",
+                    "act_as_user": "ghost@example.com",
+                },
+            )()
+            assert "error" in payload
+            assert "ghost@example.com" in payload["error"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_emits_audit_log_on_argument_driven_sudo(self, config):
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        respx.post(f"{API_URL}/login/42").mock(
+            return_value=httpx.Response(200, json={"access_token": "sudo-tok"})
+        )
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        respx.delete(f"{API_URL}/projects/p1/git_branch/tmp_ci_abc").mock(
+            return_value=httpx.Response(204)
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            with structlog.testing.capture_logs() as captured:
+                await _invoke_tool(
+                    mcp,
+                    "delete_git_branch",
+                    {
+                        "project_id": "p1",
+                        "branch_name": "tmp_ci_abc",
+                        "act_as_user": "42",
+                    },
+                )()
+
+            audit = [line for line in captured if line.get("event") == "looker.audit.act_as_user"]
+            assert len(audit) == 1, captured
+            entry = audit[0]
+            assert entry["target_user_id"] == "42"
+            assert entry["triggered_by"] == "argument"
+            assert entry["configured_user"] == "test-id"
+            assert entry["tool"] == "delete_git_branch"
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_invalid_format_rejected_up_front(self, config):
+        # A bare username (no ``@``, not all-digits) must fail validation
+        # rather than be forwarded to ``/login/alice`` where Looker would
+        # respond with an opaque 400/404. No login or sudo route is
+        # registered — if the validation isn't up-front, respx will
+        # surface an unmatched-request RuntimeError.
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "delete_git_branch",
+                {
+                    "project_id": "p1",
+                    "branch_name": "tmp_ci_abc",
+                    "act_as_user": "alice",
+                },
+            )()
+            # Surfaced as a clean validation error — no "Unexpected
+            # error" wrapper, since format_api_error special-cases
+            # ValueError.
+            assert "error" in payload
+            assert "Unexpected" not in payload["error"]
+            assert "alice" in payload["error"]
+            assert "numeric" in payload["error"].lower()
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_act_as_user_refused_when_sudo_disabled(self, config_sudo_disabled):
+        # The gate: with ``LOOKER_SUDO_AS_USER=false`` the operator has
+        # explicitly disabled sudo. ``act_as_user`` must fail loudly so
+        # the misconfiguration surfaces at the call site instead of
+        # silently routing the call under the configured identity.
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+        mcp, looker_client = create_server(config_sudo_disabled, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "delete_git_branch",
+                {
+                    "project_id": "p1",
+                    "branch_name": "tmp_ci_abc",
+                    "act_as_user": "42",
+                },
+            )()
+            assert "error" in payload
+            assert "LOOKER_SUDO_AS_USER" in payload["error"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_sudo_disabled_without_act_as_user_works(self, config_sudo_disabled):
+        # Companion to the gate test: without ``act_as_user``, the gate
+        # is irrelevant — calls run normally under api_key mode.
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        respx.get(f"{API_URL}/projects/p1/git_branches").mock(
+            return_value=httpx.Response(200, json=[{"name": "main"}])
+        )
+
+        mcp, looker_client = create_server(config_sudo_disabled, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(mcp, "list_git_branches", {"project_id": "p1"})()
+            assert payload[0]["name"] == "main"
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_audit_log_when_act_as_user_absent(self, config):
+        respx.post(f"{API_URL}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "admin-tok"})
+        )
+        respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        respx.get(f"{API_URL}/projects/p1/git_branches").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            with structlog.testing.capture_logs() as captured:
+                await _invoke_tool(mcp, "list_git_branches", {"project_id": "p1"})()
+
+            audit = [line for line in captured if line.get("event") == "looker.audit.act_as_user"]
+            assert audit == []
         finally:
             await looker_client.close()
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -4,6 +4,7 @@ import pytest
 
 from looker_mcp_server.identity import (
     ApiKeyIdentityProvider,
+    ArgumentSudoIdentityProvider,
     DualModeIdentityProvider,
     OAuthIdentityProvider,
     RequestContext,
@@ -73,6 +74,9 @@ class TestSudoIdentityProvider:
         assert identity.target_user_id == "42"
         assert identity.user_email == "user@example.com"
         assert identity.client_id == "admin-id"
+        # Header-driven sudo is tagged so audit logs can distinguish it
+        # from argument-driven sudo (admin per-call impersonation).
+        assert identity.triggered_by == "header"
 
     @pytest.mark.asyncio
     async def test_caches_user_id(self):
@@ -187,3 +191,253 @@ class TestRequestContext:
         ctx = RequestContext(tool_name="query")
         with pytest.raises(AttributeError):
             ctx.tool_name = "other"  # type: ignore[misc]
+
+
+class TestArgumentSudoIdentityProvider:
+    """Per-call admin impersonation via the ``act_as_user`` argument."""
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_arg_absent(self):
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner, client_id="admin-id", client_secret="admin-secret"
+        )
+        ctx = RequestContext(tool_name="list_git_branches", tool_group="git")
+        identity = await provider.resolve(ctx)
+        # Inner identity is returned unchanged, including credentials —
+        # we did NOT swap to admin-id when the argument is absent.
+        assert identity.mode == "api_key"
+        assert identity.client_id == "inner-id"
+        assert identity.triggered_by is None
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_arg_empty_string(self):
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner, client_id="admin-id", client_secret="admin-secret"
+        )
+        # Whitespace-only is treated as absent — protects against the
+        # common mistake of passing "" or "  " through a UI / config layer.
+        ctx = RequestContext(
+            tool_name="list_git_branches",
+            tool_group="git",
+            arguments={"act_as_user": "   "},
+        )
+        identity = await provider.resolve(ctx)
+        assert identity.mode == "api_key"
+        assert identity.client_id == "inner-id"
+
+    @pytest.mark.asyncio
+    async def test_resolves_sudo_with_numeric_user_id(self):
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner, client_id="admin-id", client_secret="admin-secret"
+        )
+        ctx = RequestContext(
+            tool_name="delete_git_branch",
+            tool_group="git",
+            arguments={"act_as_user": "42"},
+        )
+        identity = await provider.resolve(ctx)
+
+        # Numeric values bypass email lookup entirely.
+        assert identity.mode == "sudo"
+        assert identity.target_user_id == "42"
+        assert identity.user_email is None
+        assert identity.client_id == "admin-id"  # admin creds, not inner's
+        assert identity.client_secret == "admin-secret"
+        assert identity.triggered_by == "argument"
+
+    @pytest.mark.asyncio
+    async def test_resolves_sudo_via_email_lookup(self):
+        async def lookup(email: str) -> str | None:
+            return "99" if email == "ci-bot@example.com" else None
+
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner,
+            client_id="admin-id",
+            client_secret="admin-secret",
+            user_lookup_fn=lookup,
+        )
+        ctx = RequestContext(
+            tool_name="delete_git_branch",
+            tool_group="git",
+            arguments={"act_as_user": "ci-bot@example.com"},
+        )
+        identity = await provider.resolve(ctx)
+
+        assert identity.mode == "sudo"
+        assert identity.target_user_id == "99"
+        assert identity.user_email == "ci-bot@example.com"
+        assert identity.triggered_by == "argument"
+
+    @pytest.mark.asyncio
+    async def test_email_lookup_miss_raises_value_error(self):
+        # Fail-loud is deliberate: silently falling back to the inner
+        # identity would let a typo'd email perform an action as the
+        # *configured* identity instead of refusing.
+        async def lookup(_email: str) -> str | None:
+            return None
+
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner,
+            client_id="admin-id",
+            client_secret="admin-secret",
+            user_lookup_fn=lookup,
+        )
+        ctx = RequestContext(
+            tool_name="delete_git_branch",
+            tool_group="git",
+            arguments={"act_as_user": "ghost@example.com"},
+        )
+        with pytest.raises(ValueError, match="no Looker user found for email"):
+            await provider.resolve(ctx)
+
+    @pytest.mark.asyncio
+    async def test_email_lookup_caches(self):
+        call_count = 0
+
+        async def lookup(_email: str) -> str | None:
+            nonlocal call_count
+            call_count += 1
+            return "7"
+
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner,
+            client_id="admin-id",
+            client_secret="admin-secret",
+            user_lookup_fn=lookup,
+        )
+        ctx = RequestContext(
+            tool_name="delete_git_branch",
+            tool_group="git",
+            arguments={"act_as_user": "ci-bot@example.com"},
+        )
+        await provider.resolve(ctx)
+        await provider.resolve(ctx)
+        assert call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_set_user_lookup_propagates_to_inner(self):
+        # The realistic chain at server bootstrap is
+        # ArgumentSudo → DualMode → Sudo. A single call from the bootstrap
+        # must wire the lookup_fn through every layer that needs it
+        # (the wrapper itself, plus the inner SudoIdentityProvider that
+        # DualMode delegates to).
+        async def lookup(_email: str) -> str | None:
+            return None
+
+        inner = DualModeIdentityProvider(
+            client_id="inner-id",
+            client_secret="inner-secret",
+        )
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner,
+            client_id="admin-id",
+            client_secret="admin-secret",
+        )
+        provider.set_user_lookup(lookup)
+
+        # Wrapper got the function for its own email-resolution path.
+        assert provider._user_lookup_fn is lookup
+        # Propagated through DualMode to its underlying SudoIdentityProvider.
+        assert inner._sudo._user_lookup_fn is lookup
+
+    @pytest.mark.asyncio
+    async def test_set_user_lookup_skips_inner_without_support(self):
+        # When the inner provider doesn't expose set_user_lookup
+        # (e.g. a third-party custom provider), propagation is a no-op
+        # rather than raising — the wrapper still gets the function for
+        # its own resolution path.
+        async def lookup(_email: str) -> str | None:
+            return None
+
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner,
+            client_id="admin-id",
+            client_secret="admin-secret",
+        )
+        provider.set_user_lookup(lookup)
+        assert provider._user_lookup_fn is lookup
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_format(self):
+        # A bare username (no ``@``, not all-digits) must be rejected
+        # up front rather than forwarded to Looker's
+        # ``/login/{value}`` endpoint where it would surface as an
+        # opaque HTTP 400/404. The error message tells the caller the
+        # accepted forms.
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner, client_id="admin-id", client_secret="admin-secret"
+        )
+        ctx = RequestContext(
+            tool_name="delete_git_branch",
+            tool_group="git",
+            arguments={"act_as_user": "alice"},
+        )
+        with pytest.raises(ValueError, match="numeric Looker user ID"):
+            await provider.resolve(ctx)
+
+    @pytest.mark.asyncio
+    async def test_refuses_when_sudo_disabled(self):
+        # Honors the ``LOOKER_SUDO_AS_USER`` kill switch. The wrapper
+        # is still installed at bootstrap so the request fails loudly
+        # rather than silently routing under the configured identity.
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner,
+            client_id="admin-id",
+            client_secret="admin-secret",
+            sudo_enabled=False,
+        )
+        ctx = RequestContext(
+            tool_name="delete_git_branch",
+            tool_group="git",
+            arguments={"act_as_user": "42"},
+        )
+        with pytest.raises(ValueError, match="LOOKER_SUDO_AS_USER"):
+            await provider.resolve(ctx)
+
+    @pytest.mark.asyncio
+    async def test_sudo_disabled_passthrough_without_arg(self):
+        # The gate only fires when the argument is present — absent
+        # ``act_as_user`` it's transparent so existing flows aren't
+        # affected by the wrapper being installed.
+        inner = ApiKeyIdentityProvider("inner-id", "inner-secret")
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner,
+            client_id="admin-id",
+            client_secret="admin-secret",
+            sudo_enabled=False,
+        )
+        ctx = RequestContext(tool_name="list_git_branches", tool_group="git")
+        identity = await provider.resolve(ctx)
+        assert identity.mode == "api_key"
+        assert identity.client_id == "inner-id"
+
+    @pytest.mark.asyncio
+    async def test_overrides_oauth_inner(self):
+        # When the inner provider would resolve to OAuth (gateway pattern),
+        # an explicit act_as_user still wins. Looker enforces whether the
+        # configured admin credentials may impersonate.
+        inner = OAuthIdentityProvider(
+            fallback_client_id="fb-id", fallback_client_secret="fb-secret"
+        )
+        provider = ArgumentSudoIdentityProvider(
+            inner=inner, client_id="admin-id", client_secret="admin-secret"
+        )
+        ctx = RequestContext(
+            headers={"x-user-token": "gateway-token"},
+            tool_name="delete_git_branch",
+            tool_group="git",
+            arguments={"act_as_user": "42"},
+        )
+        identity = await provider.resolve(ctx)
+        assert identity.mode == "sudo"
+        assert identity.target_user_id == "42"
+        assert identity.triggered_by == "argument"

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.14.0"
+version = "0.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Looker dev mode is per-user-isolated by design — each user has their own dev workspace with their own active branch, uncommitted changes, and local branches. That means an admin running `delete_git_branch` against the *admin's* dev workspace does nothing about a stuck branch in *another user's* workspace, which has forced operators out of the MCP and into raw HTTP via `sdk.login_user(...)`.

This PR closes that gap and ships the change as **v0.15.0** atomically. Eight git workspace-scoped tools now accept an optional `act_as_user` argument (numeric Looker user ID or email) that scopes the call to a sudo session targeting that user. After merge, tag `v0.15.0` on main to trigger PyPI publish via the existing release workflow.

## What changed

### New primitive

- `ArgumentSudoIdentityProvider` (`src/looker_mcp_server/identity.py`) — wraps any inner `IdentityProvider` and reads `act_as_user` from `RequestContext.arguments`. Returns a `mode="sudo"` identity targeting the resolved user; passes through unchanged when the argument is absent.
- `triggered_by` field on `LookerIdentity` — discriminates argument-driven sudo (`"argument"`) from gateway/header-driven sudo (`"header"`).
- `looker.audit.act_as_user` INFO-level structlog event — fires on every argument-driven sudo with `tool`, `target_user_id`, `target_user_email`, `triggered_by`, `configured_user`. Distinct from the existing trace-level `looker.session.sudo` debug line so downstream pipelines can scope on audit-only events.

### Bootstrap wiring

- `create_server` wraps the resolved provider in `ArgumentSudoIdentityProvider` whenever the default factory builds the chain. Caller-supplied identity providers are left untouched so downstream wrappers can compose their own auth chain.
- A single `set_user_lookup` call propagates through `ArgumentSudo → DualMode → Sudo`.

### Tools

`act_as_user` parameter added to the eight git workspace-scoped tools:

- `get_git_branch`
- `list_git_branches`
- `get_git_branch_by_name`
- `create_git_branch`
- `switch_git_branch`
- `delete_git_branch`
- `deploy_to_production`
- `reset_to_production`

Project-level git tools (deploy keys, connection diagnostics) deliberately do not — they don't depend on per-user dev-workspace state.

### Validation & failure modes

- `act_as_user` value must contain `@` or be all-digits; otherwise the request is rejected up front with a clear `ValueError` before reaching Looker.
- Email-lookup miss → validation error (silent fallback would let a typo'd email act as the wrong user).
- `LOOKER_SUDO_AS_USER=false` + `act_as_user` passed → validation error explaining how to fix. Honors the existing kill switch instead of silently routing under the configured identity.
- `format_api_error` now surfaces `ValueError` as a validation message rather than the generic "Unexpected error" prefix.

### Documentation

- New README section *Per-Call Admin Impersonation (`act_as_user`)* under **Authentication & Impersonation** — covers use case, configuration, security model, tool coverage, audit-log shape, mode interaction, and failure modes.
- README **Tool Groups** git row refreshed to list all twelve git tools currently shipped (was stale at six since v0.14.0).
- `CHANGELOG.md` `[0.15.0] - 2026-05-07` section added with brief release intro plus full Added entries.

## Security model

- The MCP **forwards** capability; Looker **enforces** it. `login_user` returns 403 if the configured admin credentials cannot impersonate, surfaced as a clean tool error.
- `act_as_user` overrides any inner identity (OAuth, header-sudo, api_key) — an explicit per-call admin override is more specific than implicit gateway routing. The underlying credentials must still have sudo capability, which Looker enforces.
- On Looker (Google Cloud core) only Embed-type users can be impersonated via sudo; for regular GCC users use OAuth pass-through (Mode 3) instead.

## Backwards compatibility

Calls that don't pass `act_as_user` are byte-identical to the previous behavior. Verified by a dedicated regression test plus the unchanged existing suite. SemVer minor bump (no breaking changes).

## Release

- `pyproject.toml`: `0.14.0` → `0.15.0`
- `CHANGELOG.md`: `[Unreleased]` block promoted to `[0.15.0] - 2026-05-07` with brief release intro; fresh empty `[Unreleased]` retained for future work
- `uv.lock`: refreshed to match the new package version

After this PR merges, tag `v0.15.0` on `main` to trigger the existing release workflow (matrix tests on 3.11/3.12/3.13, then PyPI publish via Trusted Publisher).

## Test plan

- [x] Identity-provider unit tests: passthrough, numeric `user_id`, email-lookup hit, email-lookup miss raises, invalid format raises, sudo-disabled refuses, lookup caching, `set_user_lookup` propagation through the realistic `ArgumentSudo → DualMode → Sudo` chain, graceful skip when inner has no `set_user_lookup`, override of OAuth inner.
- [x] Git-tool integration tests (mock-based, `respx`): numeric `act_as_user` triggers full sudo flow, email resolves via `/users` lookup then sudos, lookup miss surfaces a clean tool error, invalid format rejected up front, `sudo_as_user=false` refuses cleanly, audit log emits with the right fields, audit log does not emit when the argument is absent.
- [x] Full suite: 322 passed, 0 failed.
- [x] Format / lint / typecheck: `uv run ruff format --check`, `uv run ruff check`, `uv run pyright` all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-call admin impersonation via an optional act_as_user on git/workspace tools (numeric ID or email); emits audit info for argument-driven impersonation.

* **Documentation**
  * README and changelog updated with usage, validation, failure modes, tool coverage, and the sudo kill-switch.

* **Tests**
  * End-to-end and unit tests added for impersonation flows, validation, lookup failures, sudo gating, and audit emission.

* **Release**
  * Package version bumped to 0.15.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->