### PR TITLE
feat(modeling): datagroup trigger + PDT build administration tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | **board** | `list_boards`, `get_board`, `create_board`, `update_board`, `delete_board`, `get_board_section`, `create_board_section`, `update_board_section`, `delete_board_section`, `get_board_item`, `create_board_item`, `update_board_item`, `delete_board_item` | Curate content with boards, sections, and items |
 | **folder** | `list_folders`, `get_folder`, `create_folder`, `update_folder`, `delete_folder`, `get_folder_children`, `get_folder_ancestors`, `get_folder_looks`, `get_folder_dashboards` | Navigate and manage the folder hierarchy |
 | **health**\* | `health_pulse`, `health_analyze`, `health_vacuum` | Instance health checks and usage analysis |
-| **modeling** | `list_projects`, `get_project`, `create_project`, `update_project`, `delete_project`, `get_project_manifest`, `get_project_deploy_key`, `create_project_deploy_key`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project`, `list_datagroups`, `reset_datagroup` | LookML project lifecycle, file edits, syntax validation, and datagroup cache management |
+| **modeling** | `list_projects`, `get_project`, `create_project`, `update_project`, `delete_project`, `get_project_manifest`, `get_project_deploy_key`, `create_project_deploy_key`, `list_project_files`, `get_file`, `create_file`, `update_file`, `delete_file`, `validate_project`, `list_datagroups`, `get_datagroup`, `reset_datagroup`, `trigger_datagroup`, `start_pdt_build`, `check_pdt_build`, `stop_pdt_build`, `graph_derived_tables_for_view`, `graph_derived_tables_for_model` | LookML project lifecycle, file edits, syntax validation, datagroup cache + trigger management, and PDT build administration |
 | **git** | `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`, `delete_git_branch`, `deploy_to_production`, `reset_to_production`, `get_git_deploy_key`, `create_git_deploy_key`, `list_git_connection_tests`, `run_git_connection_test` | Git branch lifecycle, production deploy, SSH deploy-key rotation, and git-connection diagnostics |
 | **admin** | `list_users`, `get_user`, `create_user`, `update_user`, `delete_user`, `create_credentials_email`, `send_password_reset`, `list_roles`, `get_role`, `create_role`, `update_role`, `delete_role`, `get_role_groups`, `get_role_users`, `list_permissions`, `list_permission_sets`, `create_permission_set`, `update_permission_set`, `delete_permission_set`, `list_model_sets`, `create_model_set`, `update_model_set`, `delete_model_set`, `list_groups`, `create_group`, `delete_group`, `add_group_user`, `remove_group_user`, `set_role_groups`, `set_role_users`, `set_user_roles`, `get_user_roles`, `list_schedules`, `create_schedule`, `update_schedule`, `delete_schedule`, `run_schedule_once` | User, role, RBAC, group, and schedule management |
 | **connection** | `get_connection`, `list_connection_dialects`, `create_connection`, `update_connection`, `delete_connection`, `test_connection` | Database connection CRUD and health checks |
@@ -343,6 +343,51 @@ All three URIs must be absolute `https://` URLs; the server fails closed at star
 - **Future major release** — removed entirely.
 
 If you currently rely on `LOOKER_MCP_AUTH_TOKEN` for gateway-level MCP protection, plan the migration now: either stand up an authorization server that issues OAuth 2.1 access tokens bound to `aud=<LOOKER_MCP_RESOURCE_URI>`, or keep the server in `dev` mode behind a trusted network perimeter.
