### PR TITLE
chore(coderabbit): match GitHub-App bot logins in ignore_usernames

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,9 +27,15 @@ reviews:
       - "DRAFT"
       - "DO NOT MERGE"
     ignore_usernames:
+      # Include both bare names (for OAuth-based bots) and GitHub-App
+      # logins (suffixed with "[bot]"); CodeRabbit's ignore_usernames
+      # uses exact-match.
       - "dependabot"
+      - "dependabot[bot]"
       - "renovate"
+      - "renovate[bot]"
       - "coderabbitai"
+      - "coderabbitai[bot]"
 
   path_filters:
     - "!**/*.lock"


### PR DESCRIPTION
## Summary

Adds `[bot]`-suffixed variants to `reviews.auto_review.ignore_usernames` so the list actually skips PRs opened by GitHub App bots (Dependabot, Renovate, CodeRabbit).

## Why

CodeRabbit's `ignore_usernames` uses exact-match against the PR author's GitHub login. GitHub Apps present as logins suffixed with `[bot]` — empirically verifiable:

```bash
$ gh api repos/<any-org>/<any-repo>/pulls/<pr-with-cr-review>/reviews \
    --jq '.[].user | {login, type}'
{"login": "coderabbitai[bot]", "type": "Bot"}
```

So entries like `"dependabot"` did not match `"dependabot[bot]"`, and bot PRs were being auto-reviewed instead of skipped.

## What changes

```diff
     ignore_usernames:
+      # Include both bare names (for OAuth-based bots) and GitHub-App
+      # logins (suffixed with "[bot]"); CodeRabbit's ignore_usernames
+      # uses exact-match.
       - "dependabot"
+      - "dependabot[bot]"
       - "renovate"
+      - "renovate[bot]"
       - "coderabbitai"
+      - "coderabbitai[bot]"
```

Both forms are kept: bare names continue to cover OAuth-flavored vendor bots that don't carry the suffix; the suffixed forms cover the official GitHub Apps.

## Test plan

- [ ] Next Dependabot/Renovate PR on this repo is *not* auto-reviewed by CodeRabbit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to recognize additional bot account login variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/43)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->