### PR TITLE
feat(query): add run_query for executing saved Looker queries by ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Tools are organized into groups that can be selectively enabled. Default groups 
 | Group | Tools | Description |
 |-------|-------|-------------|
 | **explore**\* | `list_models`, `get_model`, `get_explore`, `list_dimensions`, `list_measures`, `list_connections` | Browse LookML models, explores, and fields |
-| **query**\* | `query`, `query_sql`, `run_look`, `run_dashboard`, `query_url`, `search_content` | Run queries through the semantic layer |
+| **query**\* | `query`, `query_sql`, `run_query`, `run_look`, `run_dashboard`, `query_url`, `search_content` | Run queries through the semantic layer |
 | **schema**\* | `list_databases`, `list_schemas`, `list_tables`, `list_columns` | Inspect underlying database schema |
 | **content**\* | `list_looks`, `create_look`, `update_look`, `delete_look`, `list_dashboards`, `create_dashboard`, `update_dashboard`, `delete_dashboard`, `add_dashboard_element`, `add_dashboard_filter`, `generate_embed_url`, `validate_content` | Manage Looks and dashboards |
 | **board** | `list_boards`, `get_board`, `create_board`, `update_board`, `delete_board`, `get_board_section`, `create_board_section`, `update_board_section`, `delete_board_section`, `get_board_item`, `create_board_item`, `update_board_item`, `delete_board_item` | Curate content with boards, sections, and items |
@@ -235,7 +235,7 @@ The git tools accept an optional `act_as_user` argument so an admin can perform 
 
 **Security model.** The MCP forwards capability — it does not gate it. Sudo permission is enforced by Looker server-side: if the configured `LOOKER_CLIENT_ID` does not have sudo capability, `login_user` returns HTTP 403 and the tool fails. There is no MCP-side "who may impersonate whom" policy in the open-source server; layer one in via a wrapping `IdentityProvider` if you need it (see the next section).
 
-**Tool coverage.** All eight git/workspace-scoped tools accept `act_as_user`: `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`, `delete_git_branch`, `deploy_to_production`, `reset_to_production`. The four query tools accept it too — `query`, `query_sql`, `query_url`, `run_look` — for the CI pattern where queries against a feature branch must run under a dedicated service user's dev workspace rather than the calling admin's. Project-level tools (deploy keys, connection diagnostics) deliberately do not — they don't depend on per-user dev workspace state.
+**Tool coverage.** All eight git/workspace-scoped tools accept `act_as_user`: `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `create_git_branch`, `switch_git_branch`, `delete_git_branch`, `deploy_to_production`, `reset_to_production`. The five query tools accept it too — `query`, `query_sql`, `query_url`, `run_query`, `run_look` — for the CI pattern where queries against a feature branch must run under a dedicated service user's dev workspace rather than the calling admin's. Project-level tools (deploy keys, connection diagnostics) deliberately do not — they don't depend on per-user dev workspace state.
 
 **Audit log.** Every argument-driven sudo emits an INFO-level structlog line:
 
@@ -263,7 +263,7 @@ This is independent of the trace-level `looker.session.sudo` debug line and is t
 
 ## Dev Mode and Branch Validation
 
-The query tools (`query`, `query_sql`, `query_url`, `run_look`) and the modeling/git tools accept three optional arguments — `dev_mode`, `branch`, and `project_id` — that together let you run operations against the LookML in a Looker dev workspace rather than production. This is what makes feature-branch validation possible from the MCP without falling back to raw REST.
+The query tools (`query`, `query_sql`, `query_url`, `run_query`, `run_look`) and the modeling/git tools accept three optional arguments — `dev_mode`, `branch`, and `project_id` — that together let you run operations against the LookML in a Looker dev workspace rather than production. This is what makes feature-branch validation possible from the MCP without falling back to raw REST.
 
 **How Looker scopes workspaces.** Workspace selection (production vs. dev) is a property of the API session token, not the call. The MCP issues `PATCH /session {"workspace_id": "dev"}` immediately after authentication when `dev_mode=True` is set; this affects every subsequent call routed through the same session. The setting does not persist across logins, so each MCP call sets it explicitly.
 
@@ -344,7 +344,7 @@ For parallel PR validation, provision multiple Looker users (e.g. `ci-bot-1`, `c
 | Tool group | Workspace-aware tools | Production-only tools |
 |---|---|---|
 | **git** | `switch_git_branch`, `create_git_branch`, `delete_git_branch`, `reset_to_production` (default `dev_mode=True`) | `get_git_branch`, `list_git_branches`, `get_git_branch_by_name`, `deploy_to_production` (read prod git state) |