+
+## PDT Administration Workflows
+
+The modeling tool group exposes the primitives Looker uses for PDT (Persistent Derived Table) lifecycle: `update_connection` (toggle PDT control on a connection), `start_pdt_build` / `check_pdt_build` / `stop_pdt_build` (build management), `trigger_datagroup` (force rebuild + cache invalidation), and `graph_derived_tables_for_*` (dependency inspection).
+
+Two opinionated recipes for connection-level workflows:
+
+### Disable PDT workflow on a connection
+
+When you need to quiesce all PDT builds on a connection (warehouse maintenance, cost spike investigation, etc.):
+
+```jsonc
+// 1. Stop new builds at the source — Looker will reject any further enqueues
+{ "tool": "update_connection", "args": { "name": "my_warehouse", "pdt_api_control_enabled": false } }
+
+// 2. Inspect what's currently materialized so you know what's at risk
+{ "tool": "graph_derived_tables_for_model", "args": { "model": "ecommerce", "color": true } }
+
+// 3. (Optional) Stop any in-flight builds you have materialization_ids for
+{ "tool": "stop_pdt_build", "args": { "materialization_id": "mat-abc" } }
+
+// 4. Verify the connection is quiesced
+{ "tool": "test_connection", "args": { "name": "my_warehouse", "tests": ["pdt"] } }
+```
+
+### Enable PDT workflow on a connection
+
+When you're ready to re-enable PDT builds after maintenance:
+
+```jsonc
+// 1. Re-enable PDT API control
+{ "tool": "update_connection", "args": { "name": "my_warehouse", "pdt_api_control_enabled": true } }
+
+// 2. Verify the connection is healthy for PDT builds
+{ "tool": "test_connection", "args": { "name": "my_warehouse", "tests": ["pdt"] } }
+
+// 3. (Optional) Force-rebuild gating datagroups so downstream PDTs catch up
+{ "tool": "trigger_datagroup", "args": { "datagroup_id": "dg1" } }
+
+// 4. (Optional) Pre-warm specific PDTs
+{ "tool": "start_pdt_build", "args": { "model_name": "ecommerce", "view_name": "orders_pdt" } }
+{ "tool": "check_pdt_build", "args": { "materialization_id": "mat-…" } }  // poll until status == "complete"
+```
+
+These recipes are intentionally exposed as separate primitives rather than a single `disable_pdt_workflow(connection)` composite tool. Each call emits its own audit line in the `looker.session.sudo` debug log when run under `act_as_user`, which is the right granularity for compliance review. A composite tool would hide steps from the LLM-as-operator and make failure paths less legible.
 
 ## Health Endpoints
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ If you currently rely on `LOOKER_MCP_AUTH_TOKEN` for gateway-level MCP protectio
 
 ## PDT Administration Workflows
 
-The modeling tool group exposes the primitives Looker uses for PDT (Persistent Derived Table) lifecycle: `update_connection` (toggle PDT control on a connection), `start_pdt_build` / `check_pdt_build` / `stop_pdt_build` (build management), `trigger_datagroup` (force rebuild + cache invalidation), and `graph_derived_tables_for_*` (dependency inspection).
+PDT (Persistent Derived Table) lifecycle is split across two tool groups: the `connection` group's `update_connection` toggles PDT control on a connection and the `modeling` group's `start_pdt_build` / `check_pdt_build` / `stop_pdt_build` (build management), `trigger_datagroup` (force rebuild + cache invalidation), and `graph_derived_tables_for_*` (dependency inspection) cover the per-PDT operations.
 
 Two opinionated recipes for connection-level workflows:
 

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -668,11 +668,16 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
                     f"/derived_table/{_path_seg(materialization_id)}/stop",
                     params=params or None,
                 )
+                status = (result or {}).get("status")
                 return json.dumps(
                     {
                         "materialization_id": (result or {}).get("materialization_id"),
-                        "stopped": True,
-                        "status": (result or {}).get("status"),
+                        # Derive ``stopped`` from the actual response state.
+                        # A no-op stop (e.g., the materialization already
+                        # finished) returns a non-stopped status, and we
+                        # must not falsely report cancellation success.
+                        "stopped": status == "stopped",
+                        "status": status,
                         "resp_text": (result or {}).get("resp_text"),
                     },
                     indent=2,

--- a/src/looker_mcp_server/tools/modeling.py
+++ b/src/looker_mcp_server/tools/modeling.py
@@ -482,3 +482,267 @@ def register_modeling_tools(server: FastMCP, client: LookerClient) -> None:
                 )
         except Exception as e:
             return format_api_error("reset_datagroup", e)
