### PR TITLE
test(query): tighten branch-arg test assertions

### DIFF
--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -85,10 +85,42 @@ class TestQueryWithBranch:
         bodies = [json.loads(c.request.content.decode()) for c in put_branch.calls]
         assert bodies == [{"name": "feature-x"}, {"name": "main"}]
 
+        # Atomicity isn't just call counts — the order matters. A regression
+        # that restored the branch before running the query would still
+        # produce two PUTs with the right bodies; this assertion locks the
+        # actual swap → run → restore sequence so that can't drift silently.
+        events = [(call.request.method, call.request.url.path) for call in respx.calls]
+        swap_idx = next(
+            i
+            for i, (method, path) in enumerate(events)
+            if method == "PUT" and path.endswith("/projects/proj1/git_branch")
+        )
+        run_idx = next(
+            i
+            for i, (method, path) in enumerate(events)
+            if method == "GET" and path.endswith("/queries/q1/run/json")
+        )
+        restore_idx = next(
+            i
+            for i, (method, path) in enumerate(events)
+            if method == "PUT" and path.endswith("/projects/proj1/git_branch") and i > swap_idx
+        )
+        assert swap_idx < run_idx < restore_idx, (
+            f"swap/run/restore must be in order, got events: {events}"
+        )
+
     @pytest.mark.asyncio
     @respx.mock
     async def test_branch_without_project_id_returns_clean_validation_error(self, config):
         _mock_login_logout()
+        # Mock both endpoints we expect NOT to be called — the validation
+        # must short-circuit before any session/query API side effects.
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        create_query = respx.post(f"{API_URL}/queries").mock(
+            return_value=httpx.Response(201, json={"id": "q1"})
+        )
 
         mcp, looker_client = create_server(config, enabled_groups={"query"})
         try:
@@ -112,6 +144,11 @@ class TestQueryWithBranch:
                 assert "project_id" in payload["error"]
         finally:
             await looker_client.close()
+
+        # Validation must precede every Looker side effect — neither the
+        # workspace switch nor the query create should have fired.
+        assert not patch_session.called
+        assert not create_query.called
 
     @pytest.mark.asyncio
     @respx.mock


### PR DESCRIPTION
## Summary

Follow-up to #30. Two ⚡ Quick win nitpicks that CodeRabbit flagged on the dev_mode + branch tests didn't make it into #30 before the squash merge — pulling them in here as a small standalone PR.

## What changed

Both edits are in `tests/test_query_tools.py`:

1. **`test_branch_arg_drives_save_swap_run_restore`** — previously asserted two PUTs with the right bodies but didn't prove the query ran between them. A regression that restored the branch before the query would still pass with identical call counts. Adds sequence assertions on the recorded respx call order so `swap → run → restore` must happen in that order.

2. **`test_branch_without_project_id_returns_clean_validation_error`** — previously verified only the error payload. Now mocks `PATCH /session` and `POST /queries` and asserts neither was called, proving the validation actually short-circuits before any Looker side effects.

## Test plan

- [x] `uv run pytest tests/test_query_tools.py` — 4 passed
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run pyright` — 0 errors

## Backward compatibility

Tests-only change. No production code modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Improved branch query operation tests to verify correct execution sequencing
* Enhanced validation tests to ensure immediate error handling when required parameters are missing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/35)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->