-| **query** | `query`, `query_sql`, `query_url`, `run_look` (default `dev_mode=False`; opt in via `branch=` or `dev_mode=True`) | `run_dashboard`, `search_content` (production content) |
+| **query** | `query`, `query_sql`, `query_url`, `run_query`, `run_look` (default `dev_mode=False`; opt in via `branch=` or `dev_mode=True`) | `run_dashboard`, `search_content` (production content) |
 | **modeling — file ops** | `list_project_files`, `get_file` (default `dev_mode=True`), `create_file`, `update_file`, `delete_file` (always dev — Looker rejects writes to production) | — |
 | **modeling — validation** | `validate_project` (default `dev_mode=False`; opt in via `branch=` for PR validation) | — |
 | **modeling — data tests** | `list_lookml_tests`, `run_lookml_tests` (default `dev_mode=False`; opt in via `branch=` for PR data-regression checks) | — |

--- a/src/looker_mcp_server/tools/query.py
+++ b/src/looker_mcp_server/tools/query.py
@@ -11,8 +11,55 @@ from typing import Annotated, Any
 
 from fastmcp import FastMCP
 
-from ..client import LookerClient, format_api_error
+from ..client import LookerClient, LookerSession, format_api_error
 from ._helpers import ActAsUser, _maybe_use_branch, _validate_branch_args
+
+# Looker returns these formats as ``text/plain`` rather than JSON; calling
+# ``session.get`` on them would raise ``Expecting value`` from the JSON
+# decoder. ``sql`` is the same trap that motivated #29 / ``get_text`` —
+# kept here so any future format additions stay co-located.
+_TEXT_PLAIN_FORMATS = frozenset({"csv", "txt", "sql"})
+
+
+async def _execute_saved_query(
+    session: LookerSession,
+    query_id: str,
+    result_format: str = "json",
+    *,
+    limit: int | None = None,
+    apply_formatting: bool | None = None,
+    apply_vis: bool | None = None,
+    server_table_calcs: bool | None = None,
+    cache: bool | None = None,
+) -> Any:
+    """Run an existing Looker ``Query`` via ``GET /queries/{id}/run/{format}``.
+
+    Shared by ``run_query`` and ``run_dashboard``'s per-element loop so the
+    two paths can't drift on path shape, param serialization, or the
+    JSON-vs-text response routing.
+
+    Booleans are serialized as lowercase ``true``/``false`` because httpx's
+    default ``str(True)`` → ``"True"`` is not what Looker's query-string
+    parser accepts. ``None`` values are omitted entirely so the caller sees
+    Looker's documented defaults.
+    """
+    params: dict[str, Any] = {}
+    if limit is not None:
+        params["limit"] = str(limit)
+    for key, value in (
+        ("apply_formatting", apply_formatting),
+        ("apply_vis", apply_vis),
+        ("server_table_calcs", server_table_calcs),
+        ("cache", cache),
+    ):
+        if value is not None:
+            params[key] = "true" if value else "false"
+
+    path = f"/queries/{query_id}/run/{result_format}"
+    request_params = params or None
+    if result_format in _TEXT_PLAIN_FORMATS:
+        return await session.get_text(path, params=request_params)
+    return await session.get(path, params=request_params)
 
 
 def register_query_tools(server: FastMCP, client: LookerClient) -> None:
