### PR TITLE
feat(client+tools): dev_mode + branch + act_as_user for query and git

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The git tools accept an optional `act_as_user` argument so an admin can perform 
 
 **Security model.** The MCP forwards capability — it does not gate it. Sudo permission is enforced by Looker server-side: if the configured `LOOKER_CLIENT_ID` does not have sudo capability, `login_user` returns HTTP 403 and the tool fails. There is no MCP-side "who may impersonate whom" policy in the open-source server; layer one in via a wrapping `IdentityProvider` if you need it (see the next section).
 
-**Tool coverage (v1).** All eight git/workspace-scoped tools accept `act_as_user`: `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`, `delete_git_branch`, `deploy_to_production`, `reset_to_production`. Project-level tools (deploy keys, connection diagnostics) deliberately do not — they don't depend on per-user dev workspace state.
+**Tool coverage.** All eight git/workspace-scoped tools accept `act_as_user`: `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`, `delete_git_branch`, `deploy_to_production`, `reset_to_production`. The four query tools accept it too — `query`, `query_sql`, `query_url`, `run_look` — for the CI pattern where queries against a feature branch must run under a dedicated service user's dev workspace rather than the calling admin's. Project-level tools (deploy keys, connection diagnostics) deliberately do not — they don't depend on per-user dev workspace state.
 
 **Audit log.** Every argument-driven sudo emits an INFO-level structlog line:
 
@@ -260,6 +260,82 @@ This is independent of the trace-level `looker.session.sudo` debug line and is t
 - Email does not match any Looker user → validation error. Fail-loud is deliberate; silently falling back to the configured identity would let a typo'd email run the action under the wrong user.
 - `LOOKER_SUDO_AS_USER=false` and `act_as_user` is passed → validation error explaining how to fix (enable sudo or remove the argument).
 - Configured credentials lack sudo capability → Looker returns 403 on `login_user`, surfaced as `Permission denied — the current user lacks access.`
+
+## Dev Mode and Branch Validation
+
+The query tools (`query`, `query_sql`, `query_url`, `run_look`) and the modeling/git tools accept three optional arguments — `dev_mode`, `branch`, and `project_id` — that together let you run operations against the LookML in a Looker dev workspace rather than production. This is what makes feature-branch validation possible from the MCP without falling back to raw REST.
+
+**How Looker scopes workspaces.** Workspace selection (production vs. dev) is a property of the API session token, not the call. The MCP issues `PATCH /session {"workspace_id": "dev"}` immediately after authentication when `dev_mode=True` is set; this affects every subsequent call routed through the same session. The setting does not persist across logins, so each MCP call sets it explicitly.
+
+**Branch state is per-Looker-user, server-side.** Each Looker user has exactly one dev workspace, with one currently-checked-out branch per LookML project. The branch checkout persists across logouts and concurrent calls — it's mutable shared state on Looker's server. Two operations against the same user fight over this single cell.
+
+### Atomic branch swap
+
+Set `branch="<feature-branch>"` and `project_id="<lookml-project>"` on a query tool to atomically:
+
+1. Save the user's currently-checked-out branch on the project.
+2. PUT the target branch.
+3. Run the query.
+4. Restore the saved branch in `finally` (even if the query raises).
+
+`branch` implies `dev_mode=True`. The save and restore are no-ops when the dev workspace is already on the target branch.
+
+### Canonical workflows
+
+**One-shot CI: validate a PR's LookML against real data.** Single tool call, atomic. The dedicated CI service user's dev workspace is borrowed for the duration; the saved branch is restored before the call returns.
+
+```jsonc
+{
+  "tool": "query",
+  "args": {
+    "model": "ecommerce",
+    "view": "orders",
+    "fields": ["orders.region", "orders.total_revenue"],
+    "branch": "feature/new-aggregation",
+    "project_id": "ecommerce",
+    "act_as_user": "ci-bot@example.com"
+  }
+}
+```
+
+**Production vs. PR comparison.** Two calls — the LLM diffs the results in its own context.
+
+```jsonc
+{ "tool": "query", "args": { "model": "ecommerce", "view": "orders", "fields": [...] } }
+{ "tool": "query", "args": { "model": "ecommerce", "view": "orders", "fields": [...],
+                              "branch": "feature/new-aggregation", "project_id": "ecommerce",
+                              "act_as_user": "ci-bot@example.com" } }
+```
+
+**Iterative human debug.** The branch state is sticky in the dev workspace, so set it once with `switch_git_branch` and run multiple queries with `dev_mode=True` (no `branch` arg). Restore the user's normal branch with another `switch_git_branch` when done.
+
+```jsonc
+{ "tool": "switch_git_branch", "args": { "project_id": "ecommerce", "branch_name": "feature/new-aggregation" } }
+{ "tool": "query",             "args": { "model": "ecommerce", "view": "orders", "fields": [...], "dev_mode": true } }
+{ "tool": "update_lookml_file", "args": { ... } }
+{ "tool": "query",             "args": { "model": "ecommerce", "view": "orders", "fields": [...], "dev_mode": true } }
+{ "tool": "switch_git_branch", "args": { "project_id": "ecommerce", "branch_name": "main" } }
+```
+
+**Cleanup another user's stuck dev workspace.** Combine `act_as_user` with the git tools to operate on someone else's per-user state.
+
+```jsonc
+{
+  "tool": "switch_git_branch",
+  "args": { "project_id": "ecommerce", "branch_name": "main", "act_as_user": "alice@example.com" }
+}
+```
+
+### Concurrency caveat
+
+Looker's per-user-per-project branch checkout is a single mutable cell. Two concurrent operations on the same `act_as_user` (or the same configured admin identity, when `act_as_user` is omitted) race on it. The atomic save+restore prevents accidental state leaks, but it does **not** serialize concurrent calls — if your CI fans out across many open PRs against a single ci-bot user, you'll see non-deterministic results.
+
+For parallel PR validation, provision multiple Looker users (e.g. `ci-bot-1`, `ci-bot-2`, …) and have your CI fan-out logic rotate through them via `act_as_user`. There is no MCP-side mutex; this is an operational choice the deployer makes.
+
+### What `dev_mode` does *not* cover (v1)
+
+- **Multi-project manifest imports.** If your LookML project imports another project, the import stays on whatever branch is currently checked out in the dev workspace for that imported project. The atomic swap is single-project; recursive manifest-aware swapping is a v2 concern.
+- **Cross-call session continuity.** Each tool call gets its own ephemeral API session (login → operation → logout), so `dev_mode=True` only takes effect within a single call. The branch state persists across calls because Looker stores it server-side per-user; the workspace setting does not.
 
 ## Extending with Custom Identity Providers
 

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Set `branch="<feature-branch>"` and `project_id="<lookml-project>"` on a query t
 ```jsonc
 {
   "tool": "query",
-  "args": {
+  "arguments": {
     "model": "ecommerce",
     "view": "orders",
     "fields": ["orders.region", "orders.total_revenue"],
@@ -301,20 +301,20 @@ Set `branch="<feature-branch>"` and `project_id="<lookml-project>"` on a query t
 **Production vs. PR comparison.** Two calls — the LLM diffs the results in its own context.
 
 ```jsonc
