### PR TITLE
chore: add CodeRabbit configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,69 @@
+# CodeRabbit configuration
+# Docs: https://docs.coderabbit.ai/reference/configuration
+#
+# Stack: Python 3.11+, uv, ruff, pytest
+
+language: en-US
+
+reviews:
+  profile: assertive
+  request_changes_workflow: true
+  commit_status: true
+  high_level_summary: true
+  high_level_summary_placeholder: "@coderabbitai summary"
+  suggested_labels: true
+  suggested_reviewers: false
+  poem: false
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 5
+    drafts: false
+    base_branches:
+      - "main"
+    ignore_title_keywords:
+      - "WIP"
+      - "DRAFT"
+      - "DO NOT MERGE"
+    ignore_usernames:
+      - "dependabot"
+      - "renovate"
+      - "coderabbitai"
+
+  path_filters:
+    - "!**/*.lock"
+    - "!**/.venv/**"
+    - "!**/dist/**"
+    - "!**/__pycache__/**"
+    - "!**/build/**"
+    - "!**/coverage/**"
+    - "!**/.idea/**"
+    - "!**/.vscode/**"
+    - "!**/*.egg-info/**"
+    - "!**/.pytest_cache/**"
+    - "!**/.ruff_cache/**"
+
+  tools:
+    ruff:
+      enabled: true
+    gitleaks:
+      enabled: true
+    yamllint:
+      enabled: true
+    shellcheck:
+      enabled: true
+
+chat:
+  # Disable auto-reply to block prompt-injection via PR comments.
+  auto_reply: false
+
+knowledge_base:
+  # Scope learnings and issues to this repo only. Prevents a public PR from
+  # poisoning a shared knowledge store used across other repositories.
+  learnings:
+    scope: local
+  issues:
+    scope: local
+  code_guidelines:
+    enabled: true


### PR DESCRIPTION
## Summary

Adds a `.coderabbit.yaml` to configure CodeRabbit reviews for this public repository. Previously the repo used CodeRabbit defaults; this commit applies a hardened profile suited to a public OSS repository that accepts fork-based PRs.

## What changes

- **Disable chat auto-reply** (`chat.auto_reply: false`) — blocks the prompt-injection vector where a PR commenter engages CodeRabbit in a multi-turn chat with attacker-controlled inputs.
- **Scope knowledge base to this repo only** (`knowledge_base.learnings.scope: local`, `knowledge_base.issues.scope: local`) — prevents a public PR from seeding "learnings" that would later surface in reviews on other repositories.
- **Cap automatic work** (`auto_pause_after_reviewed_commits: 5`) — bounds review activity on PRs that push many incremental commits.
- **Skip drafts and WIP titles**, ignore bot accounts (`dependabot`, `renovate`, `coderabbitai`).
- **Enable `gitleaks`** in the review tool set — catches secret leakage from incoming PRs.
- **Enable `ruff`** for Python lint feedback in reviews.

## Notes

- Profile is `assertive` and `request_changes_workflow: true` to keep review feedback visible on the PR check.
- Path filters skip lockfiles, build output, virtualenvs, and IDE/cache directories.
- Reference: [CodeRabbit configuration](https://docs.coderabbit.ai/reference/configuration).

## Test plan

- [ ] CodeRabbit review on this PR uses the new configuration.
- [ ] `commit_status` is reported back to GitHub on subsequent PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation configuration to enhance code review processes and code quality checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/39)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->