### PR TITLE
fix(client): preserve full Looker error body on 4xx/5xx

### DIFF
--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -141,7 +141,15 @@ class LookerSession:
         else:
             if isinstance(parsed, dict):
                 body = parsed
-                detail = parsed.get("message", "") or parsed.get("error", "")
+                # ``detail`` is part of the public ``LookerApiError`` /
+                # ``format_api_error`` shape and consumers expect a string.
+                # Looker normally returns ``message``/``error`` as strings,
+                # but a non-conforming payload (nested object/array under
+                # those keys) would otherwise leak a non-string and break
+                # downstream string ops. Coerce defensively; the full
+                # structured payload is still available via ``body``.
+                hint = parsed.get("message") or parsed.get("error") or ""
+                detail = hint if isinstance(hint, str) else json.dumps(hint)[:500]
             else:
                 # Looker occasionally returns JSON arrays / scalars on error.
                 # Stringify to keep ``detail`` populated; don't carry through

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -25,10 +25,22 @@ logger = structlog.get_logger()
 class LookerApiError(Exception):
     """Raised when a Looker API call fails."""
 
-    def __init__(self, status_code: int, message: str, detail: str = "") -> None:
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        detail: str = "",
+        body: dict[str, Any] | None = None,
+    ) -> None:
         self.status_code = status_code
         self.message = message
         self.detail = detail
+        # Full decoded JSON error body when Looker returns a structured
+        # response. Carries fields like ``sql`` (compiled SQL on query
+        # failures), ``errors[]`` (LookML compile/evaluator diagnostics),
+        # and ``applied_filters`` — the highest-signal debugging payload.
+        # Left ``None`` for plain-text or unparseable bodies.
+        self.body = body
         super().__init__(f"Looker API {status_code}: {message}")
 
 
@@ -112,16 +124,30 @@ class LookerSession:
         text/plain ones). Try JSON first; fall back to a 500-char text
         truncation. Shared by both the JSON and text request paths so
         their error parsing can never drift.