-{ "tool": "query", "args": { "model": "ecommerce", "view": "orders", "fields": [...] } }
-{ "tool": "query", "args": { "model": "ecommerce", "view": "orders", "fields": [...],
-                              "branch": "feature/new-aggregation", "project_id": "ecommerce",
-                              "act_as_user": "ci-bot@example.com" } }
+{ "tool": "query", "arguments": { "model": "ecommerce", "view": "orders", "fields": [...] } }
+{ "tool": "query", "arguments": { "model": "ecommerce", "view": "orders", "fields": [...],
+                                   "branch": "feature/new-aggregation", "project_id": "ecommerce",
+                                   "act_as_user": "ci-bot@example.com" } }
 ```
 
 **Iterative human debug.** The branch state is sticky in the dev workspace, so set it once with `switch_git_branch` and run multiple queries with `dev_mode=True` (no `branch` arg). Restore the user's normal branch with another `switch_git_branch` when done.
 
 ```jsonc
-{ "tool": "switch_git_branch", "args": { "project_id": "ecommerce", "branch_name": "feature/new-aggregation" } }
-{ "tool": "query",             "args": { "model": "ecommerce", "view": "orders", "fields": [...], "dev_mode": true } }
-{ "tool": "update_lookml_file", "args": { ... } }
-{ "tool": "query",             "args": { "model": "ecommerce", "view": "orders", "fields": [...], "dev_mode": true } }
-{ "tool": "switch_git_branch", "args": { "project_id": "ecommerce", "branch_name": "main" } }
+{ "tool": "switch_git_branch", "arguments": { "project_id": "ecommerce", "branch_name": "feature/new-aggregation" } }
+{ "tool": "query",             "arguments": { "model": "ecommerce", "view": "orders", "fields": [...], "dev_mode": true } }
+{ "tool": "update_lookml_file", "arguments": { ... } }
+{ "tool": "query",             "arguments": { "model": "ecommerce", "view": "orders", "fields": [...], "dev_mode": true } }
+{ "tool": "switch_git_branch", "arguments": { "project_id": "ecommerce", "branch_name": "main" } }
 ```
 
 **Cleanup another user's stuck dev workspace.** Combine `act_as_user` with the git tools to operate on someone else's per-user state.
@@ -322,7 +322,7 @@ Set `branch="<feature-branch>"` and `project_id="<lookml-project>"` on a query t
 ```jsonc
 {
   "tool": "switch_git_branch",
-  "args": { "project_id": "ecommerce", "branch_name": "main", "act_as_user": "alice@example.com" }
+  "arguments": { "project_id": "ecommerce", "branch_name": "main", "act_as_user": "alice@example.com" }
 }
 ```
 

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -11,6 +11,7 @@ import json
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 import structlog
@@ -103,6 +104,62 @@ class LookerSession:
         """POST to an endpoint that returns ``text/plain`` (deploy-key rotation)."""
         return await self._request_text("POST", path, params=params)
 
+    async def update_workspace(self, workspace_id: str) -> None:
+        """Set the active workspace on this API session.
+
+        Looker's session model treats workspace as a per-session property:
+        ``PATCH /session {"workspace_id": "dev"}`` switches into the dev
+        workspace; ``"production"`` switches back. The setting is bound to
+        the bearer token and does not survive logout — every new login
+        starts in production. Calling this method is idempotent (Looker
+        returns the current state regardless of whether the value changed).
+
+        Required prerequisite for any operation that needs the user's dev
+        workspace: branch checkouts, dev-mode file edits, dev-LookML
+        queries, dev-LookML data tests.
+        """
+        await self.patch("/session", body={"workspace_id": workspace_id})
+
+    @asynccontextmanager
+    async def use_branch(self, project_id: str, branch_name: str) -> AsyncGenerator[None, None]:
+        """Atomically swap the project's branch for the duration of the block.
+
+        Reads the dev workspace's currently-checked-out branch on the
+        project, switches to ``branch_name`` for the body, and restores
+        the saved branch in ``finally`` — even if the body raises. This
+        is the safe default for one-shot operations against a feature
+        branch (e.g. CI validating a PR).
+
+        Caller must have already called ``update_workspace("dev")``;
+        Looker rejects branch operations from the production workspace.
+        If the dev workspace is already checked out to ``branch_name``,
+        the swap and the restore are both no-ops.
+
+        The restore is best-effort: if the second PUT fails (network
+        flake, branch deleted concurrently), the failure is logged but
+        does not mask the original exception.
+        """
+        path = f"/projects/{quote(project_id, safe='')}/git_branch"
+        current = await self.get(path)
+        saved = (current or {}).get("name")
+        if saved == branch_name:
+            yield
+            return
+        await self.put(path, body={"name": branch_name})
+        try:
+            yield
+        finally:
+            try:
+                await self.put(path, body={"name": saved})
+            except Exception as restore_err:  # pragma: no cover — log-only
+                logger.error(
+                    "looker.branch.restore_failed",
+                    project_id=project_id,
+                    saved_branch=saved,
+                    target_branch=branch_name,
+                    error=str(restore_err),
+                )
+
     @staticmethod
     def _raise_for_status(response: httpx.Response) -> None:
         """Raise ``LookerApiError`` with the best-available detail string.
@@ -185,7 +242,12 @@ class LookerClient:
     # ── Public API ───────────────────────────────────────────────────
 
     @asynccontextmanager
-    async def session(self, context: RequestContext) -> AsyncGenerator[LookerSession, None]:
+    async def session(
+        self,
+        context: RequestContext,
+        *,
+        dev_mode: bool = False,
+    ) -> AsyncGenerator[LookerSession, None]:
         """Create an ephemeral authenticated session for a tool invocation.
 
         The session lifecycle depends on the resolved identity mode:
@@ -193,6 +255,13 @@ class LookerClient:
         - **api_key**: login with client credentials → yield → logout
         - **sudo**: admin login → login_user → yield → logout sudo → logout admin
         - **oauth**: use pre-obtained token directly → yield (no login/logout)
+
+        When ``dev_mode=True``, the session is switched into the dev
+        workspace via ``PATCH /session`` immediately after authentication.
+        Looker scopes workspace selection to the bearer token, so this
+        affects every subsequent call routed through the yielded
+        ``LookerSession``. Required for branch checkouts, dev-mode file
+        edits, dev-LookML queries, and dev-LookML data tests.
         """
         identity = await self._identity_provider.resolve(context)
         log = logger.bind(mode=identity.mode, tool=context.tool_name)
@@ -202,7 +271,10 @@ class LookerClient:
                 token = await self._login(identity.client_id, identity.client_secret)
                 log.debug("looker.session.created")
                 try:
-                    yield LookerSession(self._http, token)
+                    session = LookerSession(self._http, token)
+                    if dev_mode:
+                        await session.update_workspace("dev")
+                    yield session
                 finally:
                     await self._logout(token)
 
@@ -237,7 +309,10 @@ class LookerClient:
                             configured_user=identity.client_id,
                         )
                     try:
-                        yield LookerSession(self._http, sudo_token)
+                        session = LookerSession(self._http, sudo_token)
+                        if dev_mode:
+                            await session.update_workspace("dev")
+                        yield session
                     finally:
                         await self._logout(sudo_token)
                 finally:
@@ -247,7 +322,10 @@ class LookerClient:
                 if not identity.access_token:
                     raise ValueError("OAuth identity resolved without an access token.")
                 log.debug("looker.session.oauth")
-                yield LookerSession(self._http, identity.access_token)
+                session = LookerSession(self._http, identity.access_token)
+                if dev_mode:
+                    await session.update_workspace("dev")
+                yield session
 
             case _:
                 raise ValueError(f"Unknown identity mode: {identity.mode!r}")

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -142,6 +142,19 @@ class LookerSession:
         path = f"/projects/{quote(project_id, safe='')}/git_branch"
         current = await self.get(path)
         saved = (current or {}).get("name")
+        # Fail fast if Looker returns a malformed/empty payload without a
+        # branch name. Without this guard, the swap would still PUT the
+        # target branch but the restore would PUT ``{"name": None}``,
+        # which Looker would reject — leaving the workspace stuck on the
+        # caller-supplied branch and silently breaking the atomic swap.
+        if not isinstance(saved, str) or not saved:
+            raise LookerApiError(
+                500,
+                "Cannot swap branches",
+                f"Project {project_id!r} returned no current branch name from "
+                "GET /projects/{id}/git_branch — refusing to swap without a "
+                "known restore target.",
+            )
         if saved == branch_name:
             yield
             return

--- a/src/looker_mcp_server/tools/_helpers.py
+++ b/src/looker_mcp_server/tools/_helpers.py
@@ -6,7 +6,7 @@ Anything that grows beyond one-liners should move to its own module.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Annotated, Any
 from urllib.parse import quote
 
 
@@ -29,3 +29,20 @@ def _path_seg(value: str | int) -> str:
     for values that would otherwise be interpreted as sub-paths.
     """
     return quote(str(value), safe="")
+
+
+# Per-call admin impersonation argument shared across tool groups (git,
+# query, modeling). The MCP forwards capability — Looker enforces whether
+# the configured admin credentials may impersonate (HTTP 403 if not).
+# Email values are resolved via Looker's user-search API; numeric values
+# are used directly. ``ArgumentSudoIdentityProvider`` in :mod:`..identity`
+# notices this argument and rewrites the resolved identity to a sudo
+# session targeting ``act_as_user``.
+ACT_AS_USER_DESCRIPTION = (
+    "Optional Looker user ID or email to impersonate for this call. "
+    "Use to operate on another user's dev workspace (Looker dev mode is "
+    "per-user-isolated) or to run as a dedicated CI service user. Requires "
+    "sudo capability on the configured admin credentials. When omitted, the "
+    "call uses the configured or gateway-provided identity."
+)
+ActAsUser = Annotated[str | None, ACT_AS_USER_DESCRIPTION]

--- a/src/looker_mcp_server/tools/git.py
+++ b/src/looker_mcp_server/tools/git.py
@@ -15,22 +15,7 @@ from typing import Annotated, Any
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
-from ._helpers import _path_seg
-
-# Per-call admin impersonation. The MCP forwards capability — Looker
-# enforces whether the configured admin credentials may impersonate
-# (HTTP 403 if not). Email values are resolved via Looker's user-search
-# API; numeric values are used directly. ``ArgumentSudoIdentityProvider``
-# in :mod:`..identity` notices this argument and rewrites the resolved
-# identity to a sudo session targeting ``act_as_user``.
-ACT_AS_USER_DESCRIPTION = (
-    "Optional Looker user ID or email to impersonate for this call. "
-    "Use to clean up another user's dev workspace (Looker dev mode is "
-    "per-user-isolated). Requires sudo capability on the configured "
-    "admin credentials. When omitted, the call uses the configured or "
-    "gateway-provided identity."
-)
-ActAsUser = Annotated[str | None, ACT_AS_USER_DESCRIPTION]
+from ._helpers import ActAsUser, _path_seg
 
 
 def register_git_tools(server: FastMCP, client: LookerClient) -> None:
@@ -131,7 +116,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "Create a new Git branch in a LookML project. "
-            "The branch is created from the current ref."
+            "The branch is created from the current ref. Requires Looker dev mode."
         ),
     )
     async def create_git_branch(
@@ -146,7 +131,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
             {"project_id": project_id, "act_as_user": act_as_user},
         )
         try:
-            async with client.session(ctx) as session:
+            async with client.session(ctx, dev_mode=True) as session:
                 body: dict[str, Any] = {"name": branch_name}
                 if ref:
                     body["ref"] = ref
@@ -162,7 +147,12 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
-            "Switch to a different Git branch in a LookML project. Requires dev mode to be enabled."
+            "Switch to a different Git branch in a LookML project. Operates "
+            "on the user's dev workspace (per-Looker-user, per-project). The "
+            "switch persists server-side until another switch is made — "
+            "remember to switch back to a known-good branch when done with "
+            "iterative work, or pair this with subsequent calls that include "
+            "branch=… for atomic save/restore semantics."
         ),
     )
     async def switch_git_branch(
@@ -176,7 +166,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
             {"project_id": project_id, "act_as_user": act_as_user},
         )
         try:
-            async with client.session(ctx) as session:
+            async with client.session(ctx, dev_mode=True) as session:
                 branch = await session.put(
                     f"/projects/{_path_seg(project_id)}/git_branch",
                     body={"name": branch_name},
@@ -215,7 +205,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
             },
         )
         try:
-            async with client.session(ctx) as session:
+            async with client.session(ctx, dev_mode=True) as session:
                 await session.delete(
                     f"/projects/{_path_seg(project_id)}/git_branch/{_path_seg(branch_name)}"
                 )
@@ -291,7 +281,7 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
             {"project_id": project_id, "act_as_user": act_as_user},
         )
         try:
-            async with client.session(ctx) as session:
+            async with client.session(ctx, dev_mode=True) as session:
                 result = await session.post(
                     f"/projects/{_path_seg(project_id)}/reset_to_production"
                 )

--- a/src/looker_mcp_server/tools/query.py
+++ b/src/looker_mcp_server/tools/query.py
@@ -7,11 +7,46 @@ saved Looks and dashboards, and searching across all content.
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
 
-from ..client import LookerClient, format_api_error
+from ..client import LookerClient, LookerSession, format_api_error
+from ._helpers import ActAsUser
+
+
+def _validate_branch_args(branch: str | None, project_id: str | None) -> None:
+    """Branch swap requires the project ID — Looker scopes branches per
+    project, and ``LookerSession.use_branch`` needs the path segment to
+    issue ``GET/PUT /projects/{id}/git_branch``. Raised as ``ValueError``
+    so it surfaces through ``format_api_error`` as a self-describing
+    validation error rather than an opaque API failure.
+    """
+    if branch is not None and not project_id:
+        raise ValueError(
+            "branch=… requires project_id=…; pass the LookML project ID that "
+            "owns the branch you want to atomically swap to."
+        )
+
+
+@asynccontextmanager
+async def _maybe_use_branch(
+    session: LookerSession, project_id: str | None, branch: str | None
+) -> AsyncGenerator[None, None]:
+    """Wrap the body in ``session.use_branch`` only when ``branch`` is set.
+
+    Tools that take an optional ``branch`` argument don't want to nest
+    yet another ``async with`` for the no-branch case, but they also need
+    the atomic save+restore semantics when a branch IS set. This helper
+    keeps the call site flat in both modes.
+    """
+    if branch is None or project_id is None:
+        yield
+        return
+    async with session.use_branch(project_id, branch):
+        yield
 
 
 def register_query_tools(server: FastMCP, client: LookerClient) -> None:
@@ -43,31 +78,62 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
             str,
             "Output format: 'json' (default), 'json_detail', 'csv', 'txt'",
         ] = "json",
+        dev_mode: Annotated[
+            bool,
+            "Run against the dev workspace's currently-checked-out LookML "
+            "rather than production. Required when validating in-progress "
+            "branch edits. Implied automatically when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call. The dev "
+            "workspace's saved branch is restored when the call completes "
+            "(success or failure). Implies dev_mode=True; requires project_id.",
+        ] = None,
+        project_id: Annotated[
+            str | None,
+            "LookML project ID — required when ``branch`` is set so the "
+            "MCP knows which project's branch state to swap.",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("query", "query", {"model": model, "view": view})
+        ctx = client.build_context(
+            "query",
+            "query",
+            {
+                "model": model,
+                "view": view,
+                "branch": branch,
+                "project_id": project_id,
+                "act_as_user": act_as_user,
+            },
+        )
         try:
-            async with client.session(ctx) as session:
-                body: dict[str, Any] = {
-                    "model": model,
-                    "view": view,
-                    "fields": fields,
-                    "limit": str(limit),
-                }
-                if filters:
-                    body["filters"] = filters
-                if sorts:
-                    body["sorts"] = sorts
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    body: dict[str, Any] = {
+                        "model": model,
+                        "view": view,
+                        "fields": fields,
+                        "limit": str(limit),
+                    }
+                    if filters:
+                        body["filters"] = filters
+                    if sorts:
+                        body["sorts"] = sorts
 
-                query_def = await session.post("/queries", body=body)
-                query_id = query_def["id"]
+                    query_def = await session.post("/queries", body=body)
+                    query_id = query_def["id"]
 
-                result = await session.get(f"/queries/{query_id}/run/{result_format}")
-                if isinstance(result, list):
-                    return json.dumps(
-                        {"row_count": len(result), "data": result},
-                        indent=2,
-                    )
-                return json.dumps(result, indent=2)
+                    result = await session.get(f"/queries/{query_id}/run/{result_format}")
+                    if isinstance(result, list):
+                        return json.dumps(
+                            {"row_count": len(result), "data": result},
+                            indent=2,
+                        )
+                    return json.dumps(result, indent=2)
         except Exception as e:
             return format_api_error("query", e)
 
@@ -84,30 +150,55 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
         filters: Annotated[dict[str, str] | None, "Filter expressions"] = None,
         sorts: Annotated[list[str] | None, "Sort expressions"] = None,
         limit: Annotated[int, "Maximum rows"] = 500,
+        dev_mode: Annotated[
+            bool,
+            "Compile the SQL against the dev workspace's LookML rather "
+            "than production. Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call (saved "
+            "branch restored on exit). Requires project_id.",
+        ] = None,
+        project_id: Annotated[str | None, "LookML project ID — required with ``branch``"] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("query_sql", "query", {"model": model, "view": view})
+        ctx = client.build_context(
+            "query_sql",
+            "query",
+            {
+                "model": model,
+                "view": view,
+                "branch": branch,
+                "project_id": project_id,
+                "act_as_user": act_as_user,
+            },
+        )
         try:
-            async with client.session(ctx) as session:
-                body: dict[str, Any] = {
-                    "model": model,
-                    "view": view,
-                    "fields": fields,
-                    "limit": str(limit),
-                }
-                if filters:
-                    body["filters"] = filters
-                if sorts:
-                    body["sorts"] = sorts
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    body: dict[str, Any] = {
+                        "model": model,
+                        "view": view,
+                        "fields": fields,
+                        "limit": str(limit),
+                    }
+                    if filters:
+                        body["filters"] = filters
+                    if sorts:
+                        body["sorts"] = sorts
 
-                query_def = await session.post("/queries", body=body)
-                query_id = query_def["id"]
+                    query_def = await session.post("/queries", body=body)
+                    query_id = query_def["id"]
 
-                # Looker returns the compiled SQL as text/plain; calling
-                # session.get would route through response.json() and raise
-                # ``Expecting value: line 1 column 1 (char 0)``. Mirrors the
-                # pattern used by the git deploy-key tools.
-                result = await session.get_text(f"/queries/{query_id}/run/sql")
-                return json.dumps({"sql": result}, indent=2)
+                    # Looker returns the compiled SQL as text/plain; calling
+                    # session.get would route through response.json() and raise
+                    # ``Expecting value: line 1 column 1 (char 0)``. Mirrors the
+                    # pattern used by the git deploy-key tools.
+                    result = await session.get_text(f"/queries/{query_id}/run/sql")
+                    return json.dumps({"sql": result}, indent=2)
         except Exception as e:
             return format_api_error("query_sql", e)
 
@@ -121,20 +212,47 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
         look_id: Annotated[str, "ID of the saved Look"],
         result_format: Annotated[str, "Output format: 'json', 'csv', 'txt'"] = "json",
         limit: Annotated[int, "Maximum rows to return"] = 500,
+        dev_mode: Annotated[
+            bool,
+            "Resolve the Look's model+explore against the dev workspace's "
+            "LookML rather than production. Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call (saved "
+            "branch restored on exit). Requires project_id.",
+        ] = None,
+        project_id: Annotated[
+            str | None,
+            "LookML project ID owning the Look's model — required with ``branch``",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("run_look", "query", {"look_id": look_id})
+        ctx = client.build_context(
+            "run_look",
+            "query",
+            {
+                "look_id": look_id,
+                "branch": branch,
+                "project_id": project_id,
+                "act_as_user": act_as_user,
+            },
+        )
         try:
-            async with client.session(ctx) as session:
-                result = await session.get(
-                    f"/looks/{look_id}/run/{result_format}",
-                    params={"limit": limit},
-                )
-                if isinstance(result, list):
-                    return json.dumps(
-                        {"row_count": len(result), "data": result},
-                        indent=2,
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    result = await session.get(
+                        f"/looks/{look_id}/run/{result_format}",
+                        params={"limit": limit},
                     )
-                return json.dumps(result, indent=2)
+                    if isinstance(result, list):
+                        return json.dumps(
+                            {"row_count": len(result), "data": result},
+                            indent=2,
+                        )
+                    return json.dumps(result, indent=2)
         except Exception as e:
             return format_api_error("run_look", e)
 
@@ -197,23 +315,49 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
         fields: Annotated[list[str], "Fields to select"],
         filters: Annotated[dict[str, str] | None, "Filter expressions"] = None,
         sorts: Annotated[list[str] | None, "Sort expressions"] = None,
+        dev_mode: Annotated[
+            bool,
+            "Generate the URL against dev-workspace LookML. Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call. Requires project_id.",
+        ] = None,
+        project_id: Annotated[str | None, "LookML project ID — required with ``branch``"] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("query_url", "query", {"model": model, "view": view})
+        ctx = client.build_context(
+            "query_url",
+            "query",
+            {
+                "model": model,
+                "view": view,
+                "branch": branch,
+                "project_id": project_id,
+                "act_as_user": act_as_user,
+            },
+        )
         try:
-            async with client.session(ctx) as session:
-                body: dict[str, Any] = {
-                    "model": model,
-                    "view": view,
-                    "fields": fields,
-                }
-                if filters:
-                    body["filters"] = filters
-                if sorts:
-                    body["sorts"] = sorts
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    body: dict[str, Any] = {
+                        "model": model,
+                        "view": view,
+                        "fields": fields,
+                    }
+                    if filters:
+                        body["filters"] = filters
+                    if sorts:
+                        body["sorts"] = sorts
 
-                query_def = await session.post("/queries", body=body)
-                share_url = query_def.get("share_url") or query_def.get("url")
-                return json.dumps({"url": share_url, "query_id": query_def.get("id")}, indent=2)
+                    query_def = await session.post("/queries", body=body)
+                    share_url = query_def.get("share_url") or query_def.get("url")
+                    return json.dumps(
+                        {"url": share_url, "query_id": query_def.get("id")},
+                        indent=2,
+                    )
         except Exception as e:
             return format_api_error("query_url", e)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -172,6 +172,148 @@ class TestLookerClientApiKey:
 
         await client.close()
 
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dev_mode_patches_session_workspace(self, config):
+        api_url = config.api_url
+        respx.post(f"{api_url}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "sess-token"})
+        )
+        # The contract: when ``dev_mode=True``, PATCH /session is called
+        # with workspace_id=dev before the body runs. Without it, branch
+        # operations would fail with "Developer mode required".
+        patch_route = respx.patch(f"{api_url}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        respx.delete(f"{api_url}/logout").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = RequestContext(tool_name="t", tool_group="g")
+
+        async with client.session(ctx, dev_mode=True):
+            pass
+
+        assert patch_route.called
+        body = json.loads(patch_route.calls[0].request.content.decode())
+        assert body == {"workspace_id": "dev"}
+        await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_default_session_does_not_patch_workspace(self, config):
+        api_url = config.api_url
+        respx.post(f"{api_url}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "sess-token"})
+        )
+        patch_route = respx.patch(f"{api_url}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        respx.delete(f"{api_url}/logout").mock(return_value=httpx.Response(204))
+
+        provider = ApiKeyIdentityProvider("test-id", "test-secret")
+        client = LookerClient(config, provider)
+        ctx = RequestContext(tool_name="t", tool_group="g")
+
+        async with client.session(ctx):
+            pass
+
+        # Default ``dev_mode=False`` must NOT issue PATCH /session — Looker
+        # sessions default to production workspace and that's the right
+        # behavior for non-dev-mode tools.
+        assert not patch_route.called
+        await client.close()
+
+
+class TestUseBranch:
+    """``LookerSession.use_branch`` performs an in-session save → PUT
+    target → yield → PUT saved cycle. The save+restore is what makes
+    ``query(branch=…)`` safe for one-shot CI validation: even if the
+    body raises, the workspace state is restored to whatever was checked
+    out before the call."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_save_swap_restore_on_success(self):
+        api_url = "https://test.looker.com/api/4.0"
+        # GET current branch returns the saved name
+        respx.get(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        # Two PUTs: one to feature-x (the swap), one back to main (the restore)
+        put_route = respx.put(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "tok")
+            async with session.use_branch("myproj", "feature-x"):
+                pass
+
+        # Two PUT calls: swap then restore.
+        assert put_route.call_count == 2
+        bodies = [json.loads(c.request.content.decode()) for c in put_route.calls]
+        assert bodies == [{"name": "feature-x"}, {"name": "main"}]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_restore_runs_in_finally_when_body_raises(self):
+        api_url = "https://test.looker.com/api/4.0"
+        respx.get(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        put_route = respx.put(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "tok")
+            with pytest.raises(RuntimeError, match="boom"):
+                async with session.use_branch("myproj", "feature-x"):
+                    raise RuntimeError("boom")
+
+        # Both swap AND restore happened despite the exception.
+        assert put_route.call_count == 2
+        bodies = [json.loads(c.request.content.decode()) for c in put_route.calls]
+        assert bodies[1] == {"name": "main"}, "restore must run in finally"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_no_op_when_already_on_target_branch(self):
+        api_url = "https://test.looker.com/api/4.0"
+        respx.get(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+        put_route = respx.put(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "tok")
+            async with session.use_branch("myproj", "feature-x"):
+                pass
+
+        # No swap, no restore — the branch was already where we wanted it.
+        assert put_route.call_count == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_project_id_with_slash_is_path_encoded(self):
+        api_url = "https://test.looker.com/api/4.0"
+        # ``my/proj`` must be percent-encoded as ``my%2Fproj`` so it doesn't
+        # misroute as a sub-path.
+        respx.get(f"{api_url}/projects/my%2Fproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        respx.put(f"{api_url}/projects/my%2Fproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "tok")
+            async with session.use_branch("my/proj", "feature-x"):
+                pass
+
 
 class TestLookerClientSudo:
     @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -279,6 +279,31 @@ class TestUseBranch:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_raises_when_current_branch_name_missing(self):
+        # Defense against a Looker payload that omits ``name``: the swap
+        # would silently put the workspace on the target branch, then
+        # restore with ``{"name": None}`` (which Looker rejects), leaving
+        # the workspace stuck on the caller-supplied branch. We fail fast
+        # before the swap so atomic semantics aren't quietly broken.
+        api_url = "https://test.looker.com/api/4.0"
+        respx.get(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={})  # no "name" key
+        )
+        # PUT should NEVER be called — failure must precede any state mutation.
+        put_route = respx.put(f"{api_url}/projects/myproj/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+
+        async with httpx.AsyncClient(base_url=api_url) as http:
+            session = LookerSession(http, "tok")
+            with pytest.raises(LookerApiError) as exc_info:
+                async with session.use_branch("myproj", "feature-x"):
+                    pass
+            assert "no current branch name" in exc_info.value.detail
+        assert put_route.call_count == 0
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_no_op_when_already_on_target_branch(self):
         api_url = "https://test.looker.com/api/4.0"
         respx.get(f"{api_url}/projects/myproj/git_branch").mock(

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -58,6 +58,12 @@ def _mock_login_logout():
         return_value=httpx.Response(200, json={"access_token": "sess-token"})
     )
     respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+    # Dev-mode-required tools (switch/create/delete branch, reset_to_production)
+    # call ``update_workspace("dev")`` immediately after login. Mock the
+    # session-update endpoint so respx doesn't reject it as un-mocked.
+    respx.patch(f"{API_URL}/session").mock(
+        return_value=httpx.Response(200, json={"workspace_id": "dev"})
+    )
 
 
 def _invoke_tool(mcp, tool_name: str, args: dict):
@@ -395,6 +401,10 @@ class TestActAsUser:
             return_value=httpx.Response(200, json={"access_token": "sudo-tok"})
         )
         respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        # delete_git_branch enables dev_mode, which triggers PATCH /session.
+        respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
         delete_route = respx.delete(f"{API_URL}/projects/p1/git_branch/tmp_ci_abc").mock(
             return_value=httpx.Response(204)
         )
@@ -436,6 +446,10 @@ class TestActAsUser:
             return_value=httpx.Response(200, json={"access_token": "sudo-tok"})
         )
         respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        # delete_git_branch enables dev_mode, which triggers PATCH /session.
+        respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
         delete_route = respx.delete(f"{API_URL}/projects/p1/git_branch/tmp_ci_abc").mock(
             return_value=httpx.Response(204)
         )

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -509,6 +509,10 @@ class TestActAsUser:
             return_value=httpx.Response(200, json={"access_token": "sudo-tok"})
         )
         respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+        # delete_git_branch enables dev_mode, which triggers PATCH /session.
+        respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
         respx.delete(f"{API_URL}/projects/p1/git_branch/tmp_ci_abc").mock(
             return_value=httpx.Response(204)
         )

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -1,4 +1,4 @@
-"""Tests for query tool group — semantic-layer queries and content search."""
+"""Tests for query tool group — semantic-layer queries with dev_mode + branch."""
 
 import json
 
@@ -33,17 +33,126 @@ def _mock_login_logout() -> None:
     respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
 
 
-class TestQuerySql:
-    """Looker's ``/queries/{id}/run/sql`` endpoint returns ``text/plain`` —
-    the compiled SQL as a raw string. Routing it through ``session.get``
-    (which calls ``response.json()``) raises ``Expecting value: line 1
-    column 1`` before the SQL can ever be returned. This test stops the
-    regression by mocking the text/plain response and asserting the tool
-    returns the SQL string under ``{"sql": ...}``."""
+class TestQueryWithBranch:
+    """``query(branch=…)`` is the canonical one-shot CI primitive: switch
+    the dev workspace to the PR branch, run the query, restore the saved
+    branch — all atomic. These tests pin the call sequence."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_branch_arg_drives_save_swap_run_restore(self, config):
+        _mock_login_logout()
+        # dev_mode is auto-implied by branch=
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        # Save current branch ("main")
+        get_branch = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        # PUT — captures both the swap and the restore
+        put_branch = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+        respx.post(f"{API_URL}/queries").mock(return_value=httpx.Response(201, json={"id": "q1"}))
+        respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "query",
+                    {
+                        "model": "ecommerce",
+                        "view": "orders",
+                        "fields": ["orders.region"],
+                        "branch": "feature-x",
+                        "project_id": "proj1",
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["row_count"] == 1
+        finally:
+            await looker_client.close()
+
+        assert patch_session.called, "branch= should imply dev_mode and PATCH /session"
+        assert get_branch.called, "must read current branch before swap"
+        assert put_branch.call_count == 2, "swap + restore"
+        bodies = [json.loads(c.request.content.decode()) for c in put_branch.calls]
+        assert bodies == [{"name": "feature-x"}, {"name": "main"}]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_branch_without_project_id_returns_clean_validation_error(self, config):
+        _mock_login_logout()
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "query",
+                    {
+                        "model": "ecommerce",
+                        "view": "orders",
+                        "fields": ["orders.region"],
+                        "branch": "feature-x",
+                        # No project_id — validation should fail-fast.
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                # ValueError is surfaced by format_api_error as a self-
+                # describing error (no "Unexpected error" prefix).
+                assert "branch=" in payload["error"]
+                assert "project_id" in payload["error"]
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dev_mode_without_branch_skips_swap_logic(self, config):
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        get_branch = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        respx.post(f"{API_URL}/queries").mock(return_value=httpx.Response(201, json={"id": "q1"}))
+        respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "query",
+                    {
+                        "model": "ecommerce",
+                        "view": "orders",
+                        "fields": ["orders.region"],
+                        "dev_mode": True,
+                    },
+                )
+        finally:
+            await looker_client.close()
+
+        # PATCH /session yes (dev_mode=True), but no GET branch / no PUT —
+        # the user's dev workspace's currently-checked-out branch is used
+        # as-is. This is the "iterative human debug" flow.
+        assert patch_session.called
+        assert not get_branch.called
 
     @pytest.mark.asyncio
     @respx.mock
     async def test_returns_compiled_sql_from_text_plain_response(self, config):
+        """``/queries/{id}/run/sql`` returns text/plain — must use get_text."""
         _mock_login_logout()
 
         compiled_sql = "SELECT region, SUM(total) FROM orders GROUP BY 1"
@@ -58,7 +167,7 @@ class TestQuerySql:
             )
         )
 
-        mcp, client = create_server(config, enabled_groups={"query"})
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
         try:
             async with Client(mcp) as mcp_client:
                 result = await mcp_client.call_tool(
@@ -74,4 +183,4 @@ class TestQuerySql:
                 payload = json.loads(content.text)
                 assert payload["sql"] == compiled_sql
         finally:
-            await client.close()
+            await looker_client.close()


### PR DESCRIPTION
## Summary

Adds the primitives for validating LookML feature branches against real data via the MCP. Today, `switch_git_branch` errors with `400 Developer mode required` because no tool propagates workspace context; even if it succeeded, `query` would still run against production LookML on the next call because the workspace doesn't persist across ephemeral sessions.

## Mechanism

- **`dev_mode` on `LookerClient.session()`**: when `True`, issues `PATCH /session {"workspace_id": "dev"}` immediately after authentication. Looker scopes workspace selection to the API session token, so this affects every subsequent call routed through the yielded `LookerSession`. Confirmed canonical via Looker docs and Spectacles' production code (`spectacles/client.py:288-313`).
- **`LookerSession.use_branch(project_id, branch_name)`**: async context manager that performs an atomic save → swap → run → restore cycle. The restore runs in `finally` even when the body raises. Already-on-target is a no-op for both swap and restore.

## Tool surface

All four query tools (`query`, `query_sql`, `query_url`, `run_look`) gain `dev_mode`, `branch`, `project_id`, and `act_as_user`. `branch` implies `dev_mode=True` and requires `project_id`. The four dev-mode-required git tools (`switch_git_branch`, `create_git_branch`, `delete_git_branch`, `reset_to_production`) now pass `dev_mode=True` automatically.

The `ActAsUser` annotation moves from `tools/git.py` to `tools/_helpers.py` so query tools can share it without coupling.

`query_sql` also picks up the `get_text` fix for the text/plain `/run/sql` response (same change as #29 — folds in cleanly regardless of merge order).

## Workflows enabled

- One-shot CI: `query(branch="feature-x", project_id="ecommerce", act_as_user="ci-bot")`
- Prod vs PR diff: two queries, second with `branch=…`
- Iterative human debug: `switch_git_branch` once, then queries with `dev_mode=True`
- Cleanup another user's stuck workspace: `switch_git_branch(act_as_user="alice@…")`

## Test plan

- [x] `tests/test_client.py`: `dev_mode` triggers PATCH /session; default does not. `use_branch` save/swap/restore on success and exception paths. No-op when already on target. Project IDs with slashes are path-encoded.
- [x] `tests/test_query_tools.py` (new): `query(branch=…)` drives the full sequence; missing `project_id` returns a clean validation error; `dev_mode` without `branch` skips the swap logic; `query_sql` reads text/plain.
- [x] `tests/test_git_tools.py`: shared mock helper updated to mock PATCH /session for the dev-mode-required tools.
- [x] Full suite: `uv run pytest` — 332 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## README

New `Dev Mode and Branch Validation` section documents the four canonical workflows, the per-Looker-user concurrency caveat (1 user = 1 in-flight call against that user's branch state — for parallel CI, provision multiple Looker users), and v1 limitations.

## Out of scope (deferred)

- Spectacles' `tmp_<hash>` ephemeral-branch pattern. Their `hard_reset_branch` force-pushes to the remote, which creates orphaned `tmp_*` branches on the customer's git host and requires write access on the deploy key. The atomic save+restore is simpler and works with read-only deploy keys.
- Recursive manifest-import branch swapping. Spectacles handles this in `runner.py:158-181`; v1 leaves imported projects on whatever branch their dev workspace has checked out. Documented in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dev-workspace execution added to query tools with atomic branch-swap + automatic restore
  * Admin impersonation (act-as-user) exposed to query operations
  * Query-SQL now returns compiled SQL text when provided as plain text

* **Documentation**
  * README expanded with dev-mode, branch validation, CI/debugging patterns, and limitations

* **Tests**
  * Added/updated tests covering session dev-mode, branch save/swap/restore, encoding, and tool behaviors

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/30)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->