### PR TITLE
chore(release): prepare v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-14
+
+Small follow-up release adding **`run_query`**, the missing peer to
+`run_look`: it wraps `GET /queries/{query_id}/run/{result_format}` so
+callers can re-run an existing saved `Query` by ID without re-specifying
+its body. The previously-available `query` tool always re-specifies the
+query from `model/view/fields/filters/sorts`, which silently drops
+anything not in that body — `dynamic_fields`, table calcs, vis config,
+and other settings baked into the saved `Query` object. The motivating
+use case is **tile-fidelity validation**: a dashboard tile's
+`query.id` points to a saved `Query` that may carry tile-local table
+calcs in its `dynamic_fields`, and faithfully reproducing the tile's
+data requires running *that* `Query`, not re-specifying a new one.
+`run_query` also exposes the Looker run-time knobs that matter for
+that workflow — `apply_formatting` (render values per LookML/Look
+formatting), `apply_vis` (apply vis-config rendering),
+`server_table_calcs` (compute table calcs server-side), `cache`, and
+a `limit` override. `run_dashboard`'s per-element call now routes
+through the same shared helper that backs `run_query`, so the two
+paths can't drift on path shape, query-string serialization, or the
+JSON-vs-`text/plain` response routing.
+
+### Added
+
+- **`run_query(query_id, ...)` tool** in the `query` group. Wraps
+  `GET /api/4.0/queries/{query_id}/run/{result_format}`. Accepts
+  `result_format` (`json`/`json_detail`/`csv`/`txt`), `limit`,
+  `apply_formatting`, `apply_vis`, `server_table_calcs`, `cache`,
+  plus the standard `dev_mode` + `branch` + `project_id` +
+  `act_as_user` parameter set for parity with `run_look`. `csv` and
+  `txt` formats route through `session.get_text` (the same
+  `text/plain` trap that motivated v0.16.0's `query_sql` fix) and
+  are wrapped in a `{"format": ..., "data": ...}` JSON envelope so
+  the MCP response shape stays JSON.
+- **Shared `_execute_saved_query` helper** at module level in
+  `tools/query.py`. Both `run_query` and `run_dashboard`'s per-tile
+  loop call it, so the saved-query execution path (URL shape, param
+  serialization, response routing) has a single source of truth.
+  Booleans are serialized as lowercase `true`/`false` — httpx's
+  default `str(True)` → `"True"` is not what Looker's query-string
+  parser accepts; pinned by tests.
+
+### Changed
+
+- `run_dashboard` no longer inlines its per-element
+  `session.get(f"/queries/{id}/run/json")` call; it now routes
+  through `_execute_saved_query` for consistency with `run_query`.
+  Behavior is unchanged — same endpoint, same response shape — but
+  the wire-level contract is now regression-guarded by a test.
+
 ## [0.16.0] - 2026-05-10
 
 This release closes the **dev-mode gap** across every workspace-scoped
@@ -709,6 +759,7 @@ infrastructure / deployment-posture release, not a tool surface expansion.
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[0.17.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.13.0...v0.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.16.0"
+version = "0.17.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.16.0"
+version = "0.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Release-prep PR for v0.17.0. Adds the `[0.17.0]` CHANGELOG entry covering #38 and bumps `pyproject.toml` version 0.16.0 → 0.17.0 so the next `v0.17.0` tag push triggers the PyPI release workflow with the right metadata.

## What's in v0.17.0

A small follow-up release adding **`run_query`** — the missing peer to `run_look`. Wraps `GET /api/4.0/queries/{query_id}/run/{result_format}` so callers can re-run an existing saved `Query` by ID without re-specifying its body. The previously-available `query` tool always re-specifies from `model/view/fields/filters/sorts`, which silently drops anything not in that body (`dynamic_fields`, table calcs, vis config, other settings baked into the saved `Query`).

Motivating use case: **tile-fidelity validation**. A dashboard tile's `query.id` points to a saved `Query` that may carry tile-local table calcs in `dynamic_fields`. Faithfully reproducing the tile's data requires running *that* `Query`, not re-specifying a new one.

`run_query` exposes the Looker run-time knobs that matter for that workflow: `apply_formatting`, `apply_vis`, `server_table_calcs`, `cache`, and a `limit` override — alongside the standard `dev_mode` / `branch` / `project_id` / `act_as_user` set for parity with `run_look`. `run_dashboard`'s per-element call now routes through the same shared helper (`_execute_saved_query`) so the two paths can't drift on path shape, query-string serialization, or `text/plain` response routing.

See the `[0.17.0]` section of `CHANGELOG.md` in this PR for the full entry. The originating issue (#37) and feature PR (#38) have more context.

## Files changed

| File | Change |
|---|---|
| `CHANGELOG.md` | Add `[0.17.0] - 2026-05-14` section + compare-link entry |
| `pyproject.toml` | `version = "0.16.0"` → `"0.17.0"` |
| `uv.lock` | Project's own self-entry: `version = "0.16.0"` → `"0.17.0"` (single-line diff; no transitive dependency changes) |

## Release-tagging instructions (post-merge)

After this PR squash-merges to `main`, push the tag from main to trigger the PyPI publish:

```bash
git fetch origin
git checkout main && git pull
git tag -s v0.17.0 -m "v0.17.0"
git push origin v0.17.0
```

The `release.yml` workflow will run tests across Python 3.11/3.12/3.13, build, and publish to PyPI (`looker-mcp-server`).

## CI parity verified locally

- `uv run ruff format --check .` ✅ 51 files clean
- `uv run ruff check .` ✅ All checks passed
- `uv run pyright` ✅ 0 errors, 0 warnings, 0 informations
- `uv run pytest tests/` ✅ 370 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tool to re-run saved queries by ID, eliminating the need to re-specify request details.

* **Improvements**
  * Refactored dashboard execution to use unified query processing.
  * Enhanced CSV and TXT response handling.
  * Standardized response formatting for consistency.

* **Chores**
  * Version bumped to 0.17.0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/40)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->