### PR TITLE
feat(modeling): dev_mode + branch + act_as_user for validate_project + file ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,18 @@ For parallel PR validation, provision multiple Looker users (e.g. `ci-bot-1`, `c
 - **Multi-project manifest imports.** If your LookML project imports another project, the import stays on whatever branch is currently checked out in the dev workspace for that imported project. The atomic swap is single-project; recursive manifest-aware swapping is a v2 concern.
 - **Cross-call session continuity.** Each tool call gets its own ephemeral API session (login → operation → logout), so `dev_mode=True` only takes effect within a single call. The branch state persists across calls because Looker stores it server-side per-user; the workspace setting does not.
 
+### Coverage by tool group
+
+`dev_mode`, `branch`, and `act_as_user` are propagated through the tool groups that work with workspace-scoped LookML state. Tools that read workspace-agnostic metadata don't accept these args.
+
+| Tool group | Workspace-aware tools | Production-only tools |
+|---|---|---|
+| **git** | `switch_git_branch`, `create_git_branch`, `delete_git_branch`, `reset_to_production` (default `dev_mode=True`) | `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `deploy_to_production` (read prod git state) |
+| **query** | `query`, `query_sql`, `query_url`, `run_look` (default `dev_mode=False`; opt in via `branch=` or `dev_mode=True`) | `run_dashboard`, `search_content` (production content) |
+| **modeling — file ops** | `list_project_files`, `get_file` (default `dev_mode=True`), `create_file`, `update_file`, `delete_file` (always dev — Looker rejects writes to production) | — |
+| **modeling — validation** | `validate_project` (default `dev_mode=False`; opt in via `branch=` for PR validation) | — |
+| **modeling — project metadata** | — | `list_projects`, `get_project`, `get_project_manifest`, `list_datagroups`, `reset_datagroup` (workspace-agnostic project state) |
+
 ## Extending with Custom Identity Providers
 
 The `IdentityProvider` protocol is the primary extension point for integrating with custom authentication systems.

--- a/src/looker_mcp_server/tools/_helpers.py
+++ b/src/looker_mcp_server/tools/_helpers.py
@@ -6,8 +6,12 @@ Anything that grows beyond one-liners should move to its own module.
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Annotated, Any
 from urllib.parse import quote
+
+from ..client import LookerSession
 
 
 def _set_if(body: dict[str, Any], key: str, value: Any) -> None:
@@ -46,3 +50,35 @@ ACT_AS_USER_DESCRIPTION = (
     "call uses the configured or gateway-provided identity."
 )
 ActAsUser = Annotated[str | None, ACT_AS_USER_DESCRIPTION]
+
+
+def _validate_branch_args(branch: str | None, project_id: str | None) -> None:
+    """Branch swap requires the project ID — Looker scopes branches per
+    project, and ``LookerSession.use_branch`` needs the path segment to
+    issue ``GET/PUT /projects/{id}/git_branch``. Raised as ``ValueError``
+    so it surfaces through ``format_api_error`` as a self-describing
+    validation error rather than an opaque API failure.
+    """
+    if branch is not None and not project_id:
+        raise ValueError(
+            "branch=… requires project_id=…; pass the LookML project ID that "
+            "owns the branch you want to atomically swap to."
+        )
+
+
+@asynccontextmanager
+async def _maybe_use_branch(
+    session: LookerSession, project_id: str | None, branch: str | None
+) -> AsyncGenerator[None, None]:
+    """Wrap the body in ``session.use_branch`` only when ``branch`` is set.
+
+    Tools that take an optional ``branch`` argument don't want to nest
+    yet another ``async with`` for the no-branch case, but they also need
+    the atomic save+restore semantics when a branch IS set. This helper
+    keeps the call site flat in both modes.
+    """
+    if branch is None or project_id is None:
+        yield
+        return
+    async with session.use_branch(project_id, branch):
+        yield

--- a/src/looker_mcp_server/tools/_helpers.py
+++ b/src/looker_mcp_server/tools/_helpers.py
@@ -53,12 +53,19 @@ ActAsUser = Annotated[str | None, ACT_AS_USER_DESCRIPTION]
 
 
 def _validate_branch_args(branch: str | None, project_id: str | None) -> None:
-    """Branch swap requires the project ID — Looker scopes branches per
-    project, and ``LookerSession.use_branch`` needs the path segment to
-    issue ``GET/PUT /projects/{id}/git_branch``. Raised as ``ValueError``
-    so it surfaces through ``format_api_error`` as a self-describing
-    validation error rather than an opaque API failure.
+    """Branch swap requires a non-empty project ID and branch name.
+
+    Looker scopes branches per project, and ``LookerSession.use_branch``
+    needs the path segment to issue ``GET/PUT /projects/{id}/git_branch``.
+    Empty/whitespace branch strings would otherwise reach Looker as
+    ``{"name": ""}`` and surface as an opaque 400 — much worse signal
+    than a self-describing ``ValueError`` here. Raised as ``ValueError``
+    so ``format_api_error`` formats it cleanly.
     """
+    if branch is not None and not branch.strip():
+        raise ValueError(
+            "branch=… must be a non-empty branch name; got an empty or whitespace-only value."
+        )
     if branch is not None and not project_id:
         raise ValueError(
             "branch=… requires project_id=…; pass the LookML project ID that "
@@ -76,6 +83,14 @@ async def _maybe_use_branch(
     yet another ``async with`` for the no-branch case, but they also need
     the atomic save+restore semantics when a branch IS set. This helper
     keeps the call site flat in both modes.
+
+    This is *dispatch* logic, not validation: it decides whether a swap
+    is requested at all. Validity of the requested swap (non-empty
+    branch, non-empty project_id) is enforced upstream by
+    ``_validate_branch_args``. Adding empty-string guards here would
+    silently skip the swap on invalid input rather than fail loud, which
+    is the wrong failure mode — it would mask upstream bugs that forgot
+    to call the validator.
     """
     if branch is None or project_id is None:
         yield

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -14,12 +14,7 @@ from typing import Annotated, Any
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
-from ._helpers import _path_seg, _set_if
-
-# Looker's file endpoints are dev-mode-only and require an explicit
-# workspace_id query parameter.  Sessions are ephemeral (per tool call),
-# so PATCH /session workspace state does not persist across calls.
-_DEV_PARAMS: dict[str, str] = {"workspace_id": "dev"}
+from ._helpers import ActAsUser, _maybe_use_branch, _path_seg, _set_if, _validate_branch_args
 
 
 def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
@@ -43,33 +38,55 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         except Exception as e:
             return format_api_error("list_projects", e)
 
-    @server.tool(description="List all LookML files in a project (dev workspace).")
+    @server.tool(
+        description=(
+            "List all LookML files in a project. Defaults to the dev workspace's "
+            "currently-checked-out branch — set ``branch=…`` to atomically swap "
+            "the dev workspace to a feature branch for the call (saved branch "
+            "restored on exit), or ``dev_mode=False`` to read production files."
+        ),
+    )
     async def list_project_files(
         project_id: Annotated[str, "LookML project ID"],
+        dev_mode: Annotated[bool, "Read from the dev workspace (default) or production"] = True,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call (saved branch "
+            "restored on exit). Implies dev_mode=True.",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("list_project_files", "modeling", {"project_id": project_id})
+        ctx = client.build_context(
+            "list_project_files",
+            "modeling",
+            {"project_id": project_id, "branch": branch, "act_as_user": act_as_user},
+        )
         try:
-            async with client.session(ctx) as session:
-                files = await session.get(
-                    f"/projects/{_path_seg(project_id)}/files", params=_DEV_PARAMS
-                )
-                result = [
-                    {
-                        "id": f.get("id"),
-                        "title": f.get("title"),
-                        "type": f.get("type"),
-                        "extension": f.get("extension"),
-                        "editable": f.get("editable"),
-                    }
-                    for f in (files or [])
-                ]
-                return json.dumps(result, indent=2)
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    files = await session.get(f"/projects/{_path_seg(project_id)}/files")
+                    result = [
+                        {
+                            "id": f.get("id"),
+                            "title": f.get("title"),
+                            "type": f.get("type"),
+                            "extension": f.get("extension"),
+                            "editable": f.get("editable"),
+                        }
+                        for f in (files or [])
+                    ]
+                    return json.dumps(result, indent=2)
         except Exception as e:
             return format_api_error("list_project_files", e)
 
     @server.tool(
         description=(
-            "Read the contents of a LookML file (dev workspace). Returns the full source code."
+            "Read the contents of a LookML file. Defaults to the dev workspace's "
+            "currently-checked-out branch — set ``branch=…`` to atomically swap "
+            "to a feature branch for the call, or ``dev_mode=False`` to read the "
+            "production version."
         ),
     )
     async def get_file(
@@ -77,79 +94,133 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         file_id: Annotated[
             str, "File path within the project (e.g. 'models/ecommerce.model.lkml')"
         ],
+        dev_mode: Annotated[bool, "Read from dev workspace (default) or production"] = True,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call. Implies dev_mode=True.",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("get_file", "modeling", {"project_id": project_id})
+        ctx = client.build_context(
+            "get_file",
+            "modeling",
+            {"project_id": project_id, "branch": branch, "act_as_user": act_as_user},
+        )
         try:
-            async with client.session(ctx) as session:
-                file_info = await session.get(
-                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
-                    params=_DEV_PARAMS,
-                )
-                return json.dumps(file_info, indent=2)
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    file_info = await session.get(
+                        f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
+                    )
+                    return json.dumps(file_info, indent=2)
         except Exception as e:
             return format_api_error("get_file", e)
 
     @server.tool(
-        description="Create a new LookML file in a project (dev workspace).",
+        description=(
+            "Create a new LookML file in a project. Always operates on the dev "
+            "workspace — Looker rejects writes to production LookML. Pair with "
+            "``branch=…`` to scope the create to a specific feature branch."
+        ),
     )
     async def create_file(
         project_id: Annotated[str, "LookML project ID"],
         file_id: Annotated[str, "File path (e.g. 'views/new_view.view.lkml')"],
         content: Annotated[str, "LookML source code for the file"],
+        branch: Annotated[
+            str | None,
+            "Atomically swap to this branch for the call (saved branch restored on exit).",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("create_file", "modeling", {"project_id": project_id})
+        ctx = client.build_context(
+            "create_file",
+            "modeling",
+            {"project_id": project_id, "branch": branch, "act_as_user": act_as_user},
+        )
         try:
-            async with client.session(ctx) as session:
-                file_info = await session.post(
-                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
-                    body={"id": file_id, "content": content},
-                    params=_DEV_PARAMS,
-                )
-                return json.dumps(
-                    {"created": True, "id": file_info.get("id") if file_info else file_id},
-                    indent=2,
-                )
+            _validate_branch_args(branch, project_id)
+            async with client.session(ctx, dev_mode=True) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    file_info = await session.post(
+                        f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
+                        body={"id": file_id, "content": content},
+                    )
+                    return json.dumps(
+                        {"created": True, "id": file_info.get("id") if file_info else file_id},
+                        indent=2,
+                    )
         except Exception as e:
             return format_api_error("create_file", e)
 
     @server.tool(
-        description="Update the content of an existing LookML file (dev workspace).",
+        description=(
+            "Update the content of an existing LookML file. Always operates on "
+            "the dev workspace — production is read-only. Pair with ``branch=…`` "
+            "to scope the edit to a specific feature branch."
+        ),
     )
     async def update_file(
         project_id: Annotated[str, "LookML project ID"],
         file_id: Annotated[str, "File path within the project"],
         content: Annotated[str, "New LookML source code"],
+        branch: Annotated[
+            str | None,
+            "Atomically swap to this branch for the call (saved branch restored on exit).",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("update_file", "modeling", {"project_id": project_id})
+        ctx = client.build_context(
+            "update_file",
+            "modeling",
+            {"project_id": project_id, "branch": branch, "act_as_user": act_as_user},
+        )
         try:
-            async with client.session(ctx) as session:
-                file_info = await session.patch(
-                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
-                    body={"content": content},
-                    params=_DEV_PARAMS,
-                )
-                return json.dumps(
-                    {"updated": True, "id": file_info.get("id") if file_info else file_id},
-                    indent=2,
-                )
+            _validate_branch_args(branch, project_id)
+            async with client.session(ctx, dev_mode=True) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    file_info = await session.patch(
+                        f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
+                        body={"content": content},
+                    )
+                    return json.dumps(
+                        {"updated": True, "id": file_info.get("id") if file_info else file_id},
+                        indent=2,
+                    )
         except Exception as e:
             return format_api_error("update_file", e)
 
     @server.tool(
-        description="Delete a LookML file from a project (dev workspace).",
+        description=(
+            "Delete a LookML file from a project. Always operates on the dev "
+            "workspace — production is read-only. Pair with ``branch=…`` to "
+            "scope the deletion to a specific feature branch."
+        ),
     )
     async def delete_file(
         project_id: Annotated[str, "LookML project ID"],
         file_id: Annotated[str, "File path to delete"],
+        branch: Annotated[
+            str | None,
+            "Atomically swap to this branch for the call (saved branch restored on exit).",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("delete_file", "modeling", {"project_id": project_id})
+        ctx = client.build_context(
+            "delete_file",
+            "modeling",
+            {"project_id": project_id, "branch": branch, "act_as_user": act_as_user},
+        )
         try:
-            async with client.session(ctx) as session:
-                await session.delete(
-                    f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
-                    params=_DEV_PARAMS,
-                )
-                return json.dumps({"deleted": True, "file_id": file_id}, indent=2)
+            _validate_branch_args(branch, project_id)
+            async with client.session(ctx, dev_mode=True) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    await session.delete(
+                        f"/projects/{_path_seg(project_id)}/files/{_path_seg(file_id)}",
+                    )
+                    return json.dumps({"deleted": True, "file_id": file_id}, indent=2)
         except Exception as e:
             return format_api_error("delete_file", e)
 
@@ -378,45 +449,68 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
-            "Validate LookML syntax and semantics for a project. "
-            "Returns any errors or warnings found."
+            "Validate LookML syntax and semantics for a project. By default "
+            "validates production LookML. Pass ``branch=…`` (or ``dev_mode=True``) "
+            "to validate the dev workspace's LookML — required for any CI flow "
+            "checking that a PR doesn't introduce LookML errors. Returns "
+            "errors[], warnings[], and ``valid`` (boolean) summary."
         ),
     )
     async def validate_project(
         project_id: Annotated[str, "LookML project ID to validate"],
+        dev_mode: Annotated[
+            bool,
+            "Validate the dev workspace's LookML rather than production. "
+            "Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Atomically swap to this branch for the call (saved branch restored "
+            "on exit). Implies dev_mode=True.",
+        ] = None,
+        act_as_user: ActAsUser = None,
     ) -> str:
-        ctx = client.build_context("validate_project", "modeling", {"project_id": project_id})
+        ctx = client.build_context(
+            "validate_project",
+            "modeling",
+            {"project_id": project_id, "branch": branch, "act_as_user": act_as_user},
+        )
         try:
-            async with client.session(ctx) as session:
-                result = await session.post(f"/projects/{_path_seg(project_id)}/lookml_validation")
-                errors = result.get("errors") or [] if result else []
-                warnings = result.get("warnings") or [] if result else []
-                return json.dumps(
-                    {
-                        "valid": len(errors) == 0,
-                        "error_count": len(errors),
-                        "warning_count": len(warnings),
-                        "errors": [
-                            {
-                                "severity": e.get("severity"),
-                                "kind": e.get("kind"),
-                                "message": e.get("message"),
-                                "source_file": e.get("source_file"),
-                                "line": e.get("line"),
-                            }
-                            for e in errors
-                        ],
-                        "warnings": [
-                            {
-                                "severity": w.get("severity"),
-                                "message": w.get("message"),
-                                "source_file": w.get("source_file"),
-                            }
-                            for w in warnings
-                        ],
-                    },
-                    indent=2,
-                )
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    result = await session.post(
+                        f"/projects/{_path_seg(project_id)}/lookml_validation"
+                    )
+                    errors = result.get("errors") or [] if result else []
+                    warnings = result.get("warnings") or [] if result else []
+                    return json.dumps(
+                        {
+                            "valid": len(errors) == 0,
+                            "error_count": len(errors),
+                            "warning_count": len(warnings),
+                            "errors": [
+                                {
+                                    "severity": e.get("severity"),
+                                    "kind": e.get("kind"),
+                                    "message": e.get("message"),
+                                    "source_file": e.get("source_file"),
+                                    "line": e.get("line"),
+                                }
+                                for e in errors
+                            ],
+                            "warnings": [
+                                {
+                                    "severity": w.get("severity"),
+                                    "message": w.get("message"),
+                                    "source_file": w.get("source_file"),
+                                }
+                                for w in warnings
+                            ],
+                        },
+                        indent=2,
+                    )
         except Exception as e:
             return format_api_error("validate_project", e)
 

--- a/src/looker_mcp_server/tools/query.py
+++ b/src/looker_mcp_server/tools/query.py
@@ -7,46 +7,12 @@ saved Looks and dashboards, and searching across all content.
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from typing import Annotated, Any
 
 from fastmcp import FastMCP
 
-from ..client import LookerClient, LookerSession, format_api_error
-from ._helpers import ActAsUser
-
-
-def _validate_branch_args(branch: str | None, project_id: str | None) -> None:
-    """Branch swap requires the project ID — Looker scopes branches per
-    project, and ``LookerSession.use_branch`` needs the path segment to
-    issue ``GET/PUT /projects/{id}/git_branch``. Raised as ``ValueError``
-    so it surfaces through ``format_api_error`` as a self-describing
-    validation error rather than an opaque API failure.
-    """
-    if branch is not None and not project_id:
-        raise ValueError(
-            "branch=… requires project_id=…; pass the LookML project ID that "
-            "owns the branch you want to atomically swap to."
-        )
-
-
-@asynccontextmanager
-async def _maybe_use_branch(
-    session: LookerSession, project_id: str | None, branch: str | None
-) -> AsyncGenerator[None, None]:
-    """Wrap the body in ``session.use_branch`` only when ``branch`` is set.
-
-    Tools that take an optional ``branch`` argument don't want to nest
-    yet another ``async with`` for the no-branch case, but they also need
-    the atomic save+restore semantics when a branch IS set. This helper
-    keeps the call site flat in both modes.
-    """
-    if branch is None or project_id is None:
-        yield
-        return
-    async with session.use_branch(project_id, branch):
-        yield
+from ..client import LookerClient, format_api_error
+from ._helpers import ActAsUser, _maybe_use_branch, _validate_branch_args
 
 
 def register_query_tools(server: FastMCP, client: LookerClient) -> None:

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -522,6 +522,70 @@ class TestPdtBuildAdmin:
         assert "workspace=dev" in captured["url"]
 
 
+class TestBranchArgValidation:
+    """``_validate_branch_args`` is the single source of truth for
+    rejecting invalid branch/project_id combinations. These tests
+    exercise it through ``validate_project`` since that's the simplest
+    consumer surface — but the helper itself is shared across all
+    tools that accept ``branch=…``."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_empty_branch_string_returns_validation_error(self, config):
+        # Empty branch must not reach Looker; it would PUT {"name": ""}
+        # and surface as an opaque 400. Catch upstream with a clear
+        # ValueError that format_api_error renders cleanly.
+        _mock_login_logout()
+        # Mock the endpoints we expect NOT to be called.
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        get_branch = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "validate_project",
+                    {"project_id": "proj1", "branch": ""},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert "non-empty" in payload["error"]
+        finally:
+            await looker_client.close()
+
+        assert not patch_session.called
+        assert not get_branch.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_whitespace_only_branch_returns_validation_error(self, config):
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "validate_project",
+                    {"project_id": "proj1", "branch": "   "},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert "whitespace-only" in payload["error"] or "non-empty" in payload["error"]
+        finally:
+            await looker_client.close()
+
+        assert not patch_session.called
+
+
 class TestValidateProjectDevMode:
     """``validate_project`` is the load-bearing primitive for catching
     LookML errors introduced by a PR. Default behavior validates

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -520,3 +520,189 @@ class TestPdtBuildAdmin:
 
         assert "models=ecommerce" in captured["url"]
         assert "workspace=dev" in captured["url"]
+
+
+class TestValidateProjectDevMode:
+    """``validate_project`` is the load-bearing primitive for catching
+    LookML errors introduced by a PR. Default behavior validates
+    production (backwards-compatible); ``branch=…`` flips the dev
+    workspace to the feature branch atomically with save+restore."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_default_validates_production(self, config):
+        _mock_login_logout()
+        # No PATCH /session expected with dev_mode default False.
+        patch_route = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "production"})
+        )
+        respx.post(f"{API_URL}/projects/proj1/lookml_validation").mock(
+            return_value=httpx.Response(200, json={"errors": [], "warnings": []})
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("validate_project", {"project_id": "proj1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["valid"] is True
+        finally:
+            await looker_client.close()
+
+        # Default behavior: no workspace switch.
+        assert not patch_route.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_branch_drives_save_swap_validate_restore(self, config):
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        get_branch = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        put_branch = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+        # Validation surfaces a real LookML error — exercises the failure
+        # case from the field report (broken assert in tests.lkml).
+        respx.post(f"{API_URL}/projects/proj1/lookml_validation").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "errors": [
+                        {
+                            "severity": "error",
+                            "kind": "value_error",
+                            "message": "wrong argument type NilClass (expected Integer)",
+                            "source_file": "models/tests.lkml",
+                            "line": 42,
+                        }
+                    ],
+                    "warnings": [],
+                },
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "validate_project",
+                    {"project_id": "proj1", "branch": "feature-x"},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["valid"] is False
+                assert payload["error_count"] == 1
+                assert "NilClass" in payload["errors"][0]["message"]
+        finally:
+            await looker_client.close()
+
+        # The full sequence happened in order: PATCH /session, GET branch,
+        # PUT swap, POST validate, PUT restore.
+        assert patch_session.called
+        assert get_branch.called
+        assert put_branch.call_count == 2
+        bodies = [json.loads(c.request.content.decode()) for c in put_branch.calls]
+        assert bodies == [{"name": "feature-x"}, {"name": "main"}]
+
+
+class TestFileOpsDevMode:
+    """File-ops tools migrated from the per-call ``?workspace_id=dev``
+    query-param trick to the session-level PATCH /session pattern. The
+    default behavior matches the previous behavior (dev workspace), but
+    callers can now opt for production reads or atomic branch swaps."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_project_files_defaults_to_dev_workspace(self, config):
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        respx.get(f"{API_URL}/projects/proj1/files").mock(
+            return_value=httpx.Response(
+                200,
+                json=[{"id": "models/x.lkml", "title": "x", "type": "model"}],
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("list_project_files", {"project_id": "proj1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload[0]["id"] == "models/x.lkml"
+        finally:
+            await looker_client.close()
+
+        # Default dev_mode=True triggers PATCH /session — replaces the
+        # legacy ``?workspace_id=dev`` query-param trick.
+        assert patch_session.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_project_files_with_dev_mode_false_reads_production(self, config):
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        respx.get(f"{API_URL}/projects/proj1/files").mock(return_value=httpx.Response(200, json=[]))
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "list_project_files",
+                    {"project_id": "proj1", "dev_mode": False},
+                )
+        finally:
+            await looker_client.close()
+
+        # No workspace switch when caller explicitly opts out.
+        assert not patch_session.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_update_file_with_branch_does_atomic_save_swap_restore(self, config):
+        _mock_login_logout()
+        respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        get_branch = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        put_branch = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+        respx.patch(f"{API_URL}/projects/proj1/files/models%2Fx.lkml").mock(
+            return_value=httpx.Response(200, json={"id": "models/x.lkml"})
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "update_file",
+                    {
+                        "project_id": "proj1",
+                        "file_id": "models/x.lkml",
+                        "content": "view: x { dimension: id {} }",
+                        "branch": "feature-x",
+                    },
+                )
+        finally:
+            await looker_client.close()
+
+        # branch=feature-x triggers the full save→swap→edit→restore cycle.
+        assert get_branch.called
+        assert put_branch.call_count == 2
+        bodies = [json.loads(c.request.content.decode()) for c in put_branch.calls]
+        assert bodies == [{"name": "feature-x"}, {"name": "main"}]


### PR DESCRIPTION
## Summary

Closes the remaining gap from the dev-mode rollout: the modeling tool group didn't get the same treatment as git/query in #30.

- **`validate_project` had no dev-mode support whatsoever** — it always validated production LookML. Any CI workflow that called it against a feature branch silently got production results. This PR makes it accept `dev_mode` + `branch` + `act_as_user`, defaulting to current production-validation behavior so existing callers are unaffected.
- **File-ops tools** (`list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`) used an undocumented `?workspace_id=dev` query-param trick that worked for individual calls but was inconsistent with the session-level `PATCH /session` pattern used everywhere else. Migrated to the canonical pattern, with `branch=` for atomic save/swap/restore and `act_as_user` for the CI service-user pattern.

## Stacked on #30

This PR consumes the `dev_mode` + `use_branch` plumbing in `client.py` from #30. Currently set to compare against the `nick/dev-mode-branch` branch — once #30 merges, I'll rebase to compare against `main` so CodeRabbit can review.

## What changed

- **`tools/_helpers.py`**: `_validate_branch_args` and `_maybe_use_branch` move here from `tools/query.py` so modeling can share them. Public API surface unchanged (both stay private/underscore-prefixed).
- **`tools/modeling.py`**:
  - `validate_project`: adds `dev_mode: bool = False`, `branch`, `act_as_user`. Defaults preserve current behavior.
  - File-ops tools: drop `_DEV_PARAMS`, migrate to `client.session(dev_mode=…)` + `_maybe_use_branch`. Read tools default to `dev_mode=True` (matches old behavior). Write tools always dev (Looker rejects production writes).
- **`tools/query.py`**: drops the now-shared helpers, imports from `_helpers.py`.
- **README**: new "Coverage by tool group" table in the "Dev Mode and Branch Validation" section.

## Why `validate_project` matters

This is the load-bearing primitive for catching LookML errors before they reach prod. Calling it against a feature branch is the canonical "did this PR break anything?" question. Without `dev_mode + branch`, the tool was actively misleading — it returned `valid: true` for production while the PR branch was broken.

## Test plan

- [x] `validate_project` default validates production (no PATCH /session issued — backwards-compat regression check)
- [x] `validate_project` with `branch="feature-x"` triggers PATCH /session + GET-current → PUT-target → POST validate → PUT-saved restore
- [x] `list_project_files` defaults to dev workspace (PATCH /session) — replaces the legacy query-param trick
- [x] `list_project_files` with `dev_mode=False` reads production (no PATCH /session — opt-out path)
- [x] `update_file` with `branch=feature-x` does the full atomic save+edit+restore
- [x] Full suite passes: `uv run pytest` — 337 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## Backward compatibility

Default behavior is preserved for every tool:

- File-ops read tools defaulted to dev workspace → still default to dev workspace
- File-ops write tools were dev-only → still dev-only
- `validate_project` defaulted to production → still defaults to production. Adding `dev_mode=True` or `branch=…` is opt-in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added coverage documentation describing how `dev_mode`, `branch`, and `act_as_user` parameters propagate across workspace-scoped operations.

* **New Features**
  * LookML file operations (list, read, create, update, delete) and project validation now support optional `branch` and `dev_mode` parameters for feature branch management and workspace control.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/31)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->