### PR TITLE
feat(modeling): list_lookml_tests + run_lookml_tests with branch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,14 @@ For parallel PR validation, provision multiple Looker users (e.g. `ci-bot-1`, `c
 | **query** | `query`, `query_sql`, `query_url`, `run_look` (default `dev_mode=False`; opt in via `branch=` or `dev_mode=True`) | `run_dashboard`, `search_content` (production content) |
 | **modeling — file ops** | `list_project_files`, `get_file` (default `dev_mode=True`), `create_file`, `update_file`, `delete_file` (always dev — Looker rejects writes to production) | — |
 | **modeling — validation** | `validate_project` (default `dev_mode=False`; opt in via `branch=` for PR validation) | — |
+| **modeling — data tests** | `list_lookml_tests`, `run_lookml_tests` (default `dev_mode=False`; opt in via `branch=` for PR data-regression checks) | — |
 | **modeling — project metadata** | — | `list_projects`, `get_project`, `get_project_manifest`, `list_datagroups`, `reset_datagroup` (workspace-agnostic project state) |
+
+### `run_lookml_tests` — PR data-regression checks
+
+`run_lookml_tests(project_id="ecommerce", branch="feature-x", act_as_user="ci-bot@example.com")` is the primary primitive for catching data-regression bugs introduced by a PR. Looker compiles each test's `explore_source` query, runs it against the warehouse, and evaluates the assertion expression against the result rows. Failures come back with assertion-level detail (`model_name`, `test_name`, `errors[]`).
+
+Default per-call timeout is 1800s (30 min) because data tests run real warehouse queries with assertions and can take a long time on large tables — same default Spectacles uses.
 
 ## Extending with Custom Identity Providers
 

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -60,8 +60,9 @@ class LookerSession:
         self,
         path: str,
         params: dict[str, Any] | None = None,
+        timeout: float | None = None,
     ) -> Any:
-        return await self._request("GET", path, params=params)
+        return await self._request("GET", path, params=params, timeout=timeout)
 
     async def post(
         self,
@@ -233,14 +234,19 @@ class LookerSession:
         path: str,
         params: dict[str, Any] | None = None,
         json: dict[str, Any] | list[Any] | None = None,
+        timeout: float | None = None,
     ) -> Any:
-        response = await self._http.request(
-            method,
-            path,
-            headers=self._headers,
-            params=params,
-            json=json,
-        )
+        # Per-call timeout overrides the connection default. Used for
+        # long-running endpoints like ``/lookml_tests/run`` where data
+        # tests can run for many minutes against the warehouse.
+        request_kwargs: dict[str, Any] = {
+            "headers": self._headers,
+            "params": params,
+            "json": json,
+        }
+        if timeout is not None:
+            request_kwargs["timeout"] = httpx.Timeout(timeout)
+        response = await self._http.request(method, path, **request_kwargs)
         self._raise_for_status(response)
 
         if response.status_code == 204 or not response.content:

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -625,6 +625,13 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         )
         try:
             _validate_branch_args(branch, project_id)
+            # ``httpx.Timeout(0)`` raises ``ValueError`` and negative values
+            # produce undefined behavior — both surface as opaque transport
+            # errors well after authentication and workspace setup. Catch
+            # at the validation layer so callers see a deterministic
+            # ``ValueError`` before any Looker side effects.
+            if timeout <= 0:
+                raise ValueError(f"timeout must be a positive number of seconds, got {timeout!r}.")
             effective_dev_mode = dev_mode or branch is not None
             async with client.session(ctx, dev_mode=effective_dev_mode) as session:
                 async with _maybe_use_branch(session, project_id, branch):

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -514,6 +514,145 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
         except Exception as e:
             return format_api_error("validate_project", e)
 
+    # ── LookML data tests ────────────────────────────────────────────
+
+    @server.tool(
+        description=(
+            "List the LookML/data tests defined in a project. Each entry has a "
+            "``name``, ``model``, ``explore``, ``file``, ``line``, and the "
+            "``query_url_params`` Looker uses to run it. By default lists tests "
+            "from production LookML; set ``branch=…`` (or ``dev_mode=True``) to "
+            "list tests from a feature branch under review."
+        ),
+    )
+    async def list_lookml_tests(
+        project_id: Annotated[str, "LookML project ID"],
+        file_id: Annotated[
+            str | None, "Optional: restrict to tests defined in a single file"
+        ] = None,
+        dev_mode: Annotated[
+            bool,
+            "List tests from the dev workspace rather than production. "
+            "Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Atomically swap to this branch for the call (saved branch restored "
+            "on exit). Implies dev_mode=True.",
+        ] = None,
+        act_as_user: ActAsUser = None,
+    ) -> str:
+        ctx = client.build_context(
+            "list_lookml_tests",
+            "modeling",
+            {"project_id": project_id, "branch": branch, "act_as_user": act_as_user},
+        )
+        try:
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    params: dict[str, Any] = {}
+                    _set_if(params, "file_id", file_id)
+                    tests = await session.get(
+                        f"/projects/{_path_seg(project_id)}/lookml_tests",
+                        params=params or None,
+                    )
+                    result = [
+                        {
+                            "name": t.get("name"),
+                            "model": t.get("model_name"),
+                            "explore": t.get("explore_name"),
+                            "file": t.get("file"),
+                            "line": t.get("line"),
+                            "query_url_params": t.get("query_url_params"),
+                        }
+                        for t in (tests or [])
+                    ]
+                    return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("list_lookml_tests", e)
+
+    @server.tool(
+        description=(
+            "Run LookML/data tests for a project and return the assertion "
+            "results. Optionally filter by ``model``, ``test`` (by name), or "
+            "``file_id``. By default runs against production LookML — set "
+            "``branch=…`` (or ``dev_mode=True``) to validate a PR's tests "
+            "against the warehouse data without deploying. This is the "
+            "primary primitive for catching data-regression bugs in CI."
+            "\n\nLooker compiles each test's ``explore_source`` query, runs "
+            "it against the warehouse, and evaluates the assertion expression "
+            "against the result rows. A failed assert returns a non-empty "
+            "``errors[]`` array. Tests can take many minutes — the default "
+            "per-call timeout is 1800s (30 min), matching what Spectacles "
+            "uses for the same endpoint."
+        ),
+    )
+    async def run_lookml_tests(
+        project_id: Annotated[str, "LookML project ID"],
+        model: Annotated[str | None, "Restrict to tests in a specific model"] = None,
+        test: Annotated[str | None, "Restrict to a single test by name"] = None,
+        file_id: Annotated[str | None, "Restrict to tests in a single file"] = None,
+        dev_mode: Annotated[
+            bool,
+            "Run tests against the dev workspace's LookML rather than production. "
+            "Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Atomically swap to this branch for the call (saved branch restored "
+            "on exit). Implies dev_mode=True.",
+        ] = None,
+        act_as_user: ActAsUser = None,
+        timeout: Annotated[
+            float,
+            "Per-call timeout in seconds. Defaults to 1800 (30 min) because "
+            "data tests run real warehouse queries with assertions and can "
+            "take a long time on large tables.",
+        ] = 1800.0,
+    ) -> str:
+        ctx = client.build_context(
+            "run_lookml_tests",
+            "modeling",
+            {
+                "project_id": project_id,
+                "model": model,
+                "test": test,
+                "branch": branch,
+                "act_as_user": act_as_user,
+            },
+        )
+        try:
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    params: dict[str, Any] = {}
+                    _set_if(params, "model", model)
+                    _set_if(params, "test", test)
+                    _set_if(params, "file_id", file_id)
+                    results = await session.get(
+                        f"/projects/{_path_seg(project_id)}/lookml_tests/run",
+                        params=params or None,
+                        timeout=timeout,
+                    )
+                    # Pass through raw results — failures carry assertion-level
+                    # detail (model_name, test_name, query_url, success,
+                    # errors[]) that's exactly what a regression report needs.
+                    failure_count = sum(1 for r in (results or []) if not r.get("success", True))
+                    return json.dumps(
+                        {
+                            "passed": failure_count == 0,
+                            "test_count": len(results or []),
+                            "failure_count": failure_count,
+                            "results": results or [],
+                        },
+                        indent=2,
+                    )
+        except Exception as e:
+            return format_api_error("run_lookml_tests", e)
+
     # ── Datagroups (cache management) ────────────────────────────────
 
     @server.tool(

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -947,3 +947,36 @@ class TestLookmlTests:
         # respects the API's filtering surface (model/test/file_id).
         assert "model=ecommerce" in captured["url"]
         assert "test=test_orders_total" in captured["url"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @pytest.mark.parametrize("bad_timeout", [0, 0.0, -1, -10.5])
+    async def test_run_rejects_non_positive_timeout(self, config, bad_timeout):
+        # ``httpx.Timeout(0)`` raises and negative values are undefined —
+        # both would surface as opaque transport-layer errors well after
+        # auth + workspace setup. Reject up front with a clear ValueError
+        # so callers get a deterministic validation error.
+        _mock_login_logout()
+        # Mock both endpoints we expect NOT to be called so any leak fails
+        # this test loudly instead of silently passing.
+        login_route = respx.get(f"{API_URL}/projects/proj1/lookml_tests/run").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "run_lookml_tests",
+                    {"project_id": "proj1", "timeout": bad_timeout},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert "timeout" in payload["error"]
+                assert "positive" in payload["error"]
+        finally:
+            await looker_client.close()
+
+        # Validation must short-circuit before the underlying GET.
+        assert not login_route.called

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -770,3 +770,180 @@ class TestFileOpsDevMode:
         assert put_branch.call_count == 2
         bodies = [json.loads(c.request.content.decode()) for c in put_branch.calls]
         assert bodies == [{"name": "feature-x"}, {"name": "main"}]
+
+
+class TestLookmlTests:
+    """The load-bearing primitive for catching data-regression bugs in CI:
+    runs LookML data tests against the warehouse and reports per-test
+    success/failure with the assertion-level errors. Pair with branch=…
+    to validate a PR before merge."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_list_returns_test_names_models_files(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/projects/proj1/lookml_tests").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "name": "test_orders_total",
+                        "model_name": "ecommerce",
+                        "explore_name": "orders",
+                        "file": "tests/orders.lkml",
+                        "line": 12,
+                        "query_url_params": "fields=orders.region",
+                    }
+                ],
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("list_lookml_tests", {"project_id": "proj1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload[0]["name"] == "test_orders_total"
+                assert payload[0]["model"] == "ecommerce"
+                assert payload[0]["explore"] == "orders"
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_default_runs_against_production(self, config):
+        _mock_login_logout()
+        # No PATCH /session expected with default args — production-only.
+        patch_route = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "production"})
+        )
+        respx.get(f"{API_URL}/projects/proj1/lookml_tests/run").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "model_name": "ecommerce",
+                        "test_name": "test_orders_total",
+                        "success": True,
+                        "errors": [],
+                    }
+                ],
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("run_lookml_tests", {"project_id": "proj1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["passed"] is True
+                assert payload["test_count"] == 1
+                assert payload["failure_count"] == 0
+        finally:
+            await looker_client.close()
+
+        assert not patch_route.called, "default run should not switch workspace"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_with_branch_does_full_atomic_cycle_and_surfaces_failures(self, config):
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        get_branch = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        put_branch = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+        # The exact failure pattern from the field-report incident: a
+        # broken assert that Spectacles false-passes but Looker's runtime
+        # evaluator throws on. We expect run_lookml_tests to surface it
+        # with assertion-level detail.
+        respx.get(f"{API_URL}/projects/proj1/lookml_tests/run").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "model_name": "ecommerce",
+                        "test_name": "test_orders_total",
+                        "success": False,
+                        "errors": [
+                            {
+                                "message": ("wrong argument type NilClass (expected Integer)"),
+                                "line_number": 42,
+                            }
+                        ],
+                    },
+                    {
+                        "model_name": "ecommerce",
+                        "test_name": "test_orders_count",
+                        "success": True,
+                        "errors": [],
+                    },
+                ],
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "run_lookml_tests",
+                    {"project_id": "proj1", "branch": "feature-x"},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["passed"] is False
+                assert payload["test_count"] == 2
+                assert payload["failure_count"] == 1
+                # Raw results passed through — the failure carries the
+                # assertion-level error for the regression report.
+                fail = next(r for r in payload["results"] if not r["success"])
+                assert "NilClass" in fail["errors"][0]["message"]
+        finally:
+            await looker_client.close()
+
+        # Full atomic cycle: workspace switch + branch swap + run + restore.
+        assert patch_session.called
+        assert get_branch.called
+        assert put_branch.call_count == 2
+        bodies = [json.loads(c.request.content.decode()) for c in put_branch.calls]
+        assert bodies == [{"name": "feature-x"}, {"name": "main"}]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_filters_passed_to_query_params(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json=[])
+
+        respx.get(f"{API_URL}/projects/proj1/lookml_tests/run").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "run_lookml_tests",
+                    {
+                        "project_id": "proj1",
+                        "model": "ecommerce",
+                        "test": "test_orders_total",
+                    },
+                )
+        finally:
+            await looker_client.close()
+
+        # Filter args ride as query params on the GET — verifies the tool
+        # respects the API's filtering surface (model/test/file_id).
+        assert "model=ecommerce" in captured["url"]
+        assert "test=test_orders_total" in captured["url"]


### PR DESCRIPTION
## Summary

The load-bearing primitive for catching data-regression bugs in CI. Without this tool, validating that a PR's LookML data tests behave correctly required Spectacles' internal evaluator, which has known false-positive cases (assertions that pass in Spectacles but throw at Looker's runtime evaluator). With this tool, an LLM can run the same tests directly through Looker's API in dev mode against the PR's branch and get the truth.

## Stacked on #31 (which is stacked on #30)

This PR consumes the `dev_mode` + `use_branch` plumbing from #30 and the `_helpers.py` refactor from #31. Currently set to compare against the `nick/modeling-dev-mode` branch — once #30 and #31 merge, I'll rebase to compare against `main` so CodeRabbit can review.

## What changed

- **`LookerSession.get` / `_request` accept a per-call `timeout`**. When set, `httpx.Timeout(timeout)` replaces the connection-level default for that one request. Needed because Looker data tests run real warehouse queries with assertions and can take many minutes; the OSS server's default 60s would time out. Same default Spectacles uses (1800s).
- **`list_lookml_tests`** (`GET /projects/{id}/lookml_tests`): list tests with name/model/explore/file/line/query_url_params. Optional `file_id` filter.
- **`run_lookml_tests`** (`GET /projects/{id}/lookml_tests/run`): run tests with optional `model`/`test`/`file_id` filters. Returns `{passed, test_count, failure_count, results[]}` — failures carry the raw assertion-level detail (`model_name`, `test_name`, `success`, `errors[]`) since that's exactly what a regression report needs.

Both tools use the standard `dev_mode + branch + project_id + act_as_user` pattern from the rest of the dev-mode rollout. Default `dev_mode=False` runs against production. Setting `branch=…` triggers the atomic save/swap/run/restore cycle.

## Test plan

- [x] `list_lookml_tests` returns trimmed test descriptors
- [x] `run_lookml_tests` default targets production (no PATCH /session — backwards-compat regression check)
- [x] `run_lookml_tests` with `branch="feature-x"` triggers the full atomic cycle: PATCH /session + GET branch + PUT swap + GET run + PUT restore. Surfaces the `wrong argument type NilClass (expected Integer)` failure pattern that motivated the whole series.
- [x] `model`/`test` filters ride as query params on the GET
- [x] Full suite: `uv run pytest` — 341 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## Backward compatibility

No breaking changes. New params on `LookerSession.get` are optional with current behavior preserved when `timeout=None`. Both new tools are additive. Default behavior of `run_lookml_tests` (production) matches what someone calling the underlying Looker API directly would get.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two modeling tools to list and run LookML/data tests with optional filters, branch selection, and per-run timeout support (default 30 minutes).

* **Documentation**
  * Added docs for the new data-tests tool group, usage notes, failure detail shape, and updated coverage table.

* **Tests**
  * Added tests covering listing, running (including branch flows), filter propagation, failure surfacing, and validation of non‑positive timeouts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/32)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->