+
+        When the body parses as a JSON object, it is captured verbatim on
+        the raised ``LookerApiError`` so callers can surface high-signal
+        fields like ``sql``, ``errors[]``, and ``applied_filters`` —
+        critical for debugging query and LookML failures.
         """
         if response.status_code < 400:
             return
         detail = ""
+        body: dict[str, Any] | None = None
         try:
-            body = response.json()
-            detail = body.get("message", "") or body.get("error", "")
+            parsed = response.json()
         except Exception:
             detail = response.text[:500]
-        raise LookerApiError(response.status_code, response.reason_phrase, detail)
+        else:
+            if isinstance(parsed, dict):
+                body = parsed
+                detail = parsed.get("message", "") or parsed.get("error", "")
+            else:
+                # Looker occasionally returns JSON arrays / scalars on error.
+                # Stringify to keep ``detail`` populated; don't carry through
+                # ``body`` since the contract is "dict or nothing".
+                detail = json.dumps(parsed)[:500]
+        raise LookerApiError(response.status_code, response.reason_phrase, detail, body=body)
 
     async def _request(
         self,
@@ -366,9 +392,15 @@ def format_api_error(tool_name: str, error: Exception) -> str:
                 hint = "Looker server error — the service may be temporarily unavailable."
             case _:
                 hint = error.message
-        result = {"error": hint, "status": status}
+        result: dict[str, Any] = {"error": hint, "status": status}
         if error.detail:
             result["detail"] = error.detail
+        # Surface the full Looker error body (sql, errors[], applied_filters,
+        # fields.measures[].sql, …) so debuggers don't have to re-fetch via
+        # raw REST. ``_raise_for_status`` only populates ``body`` when the
+        # response decoded as a JSON object.
+        if error.body is not None:
+            result["body"] = error.body
     elif isinstance(error, ValueError):
         # Validation errors raised by tools or identity providers
         # (e.g. ``act_as_user`` rejecting a malformed value or an

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -119,6 +119,27 @@ class TestLookerSession:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_error_with_non_string_message_coerces_detail_to_string(self):
+        # If Looker ever returns a non-string ``message`` (e.g. a nested
+        # error object), ``detail`` must remain a string for downstream
+        # consumers. The full payload is still preserved on ``body``.
+        api_url = "https://test.looker.com/api/4.0"
+        full_body = {
+            "message": {"code": "X1", "text": "structured error"},
+            "errors": [{"message": "downstream"}],
+        }
+        respx.get(f"{api_url}/something").mock(return_value=httpx.Response(400, json=full_body))
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            with pytest.raises(LookerApiError) as exc_info:
+                await session.get("/something")
+            assert isinstance(exc_info.value.detail, str)
+            assert "structured error" in exc_info.value.detail
+            # Full structured payload still accessible via body.
+            assert exc_info.value.body == full_body
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_delete_returns_none(self):
         api_url = "https://test.looker.com/api/4.0"
         respx.delete(f"{api_url}/resource/1").mock(return_value=httpx.Response(204))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -64,6 +64,61 @@ class TestLookerSession:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_error_carries_full_json_body(self):
+        api_url = "https://test.looker.com/api/4.0"
+        # Looker returns the compiled SQL and LookML evaluator errors in
+        # the 400 body for query failures. Callers need access to these.
+        full_body = {
+            "message": "Query failed with unexpected exception …",
+            "sql": "SELECT 1 FROM dual",
+            "errors": [{"message": "type mismatch"}],
+            "applied_filters": {"orders.created_date": "today"},
+        }
+        respx.get(f"{api_url}/queries/1/run/json").mock(
+            return_value=httpx.Response(400, json=full_body)
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            with pytest.raises(LookerApiError) as exc_info:
+                await session.get("/queries/1/run/json")
+            assert exc_info.value.status_code == 400
+            assert exc_info.value.detail == full_body["message"]
+            assert exc_info.value.body == full_body
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error_with_plain_text_body_leaves_body_none(self):
+        api_url = "https://test.looker.com/api/4.0"
+        respx.get(f"{api_url}/projects/p/git/deploy_key").mock(
+            return_value=httpx.Response(404, text="No deploy key configured")
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            with pytest.raises(LookerApiError) as exc_info:
+                await session.get_text("/projects/p/git/deploy_key")
+            assert exc_info.value.status_code == 404
+            assert "No deploy key configured" in exc_info.value.detail
+            assert exc_info.value.body is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_error_with_array_body_leaves_body_none(self):
+        # Some Looker endpoints occasionally return JSON arrays on error.
+        # The contract is "body is a dict or it's None" — array responses
+        # populate detail (truncated repr) but not body.
+        api_url = "https://test.looker.com/api/4.0"
+        respx.get(f"{api_url}/something").mock(
+            return_value=httpx.Response(400, json=["error1", "error2"])
+        )
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "test-token")
+            with pytest.raises(LookerApiError) as exc_info:
+                await session.get("/something")
+            assert exc_info.value.body is None
+            assert "error1" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_delete_returns_none(self):
         api_url = "https://test.looker.com/api/4.0"
         respx.delete(f"{api_url}/resource/1").mock(return_value=httpx.Response(204))
@@ -256,6 +311,31 @@ class TestFormatApiError:
         err = RuntimeError("something broke")
         result = json.loads(format_api_error("test_tool", err))
         assert "something broke" in result["error"]
+
+    def test_format_includes_full_body_when_present(self):
+        # Mimics a Looker query failure: detail message is generic but the
+        # body carries the compiled SQL, the LookML evaluator errors[], and
+        # applied_filters — the high-signal debugging payload that callers
+        # otherwise have to re-fetch via raw REST.
+        body = {
+            "message": "Query failed with unexpected exception …",
+            "sql": "SELECT region, SUM(total) FROM orders GROUP BY 1",
+            "errors": [
+                {"message": "wrong argument type NilClass (expected Integer)"},
+            ],
+            "applied_filters": {"orders.created_date": "90 days"},
+        }
+        err = LookerApiError(400, "Bad Request", "Query failed …", body=body)
+        result = json.loads(format_api_error("query", err))
+        assert result["status"] == 400
+        assert result["body"] == body
+        assert result["body"]["sql"].startswith("SELECT region")
+        assert result["body"]["errors"][0]["message"].startswith("wrong argument type")
+
+    def test_format_omits_body_when_absent(self):
+        err = LookerApiError(401, "Unauthorized", "Bad creds")
+        result = json.loads(format_api_error("test_tool", err))
+        assert "body" not in result
 
 
 class TestCheckConnectivity:


### PR DESCRIPTION
## Summary

When a Looker API call fails, `format_api_error` was reducing the response to `{error, status, detail}` — discarding the high-signal debugging fields that Looker actually returns in the error body:

- `sql` — fully compiled SQL (including any prepended PDT CTAS)
- `errors[]` — LookML compile/evaluator diagnostics (line numbers, file paths)
- `applied_filters` — filters Looker actually attached
- `fields.measures[].sql` — per-measure SQL fragments

For query failures hitting the LookML evaluator (e.g. a `wrong argument type NilClass (expected Integer)` evaluator error from a malformed `tests.lkml` assert), the compiled SQL and the LookML error array are exactly the fields you need to triage. Today users have to fall back to direct REST or browser DevTools to recover them.

## What changed

- `LookerApiError` now carries an optional `body: dict | None` field — populated when the 4xx/5xx response parses as a JSON object.
- `_raise_for_status` captures the full decoded body when present. Plain-text bodies, JSON arrays, and unparseable bodies all leave `body=None` (contract: "dict or nothing"). The existing 500-char text-truncation fallback is preserved for `detail`.
- `format_api_error` surfaces `body` in the result when set. Existing `error` / `status` / `detail` are unchanged so callers that read those keep working — the new field is purely additive.
- Both the JSON request path and the `get_text` / `post_text` paths share `_raise_for_status`, so deploy-key endpoints and similar text/plain responses pick up the same behavior automatically.

## Test plan

- [x] New unit tests in `tests/test_client.py`:
  - JSON 4xx with full evaluator-style body — `sql` + `errors[]` + `applied_filters` all surface in formatted result
  - Plain-text 404 — `body` stays `None`, `detail` carries text excerpt
  - JSON-array 4xx — `body` stays `None`, `detail` carries truncated JSON
  - `format_api_error` shape with and without a body present
- [x] Full suite passes: `uv run pytest` — 327 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## Backward compatibility

No breaking changes. `LookerApiError.body` defaults to `None`; the new `body` key in `format_api_error` output only appears when the underlying response carried one.

## Security

Looker error bodies do not contain credentials — only compile/eval state, query metadata, and SQL. Nothing sensitive is being newly surfaced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error reporting: when responses include structured JSON the error output now preserves that payload and provides a clearer, truncated textual detail for display; plain-text or non-object responses remain readable without exposing broken structure.
* **Tests**
  * Added tests covering structured and plain error responses, detail coercion, and formatted error output including the optional payload.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/28)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->