### PR TITLE
fix(query): use get_text for /run/sql endpoint

### DIFF
--- a/src/looker_mcp_server/tools/query.py
+++ b/src/looker_mcp_server/tools/query.py
@@ -102,7 +102,11 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
                 query_def = await session.post("/queries", body=body)
                 query_id = query_def["id"]
 
-                result = await session.get(f"/queries/{query_id}/run/sql")
+                # Looker returns the compiled SQL as text/plain; calling
+                # session.get would route through response.json() and raise
+                # ``Expecting value: line 1 column 1 (char 0)``. Mirrors the
+                # pattern used by the git deploy-key tools.
+                result = await session.get_text(f"/queries/{query_id}/run/sql")
                 return json.dumps({"sql": result}, indent=2)
         except Exception as e:
             return format_api_error("query_sql", e)

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -1,0 +1,77 @@
+"""Tests for query tool group — semantic-layer queries and content search."""
+
+import json
+
+import httpx
+import pytest
+import respx
+from fastmcp import Client
+from mcp.types import TextContent
+
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout() -> None:
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestQuerySql:
+    """Looker's ``/queries/{id}/run/sql`` endpoint returns ``text/plain`` —
+    the compiled SQL as a raw string. Routing it through ``session.get``
+    (which calls ``response.json()``) raises ``Expecting value: line 1
+    column 1`` before the SQL can ever be returned. This test stops the
+    regression by mocking the text/plain response and asserting the tool
+    returns the SQL string under ``{"sql": ...}``."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_compiled_sql_from_text_plain_response(self, config):
+        _mock_login_logout()
+
+        compiled_sql = "SELECT region, SUM(total) FROM orders GROUP BY 1"
+        respx.post(f"{API_URL}/queries").mock(
+            return_value=httpx.Response(201, json={"id": "abc123"})
+        )
+        respx.get(f"{API_URL}/queries/abc123/run/sql").mock(
+            return_value=httpx.Response(
+                200,
+                text=compiled_sql,
+                headers={"content-type": "text/plain"},
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "query_sql",
+                    {
+                        "model": "ecommerce",
+                        "view": "orders",
+                        "fields": ["orders.region", "orders.total"],
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["sql"] == compiled_sql
+        finally:
+            await client.close()


### PR DESCRIPTION
## Summary

`query_sql` is unconditionally broken on every Looker connection:

```
mcp__looker__query_sql(...) →
"Unexpected error in query_sql: Expecting value: line 1 column 1 (char 0)"
```

The endpoint at `GET /queries/{id}/run/sql` returns the compiled SQL as `text/plain` — not JSON. The previous code routed through `session.get` (which calls `response.json()`), so the JSON decoder raised before the SQL string could be returned. Made it impossible to capture compiled SQL via the MCP.

## What changed

- `tools/query.py`: swap `session.get` → `session.get_text` for the `/run/sql` call. The `get_text` helper already exists at `client.py:84` and is used by the git deploy-key tools (`tools/git.py:324, 351`) for the same reason. Both paths share `_raise_for_status` so error handling stays consistent.

## Test plan

- [x] New test `tests/test_query_tools.py::TestQuerySql::test_returns_compiled_sql_from_text_plain_response` mocks a text/plain `/run/sql` response and asserts the SQL string surfaces under `{"sql": ...}`.
- [x] Full suite passes: `uv run pytest` — 323 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## Backward compatibility

No breaking changes. The tool's response shape is unchanged — `{"sql": ...}` — but `sql` now actually contains the compiled SQL instead of the tool always erroring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the query_sql tool failed to retrieve compiled SQL when Looker returned responses as plain text. The tool now handles both text and JSON response formats correctly.

* **Tests**
  * Added comprehensive test coverage for the query_sql tool to validate proper handling of plain text SQL responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/29)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->