### PR TITLE
feat(identity): whoami tool for current authenticated user

### DIFF
--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -64,7 +64,7 @@ class DeploymentPostureError(ValueError):
 
 
 # Tool groups that are enabled by default (read-oriented, safe for most deployments).
-DEFAULT_GROUPS = frozenset({"explore", "query", "schema", "content", "health"})
+DEFAULT_GROUPS = frozenset({"explore", "query", "schema", "content", "health", "identity"})
 
 # All available tool groups.
 ALL_GROUPS = frozenset(
@@ -84,6 +84,7 @@ ALL_GROUPS = frozenset(
         "audit",
         "workflows",
         "health",
+        "identity",
     }
 )
 

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -161,6 +161,7 @@ def create_server(
     from .tools.folder import register_folder_tools
     from .tools.git import register_git_tools
     from .tools.health import register_health_tools
+    from .tools.identity import register_identity_tools
     from .tools.modeling import register_modeling_tools
     from .tools.query import register_query_tools
     from .tools.schema import register_schema_tools
@@ -183,6 +184,7 @@ def create_server(
         "audit": register_audit_tools,
         "workflows": register_workflow_tools,
         "health": register_health_tools,
+        "identity": register_identity_tools,
     }
 
     registered = []

--- a/src/looker_mcp_server/tools/identity.py
+++ b/src/looker_mcp_server/tools/identity.py
@@ -1,0 +1,59 @@
+"""Identity tool group — current-user introspection.
+
+Tools that answer "as which Looker user is this MCP session
+authenticated?" Useful for confirming the active identity before
+running operations that depend on user-specific state (dev workspace,
+content access, license seat). When the configured admin credentials
+are sudo-impersonating another user (via ``act_as_user`` per-call or
+``X-User-Token`` header), ``whoami`` returns the impersonated user's
+record because Looker resolves ``GET /user`` against the bearer token
+the session is currently using.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fastmcp import FastMCP
+
+from ..client import LookerClient, format_api_error
+
+
+def register_identity_tools(server: FastMCP, client: LookerClient) -> None:
+    @server.tool(
+        description=(
+            "Return the Looker user this MCP session is currently authenticated "
+            "as. Calls ``GET /user``, which Looker resolves against the active "
+            "session token — so when the session is sudo-impersonating another "
+            "user (per-call ``act_as_user`` or ``X-User-Token`` header), the "
+            "impersonated user's record is returned. Useful when the same "
+            "Looker instance has multiple similarly-named users and you need "
+            "to confirm which one the MCP is operating as."
+        ),
+    )
+    async def whoami() -> str:
+        ctx = client.build_context("whoami", "identity")
+        try:
+            async with client.session(ctx) as session:
+                user = await session.get("/user")
+                # Field allow-list: don't pass through raw response. Looker
+                # adds new fields over time (home_folder_id, OAuth provider
+                # IDs, etc.) and a permissive default would surface them
+                # without us deciding they're appropriate. Add to this list
+                # deliberately when a new field becomes useful.
+                return json.dumps(
+                    {
+                        "id": user.get("id"),
+                        "display_name": user.get("display_name"),
+                        "email": user.get("email"),
+                        "first_name": user.get("first_name"),
+                        "last_name": user.get("last_name"),
+                        "role_ids": user.get("role_ids"),
+                        "group_ids": user.get("group_ids"),
+                        "verified_looker_employee": user.get("verified_looker_employee"),
+                        "is_disabled": user.get("is_disabled"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("whoami", e)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,7 @@ class TestGroupConstants:
             "audit",
             "workflows",
             "health",
+            "identity",
         }
         assert ALL_GROUPS == expected
 

--- a/tests/test_identity_tools.py
+++ b/tests/test_identity_tools.py
@@ -1,0 +1,96 @@
+"""Tests for the identity tool group — current-user introspection."""
+
+import json
+
+import httpx
+import pytest
+import respx
+from fastmcp import Client
+from mcp.types import TextContent
+
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout() -> None:
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+class TestWhoami:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_current_user_with_field_allow_list(self, config):
+        _mock_login_logout()
+        # Looker's response carries many fields; the tool's allow-list
+        # surfaces a stable subset and ignores the rest. ``home_folder_id``
+        # is in the response but should NOT appear in the tool result.
+        respx.get(f"{API_URL}/user").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "42",
+                    "display_name": "Test User",
+                    "email": "test@example.com",
+                    "first_name": "Test",
+                    "last_name": "User",
+                    "role_ids": ["1", "2"],
+                    "group_ids": ["10"],
+                    "verified_looker_employee": False,
+                    "is_disabled": False,
+                    "home_folder_id": "secret-internal-id",  # NOT in allow-list
+                },
+            )
+        )
+
+        mcp, client = create_server(config, enabled_groups={"identity"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("whoami", {})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["id"] == "42"
+                assert payload["email"] == "test@example.com"
+                assert payload["role_ids"] == ["1", "2"]
+                # Field allow-list keeps the surface stable across Looker
+                # API additions — new server-side fields don't auto-leak
+                # into tool output until a maintainer adds them.
+                assert "home_folder_id" not in payload
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_surfaces_api_error_via_format_api_error(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/user").mock(
+            return_value=httpx.Response(401, json={"message": "Unauthorized"})
+        )
+
+        mcp, client = create_server(config, enabled_groups={"identity"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("whoami", {})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["status"] == 401
+        finally:
+            await client.close()


### PR DESCRIPTION
## Summary

Adds an `identity` tool group with a single `whoami` tool that calls `GET /user` and returns a stable subset of the response. The group is on by default — it's a low-risk read-only diagnostic that's universally useful when the same Looker instance has multiple similarly-named users and operators need to confirm which one the MCP is currently authenticated as.

When the configured admin credentials are sudo-impersonating another user (per-call `act_as_user` or `X-User-Token` header), `whoami` returns the impersonated user's record — Looker resolves `GET /user` against whichever bearer token the session is currently using.

## Field allow-list

Output is allow-listed to: `id`, `display_name`, `email`, `first_name`, `last_name`, `role_ids`, `group_ids`, `verified_looker_employee`, `is_disabled`. Looker adds new fields to its user response over time (`home_folder_id`, OAuth provider IDs, etc.) and a permissive default would surface them without a maintainer deciding they're appropriate. New fields get added to the allow-list deliberately.

## Test plan

- [x] `whoami` returns allow-listed fields and drops anything else (regression check that defends against future Looker API additions silently appearing in tool output)
- [x] API errors surface via `format_api_error`
- [x] Full suite: `uv run pytest` — 324 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## Backward compatibility

Purely additive. New `identity` group; no existing tools affected. Default-group test in `test_config.py` updated to include the new entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identity tools with a `whoami` command that retrieves the currently authenticated Looker user's information, including user ID, display name, email, role, and group assignments.

* **Tests**
  * Added comprehensive test coverage for the new identity tool functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->