### PR TITLE
ci: bump action pins to Node.js 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
 
@@ -34,10 +34,10 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
 
@@ -58,10 +58,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -39,10 +39,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e  # v6.8.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
 
       - name: Build
         run: uv build


### PR DESCRIPTION
Closes #41.

## Why

GitHub Actions surfaces a deprecation annotation on every job in both `ci.yml` and `release.yml`:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: `actions/checkout`, `astral-sh/setup-uv`. Actions will be forced to run with Node.js 24 by default starting **2026-06-02**. Node.js 20 will be removed from the runner on **2026-09-16**.

Source: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Both pins ship Node.js 20 today, so this needs to land well before the June flip — otherwise the next release workflow run will start failing once Node.js 20 is removed.

## What

Bumps both pinned actions to the latest stable releases that ship Node.js 24. SHA pinning convention preserved (per the policy established in #27).

| Action | From (Node.js 20) | To (Node.js 24) |
|---|---|---|
| `actions/checkout` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1) | `@de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) |
| `astral-sh/setup-uv` | `@d0cc045d04ccac9d8b7881df0226f9e82c39688e` (v6.8.0) | `@08807647e7069bb48b6ef5acd8ec9567f424441b` (v8.1.0) |

Both target versions verified to declare `runs.using: node24` in their `action.yml`.

## Scope

10 lines touched across two files:

- `.github/workflows/ci.yml`: 3 checkout sites + 3 setup-uv sites
- `.github/workflows/release.yml`: 2 checkout sites + 2 setup-uv sites

**No workflow semantic changes.** Every step, job, matrix, permission block, and `with:` config is unchanged. Only the action references and their version comments were touched.

## Validation

Local CI parity ✅ (action SHA changes don't affect the Python suite, but ran the full sweep for hygiene):

- `uv run ruff format --check .` ✅ 51 files clean
- `uv run ruff check .` ✅ All checks passed
- `uv run pyright` ✅ 0 errors, 0 warnings, 0 informations
- `uv run pytest tests/` ✅ 370 passed

The actual Node.js 24-runtime validation happens when this PR's CI jobs run on GitHub Actions — the new pins exercise the same `runs.using: node24` setup that will become mandatory on 2026-06-02. If anything regresses (e.g. setup-uv v8.x changed an env var or input shape we depend on), it'll surface in the PR's own CI run, not after merge.

## Compatibility notes

- `actions/checkout` v4 → v6 is a *runtime* bump (Node.js 20 → 24); the action's inputs and outputs are unchanged for the ways we use it (default `with:` config, no submodule/LFS flags). v5 was the first to ship Node.js 24; v6 is the current major and brings additional GHES-compatibility fixes.
- `astral-sh/setup-uv` v6 → v8 includes the Node.js 20 → 24 transition (in v7) plus a v8 input-handling cleanup. We use `enable-cache: true` and `python-version: <matrix>` — both inputs are preserved across the v6 → v8 transition per the upstream changelog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to latest versions for improved build and test pipeline reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/42)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->