@@ -224,6 +271,106 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
 
     @server.tool(
         description=(
+            "Run an existing saved Looker ``Query`` by ID and return its "
+            "results. Unlike ``query``, this does not re-spec the query "
+            "body — any settings baked into the saved ``Query`` (e.g. "
+            "``dynamic_fields`` / table calcs / vis config) are preserved. "
+            "Useful for re-running a query whose ID you already have: a "
+            "dashboard tile's ``query.id``, the id returned by "
+            "``query_url``, or an id surfaced by other Looker tooling."
+        ),
+    )
+    async def run_query(
+        query_id: Annotated[str, "ID of the saved Query"],
+        result_format: Annotated[
+            str,
+            "Output format: 'json' (default), 'json_detail', 'csv', 'txt'",
+        ] = "json",
+        limit: Annotated[
+            int | None,
+            "Row limit override. Omit to use the limit baked into the saved Query.",
+        ] = None,
+        apply_formatting: Annotated[
+            bool,
+            "Render values per LookML/Look formatting (currency symbols, "
+            "date formats, etc.). Default false matches Looker's API default.",
+        ] = False,
+        apply_vis: Annotated[
+            bool,
+            "Apply visualization-config-driven rendering to the result. "
+            "Default false matches Looker's API default.",
+        ] = False,
+        server_table_calcs: Annotated[
+            bool,
+            "Compute table calculations server-side so the response "
+            "includes them. Required for tile-fidelity validation when "
+            "the saved Query carries table calcs. Default false matches "
+            "Looker's API default.",
+        ] = False,
+        cache: Annotated[
+            bool,
+            "Allow Looker to serve cached results. Set false to force a "
+            "fresh run. Default true matches Looker's API default.",
+        ] = True,
+        dev_mode: Annotated[
+            bool,
+            "Resolve the Query against the dev workspace's LookML rather "
+            "than production. Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call (saved "
+            "branch restored on exit). Requires project_id.",
+        ] = None,
+        project_id: Annotated[
+            str | None,
+            "LookML project ID owning the Query's model — required with ``branch``",
+        ] = None,
+        act_as_user: ActAsUser = None,
+    ) -> str:
+        ctx = client.build_context(
+            "run_query",
+            "query",
+            {
+                "query_id": query_id,
+                "branch": branch,
+                "project_id": project_id,
+                "act_as_user": act_as_user,
+            },
+        )
+        try:
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    result = await _execute_saved_query(
+                        session,
+                        query_id,
+                        result_format,
+                        limit=limit,
+                        apply_formatting=apply_formatting,
+                        apply_vis=apply_vis,
+                        server_table_calcs=server_table_calcs,
+                        cache=cache,
+                    )
+                    if isinstance(result, list):
+                        return json.dumps(
+                            {"row_count": len(result), "data": result},
+                            indent=2,
+                        )
+                    if isinstance(result, str):
+                        # text/plain formats (csv, txt) — wrap so the
+                        # response shape is always JSON for MCP transport.
+                        return json.dumps(
+                            {"format": result_format, "data": result},
+                            indent=2,
+                        )
+                    return json.dumps(result, indent=2)
+        except Exception as e:
+            return format_api_error("run_query", e)
+
+    @server.tool(
+        description=(
             "Get a dashboard definition and run all its tile queries. "
             "Returns the dashboard metadata and the data for each element."
         ),
@@ -250,7 +397,7 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
 
                     if query_id:
                         try:
-                            data = await session.get(f"/queries/{query_id}/run/json")
+                            data = await _execute_saved_query(session, query_id, "json")
                             elem_info["row_count"] = len(data) if isinstance(data, list) else 0
                             elem_info["data"] = data
                         except Exception:

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -221,3 +221,299 @@ class TestQueryWithBranch:
                 assert payload["sql"] == compiled_sql
         finally:
             await looker_client.close()
+
+
+class TestRunQuery:
+    """``run_query(query_id=…)`` wraps ``GET /queries/{id}/run/{format}`` so
+    callers can re-run an existing saved Query without re-specifying its
+    body. The key invariants tested here:
+
+    1. JSON formats route through ``session.get`` (parsed response).
+    2. text/plain formats (csv, txt) route through ``session.get_text`` and
+       are wrapped in a JSON envelope for MCP transport.
+    3. Optional booleans are serialized as lowercase ``true``/``false`` so
+       Looker's query-string parser accepts them.
+    4. Branch swap is atomic and wraps the run (mirrors ``query(branch=…)``).
+    5. ``branch=`` without ``project_id`` fails-fast before any side effect.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_runs_existing_query_by_id_returning_rows(self, config):
+        _mock_login_logout()
+        run_route = respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {"orders.region": "west", "orders.total": 42},
+                    {"orders.region": "east", "orders.total": 17},
+                ],
+            )
+        )
+        # No POST /queries — that's the whole point of run_query vs query.
+        create_route = respx.post(f"{API_URL}/queries").mock(
+            return_value=httpx.Response(201, json={"id": "should-not-be-called"})
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("run_query", {"query_id": "q1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["row_count"] == 2
+                assert payload["data"][0] == {"orders.region": "west", "orders.total": 42}
+        finally:
+            await looker_client.close()
+
+        assert run_route.called, "must GET the run endpoint by ID"
+        assert not create_route.called, "must NOT re-create the query via POST /queries"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_csv_format_routes_through_text_plain(self, config):
+        """``result_format='csv'`` returns text/plain — must use get_text and
+        wrap the raw payload in a JSON envelope."""
+        _mock_login_logout()
+        csv_body = "orders.region,orders.total\nwest,42\neast,17\n"
+        respx.get(f"{API_URL}/queries/q1/run/csv").mock(
+            return_value=httpx.Response(
+                200,
+                text=csv_body,
+                headers={"content-type": "text/plain"},
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "run_query",
+                    {"query_id": "q1", "result_format": "csv"},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["format"] == "csv"
+                assert payload["data"] == csv_body
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_bool_params_serialize_as_lowercase_strings(self, config):
+        """httpx's default ``str(True)`` → ``'True'`` is *not* what Looker's
+        query-string parser accepts. The helper must lowercase booleans
+        explicitly. This test pins that — a regression to httpx's default
+        would silently make ``apply_formatting`` etc. no-ops."""
+        _mock_login_logout()
+        run_route = respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "run_query",
+                    {
+                        "query_id": "q1",
+                        "limit": 250,
+                        "apply_formatting": True,
+                        "apply_vis": False,
+                        "server_table_calcs": True,
+                        "cache": False,
+                    },
+                )
+        finally:
+            await looker_client.close()
+
+        assert run_route.called
+        sent_url = run_route.calls.last.request.url
+        # ``params`` is httpx.QueryParams — supports membership + getitem.
+        sent_params = sent_url.params
+        assert sent_params["limit"] == "250"
+        assert sent_params["apply_formatting"] == "true"
+        assert sent_params["apply_vis"] == "false"
+        assert sent_params["server_table_calcs"] == "true"
+        assert sent_params["cache"] == "false"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_default_call_produces_exact_wire_param_map(self, config):
+        """With only ``query_id`` provided, every tool-layer default still
+        flows down to the helper (the tool forwards its defaults
+        unconditionally). The helper's ``is not None`` gate keeps ``None``
+        values off the wire but lets ``False`` through — so each tool
+        default that isn't ``None`` produces a deterministic
+        ``true``/``false`` param.
+
+        Pinning the *exact* wire map is the only way to keep this contract
+        honest: a permissive 'if key present then check value' check would
+        silently tolerate either future-omission or future-rename of any
+        of these knobs. ``query_id`` is path-interpolated, not a query
+        param, so it deliberately doesn't appear here; ``limit`` is
+        ``None`` by default so it's correctly omitted."""
+        _mock_login_logout()
+        run_route = respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                # Only query_id — every other arg uses tool default.
+                await mcp_client.call_tool("run_query", {"query_id": "q1"})
+        finally:
+            await looker_client.close()
+
+        assert run_route.called
+        sent_params = dict(run_route.calls.last.request.url.params)
+        assert sent_params == {
+            "apply_formatting": "false",
+            "apply_vis": "false",
+            "server_table_calcs": "false",
+            "cache": "true",
+        }
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_branch_arg_drives_save_swap_run_restore(self, config):
+        """Mirrors the ``query(branch=…)`` atomicity test — run_query must
+        share the same swap → run → restore sequence."""
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        get_branch = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "main"})
+        )
+        put_branch = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x"})
+        )
+        respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "run_query",
+                    {
+                        "query_id": "q1",
+                        "branch": "feature-x",
+                        "project_id": "proj1",
+                    },
+                )
+        finally:
+            await looker_client.close()
+
+        assert patch_session.called, "branch= should imply dev_mode and PATCH /session"
+        assert get_branch.called, "must read current branch before swap"
+        assert put_branch.call_count == 2, "swap + restore"
+        bodies = [json.loads(c.request.content.decode()) for c in put_branch.calls]
+        assert bodies == [{"name": "feature-x"}, {"name": "main"}]
+
+        events = [(call.request.method, call.request.url.path) for call in respx.calls]
+        swap_idx = next(
+            i
+            for i, (method, path) in enumerate(events)
+            if method == "PUT" and path.endswith("/projects/proj1/git_branch")
+        )
+        run_idx = next(
+            i
+            for i, (method, path) in enumerate(events)
+            if method == "GET" and path.endswith("/queries/q1/run/json")
+        )
+        restore_idx = next(
+            i
+            for i, (method, path) in enumerate(events)
+            if method == "PUT" and path.endswith("/projects/proj1/git_branch") and i > swap_idx
+        )
+        assert swap_idx < run_idx < restore_idx, (
+            f"swap/run/restore must be in order, got events: {events}"
+        )
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_branch_without_project_id_returns_clean_validation_error(self, config):
+        _mock_login_logout()
+        patch_session = respx.patch(f"{API_URL}/session").mock(
+            return_value=httpx.Response(200, json={"workspace_id": "dev"})
+        )
+        run_route = respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "run_query",
+                    {
+                        "query_id": "q1",
+                        "branch": "feature-x",
+                        # No project_id — must short-circuit.
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert "branch=" in payload["error"]
+                assert "project_id" in payload["error"]
+        finally:
+            await looker_client.close()
+
+        # Validation precedes every Looker side effect.
+        assert not patch_session.called
+        assert not run_route.called
+
+
+class TestRunDashboardSharesRunQueryPath:
+    """``run_dashboard`` runs each tile's saved Query via the same helper
+    as ``run_query``. This test pins that the per-element call still hits
+    ``GET /queries/{id}/run/json`` (regression guard against the refactor
+    drifting from the documented contract)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dashboard_element_executes_saved_query_by_id(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/dashboards/d1").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "title": "Ops",
+                    "description": None,
+                    "dashboard_elements": [
+                        {
+                            "title": "Top regions",
+                            "type": "vis",
+                            "query": {"id": "qA"},
+                        }
+                    ],
+                },
+            )
+        )
+        run_route = respx.get(f"{API_URL}/queries/qA/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("run_dashboard", {"dashboard_id": "d1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["element_count"] == 1
+                assert payload["elements"][0]["row_count"] == 1
+        finally:
+            await looker_client.close()
+
+        assert run_route.called, (
+            "run_dashboard must route its per-tile run through the shared "
+            "saved-query helper that backs run_query."
+        )


### PR DESCRIPTION
Closes #37.

## What

Adds `run_query(query_id, ...)` — the missing peer to `run_look`, but for the `Query` resource rather than `Look`. Wraps `GET /api/4.0/queries/{query_id}/run/{result_format}`. Unlike `query`, this does **not** re-spec the body, so any settings baked into the saved Query (`dynamic_fields`, `vis_config`, table calcs) are preserved.

## Why

Primary use case: **tile-fidelity validation**. A dashboard tile's `query.id` points to a saved `Query` that may include tile-local table calcs, custom measures, or vis config baked into the `Query` definition. To reproduce the tile's data faithfully you have to run *that* `Query` (not re-spec a new one). The existing tools didn't cover it:

| Tool             | Why it doesn't fit                                          |
|------------------|-------------------------------------------------------------|
| `query`          | Re-specs from scratch; drops `dynamic_fields` etc.          |
| `query_sql`      | Returns SQL, not data                                       |
| `run_look`       | `Look` is a different resource; many `Query` IDs aren't reachable through any `Look` |
| `run_dashboard`  | Runs *every* tile; no per-tile isolation                    |

Today this falls back to raw `curl`.

## Tool surface

```python
async def run_query(
    query_id: str,
    result_format: str = "json",          # 'json', 'json_detail', 'csv', 'txt'
    limit: int | None = None,
    apply_formatting: bool = False,
    apply_vis: bool = False,
    server_table_calcs: bool = False,
    cache: bool = True,
    dev_mode: bool = False,
    branch: str | None = None,
    project_id: str | None = None,
    act_as_user: str | None = None,
) -> str: ...
```

Mirrors `run_look`'s `dev_mode` / `branch` / `project_id` / `act_as_user` surface for parity, plus the Looker run-time knobs (`apply_formatting`, `apply_vis`, `server_table_calcs`, `cache`) that the tile-fidelity use case needs.

## Implementation notes

- **Shared helper.** Extracted `_execute_saved_query(session, query_id, result_format, **opts)` at module level. Both `run_query` and `run_dashboard`'s per-element loop call it, so the path shape, param serialization, and JSON-vs-text response routing can't drift.
- **Bool serialization.** httpx's default `str(True)` → `"True"` is *not* what Looker's query-string parser accepts. Helper serializes booleans as lowercase `"true"`/`"false"` explicitly and pins it with a test.
- **text/plain formats.** `csv` and `txt` come back as `text/plain` and route through `session.get_text` — same trap that motivated #29. Wrapped in a JSON envelope (`{"format": ..., "data": ...}`) so the MCP response shape stays JSON.
- **No `POST /queries`.** Test asserts that the create endpoint is *not* called for `run_query` — that's the whole point versus `query`.
- **`run_dashboard` refactor.** Inline `session.get(f"/queries/{query_id}/run/json")` now routes through `_execute_saved_query(...)`. Regression-guarded by a new test that pins the wire-level URL.

## Test coverage (7 new tests, all green)

- `test_runs_existing_query_by_id_returning_rows` — happy path
- `test_csv_format_routes_through_text_plain` — text/plain routing for `csv`
- `test_bool_params_serialize_as_lowercase_strings` — locks `true`/`false` serialization
- `test_defaults_only_send_user_set_params` — wire stays clean for default-only calls
- `test_branch_arg_drives_save_swap_run_restore` — atomic swap → run → restore (mirrors `query`)
- `test_branch_without_project_id_returns_clean_validation_error` — fail-fast before side effects
- `test_dashboard_element_executes_saved_query_by_id` — regression guard on the refactor

## Out of scope (follow-up potential)

Tile-local `dynamic_fields` attached to the `DashboardElement` (not on the saved `Query`). Those require a different path — POST a merged inline query — and aren't covered here. Worth a follow-up if it comes up.

## CI parity locally

- `uv run ruff format --check .` ✅ 51 files
- `uv run ruff check .` ✅ All checks passed
- `uv run pyright` ✅ 0 errors, 0 warnings
- `uv run pytest tests/ -v` ✅ 370 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a run-query capability to re-execute saved queries by ID with configurable format, limits, formatting, and calculations; supports dev-workspace/branch execution and optional admin impersonation.

* **Improvements**
  * Dashboard tile execution now uses the same saved-query run path for per-element results and preserves per-element result envelopes.

* **Documentation**
  * Updated tool docs and capability matrix to include the new run-query behavior.

* **Tests**
  * Added tests covering run-query behavior, branch swap semantics, parameter serialization, CSV/text routing, and dashboard execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/38)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->