+
+    @server.tool(
+        description=(
+            "Get detail for a single datagroup, including its model, name, "
+            "interval/sql triggers, last ``triggered_at`` time, and current "
+            "``stale_before`` marker. Use to inspect a datagroup before "
+            "calling ``trigger_datagroup`` or ``reset_datagroup``."
+        ),
+    )
+    async def get_datagroup(
+        datagroup_id: Annotated[str, "Datagroup ID (from list_datagroups)"],
+    ) -> str:
+        ctx = client.build_context("get_datagroup", "modeling", {"datagroup_id": datagroup_id})
+        try:
+            async with client.session(ctx) as session:
+                d = await session.get(f"/datagroups/{_path_seg(datagroup_id)}")
+                if not d:
+                    return json.dumps({"id": datagroup_id, "found": False}, indent=2)
+                return json.dumps(
+                    {
+                        "id": d.get("id"),
+                        "model_name": d.get("model_name"),
+                        "name": d.get("name"),
+                        "trigger_check_at": d.get("trigger_check_at"),
+                        "triggered_at": d.get("triggered_at"),
+                        "stale_before": d.get("stale_before"),
+                        "trigger_value": d.get("trigger_value"),
+                        "trigger_error": d.get("trigger_error"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("get_datagroup", e)
+
+    @server.tool(
+        description=(
+            "Trigger a datagroup by setting its ``triggered_at`` to the "
+            "current time. Forces a PDT rebuild AND cache invalidation for "
+            "everything tagged with the datagroup — distinct from "
+            "``reset_datagroup``, which only updates ``stale_before`` (cache "
+            "bust without a rebuild). Use this to manually pre-warm a PDT or "
+            "to force-rebuild after upstream data corrections."
+        ),
+    )
+    async def trigger_datagroup(
+        datagroup_id: Annotated[str, "Datagroup ID (from list_datagroups)"],
+    ) -> str:
+        import time
+
+        ctx = client.build_context("trigger_datagroup", "modeling", {"datagroup_id": datagroup_id})
+        try:
+            async with client.session(ctx) as session:
+                body = {"triggered_at": int(time.time())}
+                updated = await session.patch(f"/datagroups/{_path_seg(datagroup_id)}", body=body)
+                return json.dumps(
+                    {
+                        "id": updated.get("id") if updated else datagroup_id,
+                        "triggered": True,
+                        "triggered_at": body["triggered_at"],
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("trigger_datagroup", e)
+
+    # ── PDT (Persistent Derived Table) build administration ──────────
+
+    @server.tool(
+        description=(
+            "Enqueue materialization of a PDT identified by ``model`` + "
+            "``view``. Returns a ``materialization_id`` you can poll via "
+            "``check_pdt_build`` and cancel via ``stop_pdt_build``. By "
+            "default builds in production; pass ``workspace='dev'`` to "
+            "build the dev-workspace's version of the PDT (useful when "
+            "validating LookML changes that affect derived-table SQL)."
+        ),
+    )
+    async def start_pdt_build(
+        model_name: Annotated[str, "LookML model name owning the PDT"],
+        view_name: Annotated[str, "View name of the PDT to build"],
+        force_rebuild: Annotated[
+            bool,
+            "Force rebuild of dependent PDTs even if already materialized.",
+        ] = False,
+        force_full_incremental: Annotated[
+            bool,
+            "Force any incremental PDTs in the dependency chain to fully re-materialize.",
+        ] = False,
+        workspace: Annotated[
+            str,
+            "Workspace for materialization: ``'production'`` (default) or ``'dev'``.",
+        ] = "production",
+        source: Annotated[
+            str | None,
+            "Optional caller tag — surfaces in Looker's PDT build logs.",
+        ] = None,
+    ) -> str:
+        ctx = client.build_context(
+            "start_pdt_build",
+            "modeling",
+            {"model_name": model_name, "view_name": view_name, "workspace": workspace},
+        )
+        try:
+            async with client.session(ctx) as session:
+                # Looker's start_pdt_build is GET (per OpenAPI spec); booleans
+                # ride as the strings 'true'/'false' in the query string.
+                params: dict[str, Any] = {"workspace": workspace}
+                if force_rebuild:
+                    params["force_rebuild"] = "true"
+                if force_full_incremental:
+                    params["force_full_incremental"] = "true"
+                _set_if(params, "source", source)
+                result = await session.get(
+                    f"/derived_table/{_path_seg(model_name)}/{_path_seg(view_name)}/start",
+                    params=params,
+                )
+                return json.dumps(
+                    {
+                        "materialization_id": (result or {}).get("materialization_id"),
+                        "resp_text": (result or {}).get("resp_text"),
+                        "status": (result or {}).get("status"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("start_pdt_build", e)
+
+    @server.tool(
+        description=(
+            "Check the status of a PDT materialization started via "
+            "``start_pdt_build``. Returns ``status`` (e.g. ``running``, "
+            "``complete``, ``error``), progress ratio, and any "
+            "``resource_usage`` Looker has emitted. Poll until status "
+            "is terminal."
+        ),
+    )
+    async def check_pdt_build(
+        materialization_id: Annotated[str, "ID returned by ``start_pdt_build``"],
+    ) -> str:
+        ctx = client.build_context(
+            "check_pdt_build", "modeling", {"materialization_id": materialization_id}
+        )
+        try:
+            async with client.session(ctx) as session:
+                result = await session.get(f"/derived_table/{_path_seg(materialization_id)}/status")
+                return json.dumps(
+                    {
+                        "materialization_id": (result or {}).get("materialization_id"),
+                        "status": (result or {}).get("status"),
+                        "ratio": (result or {}).get("ratio"),
+                        "resp_text": (result or {}).get("resp_text"),
+                        "resource_usage": (result or {}).get("resource_usage"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("check_pdt_build", e)
+
+    @server.tool(
+        description=(
+            "Cancel an in-flight PDT materialization. Use to free a stuck "
+            "build or recover after a runaway query. Note: Looker's API "
+            "implements stop as a GET (not DELETE) — this tool wraps that "
+            "convention. The materialization_id comes from "
+            "``start_pdt_build`` or from the PDT build log in "
+            "``system__activity``."
+        ),
+    )
+    async def stop_pdt_build(
+        materialization_id: Annotated[str, "ID returned by ``start_pdt_build``"],
+        source: Annotated[
+            str | None,
+            "Optional caller tag — surfaces in Looker's PDT build logs.",
+        ] = None,
+    ) -> str:
+        ctx = client.build_context(
+            "stop_pdt_build", "modeling", {"materialization_id": materialization_id}
+        )
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] = {}
+                _set_if(params, "source", source)
+                result = await session.get(
+                    f"/derived_table/{_path_seg(materialization_id)}/stop",
+                    params=params or None,
+                )
+                return json.dumps(
+                    {
+                        "materialization_id": (result or {}).get("materialization_id"),
+                        "stopped": True,
+                        "status": (result or {}).get("status"),
+                        "resp_text": (result or {}).get("resp_text"),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("stop_pdt_build", e)
+
+    @server.tool(
+        description=(
+            "Get the PDT dependency graph for a single derived-table view. "
+            "Returns a DOT-language description of the subgraph (the view "
+            "and everything it transitively depends on). Useful before "
+            "kicking off a force-rebuild — you can see what other PDTs "
+            "will be regenerated."
+        ),
+    )
+    async def graph_derived_tables_for_view(
+        view: Annotated[str, "Derived-table view name"],
+        models: Annotated[
+            str | None,
+            "Optional comma-separated model names to scope the search.",
+        ] = None,
+        workspace: Annotated[
+            str,
+            "Workspace to query: ``'production'`` (default) or ``'dev'``.",
+        ] = "production",
+    ) -> str:
+        ctx = client.build_context(
+            "graph_derived_tables_for_view",
+            "modeling",
+            {"view": view, "workspace": workspace},
+        )
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] = {"workspace": workspace}
+                _set_if(params, "models", models)
+                graph = await session.get(
+                    f"/derived_table/graph/view/{_path_seg(view)}",
+                    params=params,
+                )
+                return json.dumps(graph, indent=2)
+        except Exception as e:
+            return format_api_error("graph_derived_tables_for_view", e)
+
+    @server.tool(
+        description=(
+            "Get the full PDT dependency graph for a model. Returns DOT-"
+            "language graph description with optional color coding by "
+            "build state (grey=not built, green=built, yellow=building, "
+            "red=error). Use to audit PDT freshness across a whole model."
+        ),
+    )
+    async def graph_derived_tables_for_model(
+        model: Annotated[str, "LookML model name"],
+        format: Annotated[str, "Graph format. Currently only 'dot' is supported."] = "dot",
+        color: Annotated[
+            bool,
+            "Color the graph nodes by current build status.",
+        ] = False,
+    ) -> str:
+        ctx = client.build_context("graph_derived_tables_for_model", "modeling", {"model": model})
+        try:
+            async with client.session(ctx) as session:
+                params: dict[str, Any] = {"format": format}
+                if color:
+                    params["color"] = "true"
+                graph = await session.get(
+                    f"/derived_table/graph/model/{_path_seg(model)}",
+                    params=params,
+                )
+                return json.dumps(graph, indent=2)
+        except Exception as e:
+            return format_api_error("graph_derived_tables_for_model", e)

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -288,3 +288,203 @@ class TestPathEncoding:
                 assert " " not in captured["raw_path"]
         finally:
             await client.close()
+
+
+class TestDatagroupAdmin:
+    """``trigger_datagroup`` and ``get_datagroup`` complete the datagroup
+    admin surface. ``trigger_datagroup`` is the missing primitive — sets
+    ``triggered_at`` to force a PDT rebuild AND cache invalidation
+    simultaneously. ``reset_datagroup`` only does cache bust (sets
+    ``stale_before``)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_datagroup_returns_field_allow_list(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/datagroups/dg1").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "dg1",
+                    "model_name": "ecommerce",
+                    "name": "hourly",
+                    "trigger_check_at": 1716000000,
+                    "triggered_at": 1716000000,
+                    "stale_before": 0,
+                    "trigger_value": "abc123",
+                    "trigger_error": None,
+                    "internal_only_field": "hidden",  # NOT in allow-list
+                },
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("get_datagroup", {"datagroup_id": "dg1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["id"] == "dg1"
+                assert payload["model_name"] == "ecommerce"
+                assert "internal_only_field" not in payload
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_trigger_datagroup_patches_triggered_at(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content.decode())
+            return httpx.Response(200, json={"id": "dg1"})
+
+        respx.patch(f"{API_URL}/datagroups/dg1").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("trigger_datagroup", {"datagroup_id": "dg1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["triggered"] is True
+                # Body MUST set triggered_at (not stale_before) — that's
+                # the difference from ``reset_datagroup``.
+                assert "triggered_at" in captured["body"]
+                assert "stale_before" not in captured["body"]
+                assert isinstance(captured["body"]["triggered_at"], int)
+        finally:
+            await looker_client.close()
+
+
+class TestPdtBuildAdmin:
+    """``start_pdt_build`` / ``check_pdt_build`` / ``stop_pdt_build``
+    cover the on-demand PDT regen flow. All three are GET requests per
+    Looker's OpenAPI spec — the ``stop`` endpoint is GET (not DELETE),
+    which is unusual but documented and stable."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_start_pdt_build_passes_force_flags_as_query_strings(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(
+                200,
+                json={"materialization_id": "mat-1", "status": "started"},
+            )
+
+        respx.get(f"{API_URL}/derived_table/ecommerce/orders_pdt/start").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "start_pdt_build",
+                    {
+                        "model_name": "ecommerce",
+                        "view_name": "orders_pdt",
+                        "force_rebuild": True,
+                        "force_full_incremental": True,
+                        "workspace": "dev",
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["materialization_id"] == "mat-1"
+        finally:
+            await looker_client.close()
+
+        assert "force_rebuild=true" in captured["url"]
+        assert "force_full_incremental=true" in captured["url"]
+        assert "workspace=dev" in captured["url"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_check_pdt_build_returns_status_and_progress(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/derived_table/mat-1/status").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "materialization_id": "mat-1",
+                    "status": "running",
+                    "ratio": 0.42,
+                    "resp_text": "Building…",
+                    "resource_usage": {"warehouse_credits": 12.5},
+                },
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "check_pdt_build", {"materialization_id": "mat-1"}
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["status"] == "running"
+                assert payload["ratio"] == 0.42
+                assert payload["resource_usage"]["warehouse_credits"] == 12.5
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_stop_pdt_build_uses_get_per_looker_spec(self, config):
+        _mock_login_logout()
+        # Per Looker's OpenAPI spec, ``/derived_table/{id}/stop`` is GET
+        # (not DELETE) — this regression-locks that surprising shape.
+        respx.get(f"{API_URL}/derived_table/mat-1/stop").mock(
+            return_value=httpx.Response(
+                200,
+                json={"materialization_id": "mat-1", "status": "stopped"},
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "stop_pdt_build", {"materialization_id": "mat-1"}
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["stopped"] is True
+                assert payload["status"] == "stopped"
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_graph_derived_tables_for_view_passes_models_and_workspace(self, config):
+        _mock_login_logout()
+        captured: dict = {}
+
+        def capture(request: httpx.Request) -> httpx.Response:
+            captured["url"] = str(request.url)
+            return httpx.Response(200, json={"graph_text": "digraph { ... }"})
+
+        respx.get(f"{API_URL}/derived_table/graph/view/orders_pdt").mock(side_effect=capture)
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "graph_derived_tables_for_view",
+                    {"view": "orders_pdt", "models": "ecommerce", "workspace": "dev"},
+                )
+        finally:
+            await looker_client.close()
+
+        assert "models=ecommerce" in captured["url"]
+        assert "workspace=dev" in captured["url"]

--- a/tests/test_modeling_tools.py
+++ b/tests/test_modeling_tools.py
@@ -466,6 +466,38 @@ class TestPdtBuildAdmin:
 
     @pytest.mark.asyncio
     @respx.mock
+    async def test_stop_pdt_build_does_not_falsely_report_success_on_noop(self, config):
+        # Edge case: caller stops an already-finished materialization.
+        # Looker returns the existing status (``complete``) — we must
+        # NOT hard-code ``stopped: True``, because that would misreport
+        # the cancellation as successful when the build had already
+        # naturally completed.
+        _mock_login_logout()
+        respx.get(f"{API_URL}/derived_table/mat-2/stop").mock(
+            return_value=httpx.Response(
+                200,
+                json={"materialization_id": "mat-2", "status": "complete"},
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"modeling"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "stop_pdt_build", {"materialization_id": "mat-2"}
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                # Status reflects what Looker actually returned, and
+                # ``stopped`` is derived from it — not hard-coded.
+                assert payload["status"] == "complete"
+                assert payload["stopped"] is False
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
     async def test_graph_derived_tables_for_view_passes_models_and_workspace(self, config):
         _mock_login_logout()
         captured: dict = {}


### PR DESCRIPTION
## Summary

Closes the datagroup/PDT admin gap. Existing OSS coverage was just `list_datagroups` + `reset_datagroup` (cache invalidation only) and the connection-level toggles via `update_connection`. The `/derived_table/*` build-management endpoints had zero coverage, and `trigger_datagroup` (forces PDT rebuild + cache invalidation simultaneously) wasn't exposed.

## New tools (all in the `modeling` group)

| Tool | Endpoint | Purpose |
|---|---|---|
| `get_datagroup` | `GET /datagroups/{id}` | Inspect a single datagroup |
| `trigger_datagroup` | `PATCH /datagroups/{id}` (sets `triggered_at`) | Force PDT rebuild + cache invalidation. Distinct from `reset_datagroup` (only `stale_before`). |
| `start_pdt_build` | `GET /derived_table/{model}/{view}/start` | Enqueue PDT materialization |
| `check_pdt_build` | `GET /derived_table/{materialization_id}/status` | Poll a build's status |
| `stop_pdt_build` | `GET /derived_table/{materialization_id}/stop` | Cancel an in-flight build |
| `graph_derived_tables_for_view` | `GET /derived_table/graph/view/{view}` | PDT subgraph for a view |
| `graph_derived_tables_for_model` | `GET /derived_table/graph/model/{model}` | Full PDT dependency graph for a model |

All endpoint shapes verified against Looker's OpenAPI 4.0 spec before implementation — caught two surprises: `start_pdt_build` is GET (not POST), and `stop_pdt_build` is GET (not DELETE).

## Test plan

- [x] `get_datagroup` returns allow-listed subset (regression check that defends against future Looker API additions)
- [x] `trigger_datagroup` PATCHes `triggered_at` (not `stale_before` — locks the contract that distinguishes it from `reset_datagroup`)
- [x] `start_pdt_build` passes booleans as the strings `true`/`false` in the query string and includes the workspace selector
- [x] `check_pdt_build` returns status + ratio + resource_usage
- [x] `stop_pdt_build` uses GET per the spec (regression-locks the surprising HTTP method)
- [x] `graph_derived_tables_for_view` includes `models` and `workspace` query params
- [x] Full suite: `uv run pytest` — 328 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## README

- Tool group table updated with the seven new tools
- New **PDT Administration Workflows** section documents the canonical enable/disable PDT recipes on a connection. Intentionally exposed as separate primitive calls rather than a single composite tool — each call emits its own audit line under `act_as_user`, which is the right granularity for compliance review.

## Backward compatibility

Purely additive. No existing tools modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added datagroup management tools to inspect details and manually trigger rebuilds.
  * Added PDT build administration capabilities to start, monitor, and stop derived table builds.
  * Added derived table graphing for individual views and entire models.

* **Documentation**
  * Updated README with PDT Administration Workflows guide covering new connection-level operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/34)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->