### PR TITLE
feat(render): RenderTask tool group for query/look/dashboard/tile (v0.18.0)

### DIFF
--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -117,6 +117,41 @@ class LookerSession:
         """POST to an endpoint that returns ``text/plain`` (deploy-key rotation)."""
         return await self._request_text("POST", path, params=params)
 
+    async def get_bytes(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        *,
+        max_bytes: int | None = None,
+    ) -> tuple[bytes, str, int, bool]:
+        """GET an endpoint that returns binary content (image/png|jpeg, application/pdf).
+
+        Returns ``(body_bytes, content_type, total_bytes, truncated)``:
+
+        * ``body_bytes`` — accumulated content. Empty when the response
+          is short-circuited by Content-Length, or contains the prefix
+          read before the cap fired on a chunk boundary.
+        * ``total_bytes`` — bytes seen on the wire (or Content-Length
+          when the fast path triggered). Always set, even when truncated.
+        * ``truncated`` — True when ``max_bytes`` was provided and the
+          response exceeded it. Body is not safe to use in this case;
+          callers must surface the size signal to the user.
+
+        When ``max_bytes`` is set:
+
+        * If the server returns a ``Content-Length`` header larger than
+          ``max_bytes``, no body is downloaded — the helper returns
+          immediately with ``body=b""`` and ``truncated=True``.
+        * Otherwise the response is streamed; appending stops as soon
+          as the running total exceeds the cap.
+
+        Looker's render-task results endpoint (``/render_tasks/{id}/results``)
+        is the canonical caller. Reuses :meth:`_raise_for_status` for
+        4xx/5xx so the structured error body still reaches callers as a
+        ``LookerApiError``.
+        """
+        return await self._request_bytes("GET", path, params=params, max_bytes=max_bytes)
+
     async def update_workspace(self, workspace_id: str) -> None:
         """Set the active workspace on this API session.
 
@@ -267,6 +302,63 @@ class LookerSession:
         )
         self._raise_for_status(response)
         return response.text
+
+    async def _request_bytes(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+        *,
+        max_bytes: int | None = None,
+    ) -> tuple[bytes, str, int, bool]:
+        # Stream the response so a render result larger than ``max_bytes``
+        # never fully materializes in memory. Error responses still go
+        # through ``_raise_for_status`` (after one explicit ``aread``) so
+        # the structured-body contract used by the JSON and text paths
+        # carries over to binary callers.
+        async with self._http.stream(
+            method,
+            path,
+            headers=self._headers,
+            params=params,
+        ) as response:
+            if response.status_code >= 400:
+                await response.aread()
+                self._raise_for_status(response)  # always raises
+
+            # Strip parameters (charset, boundary) so callers can match
+            # on the bare MIME type without case-sensitivity surprises.
+            content_type = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+
+            # Trust ``Content-Length`` when the server provides it: if
+            # the advertised size already exceeds the cap, skip the
+            # download entirely. Looker's render-task results endpoint
+            # always sets Content-Length, so this is the common path
+            # for oversized renders.
+            if max_bytes is not None:
+                cl_header = response.headers.get("content-length")
+                if cl_header is not None:
+                    try:
+                        cl = int(cl_header)
+                    except ValueError:
+                        cl = -1
+                    if cl > max_bytes:
+                        return b"", content_type, cl, True
+
+            # No fast path: stream and accumulate, stopping as soon as
+            # the running total passes the cap. We track ``total``
+            # independently of ``len(body)`` so the truncated case can
+            # still surface a size signal (lower bound = cap + 1).
+            body = bytearray()
+            total = 0
+            truncated = False
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if max_bytes is not None and total > max_bytes:
+                    truncated = True
+                    break
+                body.extend(chunk)
+            return bytes(body), content_type, total, truncated
 
 
 class LookerClient:

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -71,6 +71,7 @@ ALL_GROUPS = frozenset(
     {
         "explore",
         "query",
+        "render",
         "schema",
         "content",
         "board",

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -164,6 +164,7 @@ def create_server(
     from .tools.identity import register_identity_tools
     from .tools.modeling import register_modeling_tools
     from .tools.query import register_query_tools
+    from .tools.render import register_render_tools
     from .tools.schema import register_schema_tools
     from .tools.user_attributes import register_user_attribute_tools
     from .tools.workflows import register_workflow_tools
@@ -171,6 +172,7 @@ def create_server(
     _group_registry: dict[str, Any] = {
         "explore": register_explore_tools,
         "query": register_query_tools,
+        "render": register_render_tools,
         "schema": register_schema_tools,
         "content": register_content_tools,
         "board": register_board_tools,

--- a/src/looker_mcp_server/tools/render.py
+++ b/src/looker_mcp_server/tools/render.py
@@ -1,0 +1,623 @@
+"""Render tool group — async PNG/JPG/PDF rendering of Looker content.
+
+Wraps Looker's ``/render_tasks/*`` API surface as four MCP tools:
+
+* ``render_query``           — ad-hoc explore (model+view+fields → PNG/JPG)
+* ``render_look``            — saved Look (PNG/JPG)
+* ``render_dashboard``       — full dashboard (PDF/PNG/JPG, with paper-size,
+                               orientation, theme, dashboard_filters)
+* ``render_dashboard_tile``  — individual dashboard element (PNG/JPG)
+
+All four share the same three-step Looker pattern: POST a create-task
+endpoint, poll ``GET /render_tasks/{id}`` until the task reaches
+``success`` or ``failure``, then fetch the rendered bytes from
+``GET /render_tasks/{id}/results``. The shared
+``_create_and_wait_for_render_task`` helper owns that loop so the four
+tools cannot drift on backoff, terminal-state handling, or failure
+detail propagation.
+
+Binary results are returned via FastMCP's typed helpers:
+
+* PNG/JPG → ``Image`` → MCP ``ImageContent`` (LLM-visible)
+* PDF     → ``File``  → MCP ``EmbeddedResource`` with ``BlobResourceContents``
+
+Timeout, dimension-cap, and size-cap conditions return JSON strings so
+the caller can recover (e.g. re-fetch results with the surfaced
+``render_task_id``) without losing the in-flight render.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Annotated, Any, Literal
+from urllib.parse import urlencode
+
+from fastmcp import FastMCP
+from fastmcp.utilities.types import File, Image
+
+from ..client import LookerApiError, LookerClient, LookerSession, format_api_error
+from ._helpers import (
+    ActAsUser,
+    _maybe_use_branch,
+    _path_seg,
+    _set_if,
+    _validate_branch_args,
+)
+
+# ─── Constants ─────────────────────────────────────────────────────────
+
+# Hard pixel-product cap. Looker accepts very large render requests but
+# starves its own queue under them; rejecting client-side keeps a single
+# bad call from blocking unrelated renders on the same instance.
+_MAX_PIXELS = 4000 * 4000
+
+# Cap returned binary at 10 MB so a giant PDF doesn't blow up the MCP
+# transport. Past this, return the ``render_task_id`` and let the caller
+# fetch the bytes through the Looker UI / direct API.
+_MAX_BYTES = 10 * 1024 * 1024
+
+# Looker's RenderTask.status state machine. Terminal states end polling.
+_TERMINAL_STATUSES = frozenset({"success", "failure"})
+
+# Polling backoff schedule (seconds). Fast renders feel instant; long
+# PDFs don't burn tokens on a tight loop. Capped at the last value.
+_POLL_DELAYS_SECONDS = (0.5, 1.0, 2.0)
+
+
+# ─── Shared dataclasses ────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _RenderResult:
+    """Outcome of a render-task create/poll/fetch cycle.
+
+    Three terminal shapes the tool layer turns into MCP responses:
+
+    * **Success**  ``body`` carries the bytes; ``truncated`` is False.
+    * **Timeout**  ``body`` is None and ``truncated`` is False — the
+      polling deadline expired before the task reached a terminal
+      status. ``meta["render_task_id"]`` lets callers recover.
+    * **Truncated**  ``truncated`` is True — the response exceeded the
+      streaming cap. ``body`` is unsafe to return (empty when the
+      Content-Length fast path fired, or a prefix when the cap fired
+      mid-chunk); ``size_bytes`` carries the size signal (exact when
+      Content-Length was honoured, a lower bound when the cap fired
+      mid-stream).
+    """
+
+    body: bytes | None
+    content_type: str | None
+    size_bytes: int | None
+    truncated: bool
+    meta: dict[str, Any]
+
+
+# ─── Validation helpers ────────────────────────────────────────────────
+
+
+def _validate_dimensions(width: int, height: int) -> None:
+    """Reject obviously-bad render dimensions before hitting Looker.
+
+    Looker validates each dimension server-side but the more interesting
+    failure mode is the product — a 10_000 × 10_000 PNG is technically
+    "valid" but starves the render queue. Capping the product keeps a
+    single oversized request from blocking unrelated renders on the
+    same instance.
+    """
+    if width <= 0 or height <= 0:
+        raise ValueError(f"width and height must be positive; got width={width}, height={height}.")
+    if width * height > _MAX_PIXELS:
+        raise ValueError(
+            f"width * height ({width * height}) exceeds the {_MAX_PIXELS} pixel "
+            f"cap. Looker accepts larger requests but they starve the render "
+            f"queue. Try a smaller size, then upscale client-side if needed."
+        )
+
+
+def _encode_dashboard_filters(filters: dict[str, str] | None) -> str | None:
+    """Encode a ``{field: value}`` filter map as Looker's URL-query string.
+
+    Looker's ``POST /render_tasks/dashboards/{id}/{format}`` takes
+    ``dashboard_filters`` as a single URL-encoded string in the
+    ``?Foo=bar&Baz=qux`` shape Looker URLs use natively. Accepting a
+    typed dict at the tool boundary keeps the surface symmetric with
+    the existing ``query`` tool's ``filters: dict[str, str]`` — at the
+    cost of one urlencode here.
+    """
+    if not filters:
+        return None
+    return urlencode(filters, doseq=False)
+
+
+# ─── Render-task lifecycle helper ──────────────────────────────────────
+
+
+async def _create_and_wait_for_render_task(
+    session: LookerSession,
+    *,
+    create_path: str,
+    create_params: dict[str, Any],
+    max_wait_seconds: float,
+) -> _RenderResult:
+    """POST create, poll status, GET binary results.
+
+    The three Looker calls in lock-step:
+
+    1. ``POST {create_path}?width=…&height=…&…`` → returns
+       ``{"id": render_task_id, …}``
+    2. ``GET /render_tasks/{id}`` repeatedly until
+       ``status in {"success", "failure"}`` or the wall-clock deadline
+       passes. Backoff is ``_POLL_DELAYS_SECONDS`` capped at the last
+       value.
+    3. On ``success``: ``GET /render_tasks/{id}/results`` for the bytes.
+       Returns ``_RenderResult(body, content_type, meta)``.
+
+    Behaviours that diverge from raw Looker:
+
+    * ``failure`` status raises :class:`LookerApiError` with the
+      ``status_detail`` body Looker returned, so tool error paths look
+      identical to a 4xx/5xx HTTP error.
+    * Deadline-hit returns ``_RenderResult(body=None, content_type=None,
+      meta={...render_task_id, last_status...})`` so the tool can return
+      a JSON escape hatch rather than swallow an in-flight render.
+    """
+    create_response = await session.post(create_path, params=create_params)
+    if not isinstance(create_response, dict) or "id" not in create_response:
+        raise LookerApiError(
+            500,
+            "Looker render-task create returned no id",
+            f"POST {create_path} returned: {create_response!r}",
+        )
+    render_task_id = str(create_response["id"])
+
+    poll_path = f"/render_tasks/{_path_seg(render_task_id)}"
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max_wait_seconds
+    last_status: str | None = None
+    last_payload: dict[str, Any] | None = None
+    attempt = 0
+    while True:
+        payload = await session.get(poll_path)
+        # Fail fast on contract violations: Looker's render-task API
+        # always returns a dict with a non-empty string ``status``
+        # field. Anything else (a non-dict body, a missing status, a
+        # numeric status) indicates a proxy/middleware injection or an
+        # API change we should surface immediately rather than burn
+        # poll cycles waiting for a terminal state we can never reach.
+        if not isinstance(payload, dict):
+            raise LookerApiError(
+                500,
+                "Looker render-task poll returned a non-dict payload",
+                f"GET {poll_path} returned: {payload!r}",
+            )
+        status = payload.get("status")
+        if not isinstance(status, str) or not status:
+            raise LookerApiError(
+                500,
+                "Looker render-task poll missing string status field",
+                f"GET {poll_path} returned: {payload!r}",
+            )
+        last_payload = payload
+        last_status = status
+        if last_status in _TERMINAL_STATUSES:
+            break
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        delay = _POLL_DELAYS_SECONDS[min(attempt, len(_POLL_DELAYS_SECONDS) - 1)]
+        await asyncio.sleep(min(delay, remaining))
+        attempt += 1
+
+    meta: dict[str, Any] = {
+        "render_task_id": render_task_id,
+        "last_status": last_status,
+    }
+    if last_payload is not None:
+        for k in ("query_runtime", "render_runtime", "runtime", "status_detail"):
+            if last_payload.get(k) is not None:
+                meta[k] = last_payload[k]
+
+    if last_status == "failure":
+        raise LookerApiError(
+            500,
+            "Looker render task failed",
+            (last_payload or {}).get("status_detail") or "no status_detail provided",
+            body=last_payload,
+        )
+
+    if last_status != "success":
+        # Deadline hit before Looker reached a terminal state. Return
+        # the task id so the caller can poll later via Looker directly.
+        return _RenderResult(
+            body=None,
+            content_type=None,
+            size_bytes=None,
+            truncated=False,
+            meta=meta,
+        )
+
+    # Pass the transport cap to ``get_bytes`` so oversized renders are
+    # short-circuited (via Content-Length) or streamed-and-truncated
+    # rather than fully materialized in memory before we'd reject them.
+    result_path = f"/render_tasks/{_path_seg(render_task_id)}/results"
+    body, content_type, total, truncated = await session.get_bytes(
+        result_path, max_bytes=_MAX_BYTES
+    )
+    return _RenderResult(
+        body=None if truncated else body,
+        content_type=content_type,
+        size_bytes=total,
+        truncated=truncated,
+        meta=meta,
+    )
+
+
+def _build_result(
+    result: _RenderResult,
+    *,
+    result_format: str,
+    subject_name: str,
+    subject_id: str,
+) -> Image | File | str:
+    """Convert a ``_RenderResult`` into the tool's MCP-friendly return.
+
+    * Truncated (``result.truncated``) → JSON escape hatch with size + id
+    * Timeout (``body is None``) → JSON escape hatch with ``render_task_id``
+    * ``png``/``jpg`` → ``Image`` (FastMCP serializes to ``ImageContent``)
+    * ``pdf`` → ``File`` (FastMCP serializes to ``EmbeddedResource``)
+
+    ``subject_name`` / ``subject_id`` are only used to name the embedded
+    PDF file resource — they have no effect on the rendered bytes.
+    """
+    if result.truncated:
+        # ``size_bytes`` is exact when Content-Length was honoured and a
+        # lower bound (``> _MAX_BYTES``) when the cap fired mid-stream.
+        return json.dumps(
+            {
+                "status": "too_large",
+                "size_bytes": result.size_bytes,
+                "format": result_format,
+                "note": (
+                    f"Render exceeded the {_MAX_BYTES}-byte MCP transport cap. "
+                    "Fetch directly from Looker's UI or via "
+                    f"GET /render_tasks/{result.meta['render_task_id']}/results."
+                ),
+                **result.meta,
+            },
+            indent=2,
+        )
+
+    if result.body is None:
+        return json.dumps(
+            {
+                "status": "timeout",
+                "note": (
+                    "Render exceeded max_wait_seconds. The task is still running "
+                    "on Looker; fetch the bytes via Looker's UI or the API "
+                    f"endpoint GET /render_tasks/{result.meta['render_task_id']}/results."
+                ),
+                **result.meta,
+            },
+            indent=2,
+        )
+
+    if result_format == "pdf":
+        return File(
+            data=result.body,
+            format="pdf",
+            name=f"{subject_name}-{subject_id}.pdf",
+        )
+    # png / jpg
+    return Image(data=result.body, format=result_format)
+
+
+# ─── Tool registration ─────────────────────────────────────────────────
+
+
+def register_render_tools(server: FastMCP, client: LookerClient) -> None:
+    @server.tool(
+        description=(
+            "Render an ad-hoc Looker query as an image. Specify the same "
+            "model/view/fields/filters/sorts surface as the ``query`` tool, "
+            "plus width/height and ``png``/``jpg`` format. Looker creates the "
+            "Query, renders it asynchronously, and returns the bytes. "
+            "Use ``render_look`` for saved Looks or ``render_dashboard`` for "
+            "dashboards (the only render subject that supports PDF)."
+        ),
+    )
+    async def render_query(
+        model: Annotated[str, "LookML model name"],
+        view: Annotated[str, "Explore/view name within the model"],
+        fields: Annotated[list[str], "Fully-qualified field names to select"],
+        width: Annotated[int, "Output width in pixels"],
+        height: Annotated[int, "Output height in pixels"],
+        result_format: Annotated[Literal["png", "jpg"], "Image format"] = "png",
+        filters: Annotated[
+            dict[str, str] | None,
+            "Filter expressions as field:value pairs",
+        ] = None,
+        sorts: Annotated[list[str] | None, "Sort expressions"] = None,
+        limit: Annotated[int, "Row limit"] = 500,
+        max_wait_seconds: Annotated[
+            float,
+            "Polling deadline in seconds. On timeout the tool returns a "
+            "JSON escape hatch with the ``render_task_id`` so the render "
+            "is recoverable without restarting.",
+        ] = 120.0,
+        dev_mode: Annotated[
+            bool,
+            "Resolve the query against the dev workspace's LookML rather than "
+            "production. Implied when ``branch`` is set.",
+        ] = False,
+        branch: Annotated[
+            str | None,
+            "Project branch to atomically swap to for this call (saved branch "
+            "restored on exit). Requires project_id.",
+        ] = None,
+        project_id: Annotated[
+            str | None,
+            "LookML project ID — required when ``branch`` is set.",
+        ] = None,
+        act_as_user: ActAsUser = None,
+    ) -> Image | File | str:
+        ctx = client.build_context(
+            "render_query",
+            "render",
+            {
+                "model": model,
+                "view": view,
+                "result_format": result_format,
+                "width": width,
+                "height": height,
+                "branch": branch,
+                "project_id": project_id,
+                "act_as_user": act_as_user,
+            },
+        )
+        try:
+            _validate_dimensions(width, height)
+            _validate_branch_args(branch, project_id)
+            effective_dev_mode = dev_mode or branch is not None
+            async with client.session(ctx, dev_mode=effective_dev_mode) as session:
+                async with _maybe_use_branch(session, project_id, branch):
+                    query_body: dict[str, Any] = {
+                        "model": model,
+                        "view": view,
+                        "fields": fields,
+                        "limit": str(limit),
+                    }
+                    if filters:
+                        query_body["filters"] = filters
+                    if sorts:
+                        query_body["sorts"] = sorts
+                    query_def = await session.post("/queries", body=query_body)
+                    # Mirror the shape check in
+                    # ``_create_and_wait_for_render_task``: surface a
+                    # ``LookerApiError`` carrying the full payload
+                    # instead of an opaque ``KeyError`` / ``TypeError``
+                    # when Looker returns a non-dict or omits ``id``,
+                    # and coerce to ``str`` so downstream path-building
+                    # never trips on a numeric id.
+                    if not isinstance(query_def, dict) or "id" not in query_def:
+                        raise LookerApiError(
+                            500,
+                            "Looker /queries create returned no id",
+                            f"POST /queries returned: {query_def!r}",
+                        )
+                    query_id = str(query_def["id"])
+
+                    result = await _create_and_wait_for_render_task(
+                        session,
+                        create_path=(
+                            f"/render_tasks/queries/{_path_seg(query_id)}/{result_format}"
+                        ),
+                        create_params={"width": width, "height": height},
+                        max_wait_seconds=max_wait_seconds,
+                    )
+                    return _build_result(
+                        result,
+                        result_format=result_format,
+                        subject_name="query",
+                        subject_id=str(query_id),
+                    )
+        except Exception as e:
+            return format_api_error("render_query", e)
+
+    @server.tool(
+        description=(
+            "Render a saved Look as an image. Returns PNG or JPG bytes. "
+            "For PDF, use ``render_dashboard``."
+        ),
+    )
+    async def render_look(
+        look_id: Annotated[str, "ID of the saved Look"],
+        width: Annotated[int, "Output width in pixels"],
+        height: Annotated[int, "Output height in pixels"],
+        result_format: Annotated[Literal["png", "jpg"], "Image format"] = "png",
+        max_wait_seconds: Annotated[
+            float,
+            "Polling deadline in seconds. On timeout the tool returns a "
+            "JSON escape hatch with the ``render_task_id``.",
+        ] = 120.0,
+        act_as_user: ActAsUser = None,
+    ) -> Image | File | str:
+        ctx = client.build_context(
+            "render_look",
+            "render",
+            {
+                "look_id": look_id,
+                "result_format": result_format,
+                "width": width,
+                "height": height,
+                "act_as_user": act_as_user,
+            },
+        )
+        try:
+            _validate_dimensions(width, height)
+            async with client.session(ctx) as session:
+                result = await _create_and_wait_for_render_task(
+                    session,
+                    create_path=(f"/render_tasks/looks/{_path_seg(look_id)}/{result_format}"),
+                    create_params={"width": width, "height": height},
+                    max_wait_seconds=max_wait_seconds,
+                )
+                return _build_result(
+                    result,
+                    result_format=result_format,
+                    subject_name="look",
+                    subject_id=look_id,
+                )
+        except Exception as e:
+            return format_api_error("render_look", e)
+
+    @server.tool(
+        description=(
+            "Render a Looker dashboard as PDF, PNG, or JPG. Dashboards are the "
+            "only render subject that supports PDF output. Accepts paper size, "
+            "orientation, ``long_tables``, ``theme``, and a "
+            "``dashboard_filters`` map. ``dashboard_id`` accepts both UDD "
+            "numeric IDs and LookML dashboard IDs (``model::dashboard``)."
+        ),
+    )
+    async def render_dashboard(
+        dashboard_id: Annotated[
+            str,
+            "Dashboard ID. UDD numeric (e.g. '42') or LookML 'model::dashboard'",
+        ],
+        width: Annotated[int, "Output width in pixels"],
+        height: Annotated[int, "Output height in pixels"],
+        result_format: Annotated[Literal["pdf", "png", "jpg"], "Output format"] = "pdf",
+        pdf_paper_size: Annotated[
+            Literal["letter", "legal", "tabloid", "a0", "a1", "a2", "a3", "a4", "a5"] | None,
+            "Paper size for PDF output. Ignored for png/jpg.",
+        ] = None,
+        pdf_landscape: Annotated[
+            bool | None,
+            "Render PDF in landscape orientation. Ignored for png/jpg.",
+        ] = None,
+        long_tables: Annotated[
+            bool | None,
+            "Expand table visualizations to their full row count. PDF only.",
+        ] = None,
+        theme: Annotated[
+            str | None,
+            "Looker theme name to apply. Renders the embedded version of the dashboard when set.",
+        ] = None,
+        dashboard_filters: Annotated[
+            dict[str, str] | None,
+            "Filter values as field:value pairs (URL-encoded internally into "
+            "Looker's ?Foo=bar&Baz=qux dashboard-filter format).",
+        ] = None,
+        max_wait_seconds: Annotated[
+            float,
+            "Polling deadline in seconds. Dashboard PDFs commonly take "
+            "30-90s; bump this for large dashboards. On timeout the tool "
+            "returns a JSON escape hatch with the ``render_task_id``.",
+        ] = 180.0,
+        act_as_user: ActAsUser = None,
+    ) -> Image | File | str:
+        ctx = client.build_context(
+            "render_dashboard",
+            "render",
+            {
+                "dashboard_id": dashboard_id,
+                "result_format": result_format,
+                "width": width,
+                "height": height,
+                "act_as_user": act_as_user,
+            },
+        )
+        try:
+            _validate_dimensions(width, height)
+            params: dict[str, Any] = {"width": width, "height": height}
+            # PDF-only knobs are gated on the format so an image render
+            # never carries page-orientation/paper-size hints Looker has
+            # no use for. ``theme`` and ``dashboard_filters`` apply to
+            # all formats, so they stay outside the gate.
+            if result_format == "pdf":
+                _set_if(params, "pdf_paper_size", pdf_paper_size)
+                # Looker's query-string parser accepts lowercase
+                # 'true'/'false' but not Python's str(True) = 'True'.
+                # Convert explicitly.
+                if pdf_landscape is not None:
+                    params["pdf_landscape"] = "true" if pdf_landscape else "false"
+                if long_tables is not None:
+                    params["long_tables"] = "true" if long_tables else "false"
+            _set_if(params, "theme", theme)
+            _set_if(params, "dashboard_filters", _encode_dashboard_filters(dashboard_filters))
+
+            async with client.session(ctx) as session:
+                result = await _create_and_wait_for_render_task(
+                    session,
+                    create_path=(
+                        f"/render_tasks/dashboards/{_path_seg(dashboard_id)}/{result_format}"
+                    ),
+                    create_params=params,
+                    max_wait_seconds=max_wait_seconds,
+                )
+                return _build_result(
+                    result,
+                    result_format=result_format,
+                    subject_name="dashboard",
+                    subject_id=dashboard_id,
+                )
+        except Exception as e:
+            return format_api_error("render_dashboard", e)
+
+    @server.tool(
+        description=(
+            "Render a single dashboard tile (one element) as PNG or JPG. Useful "
+            "when you want one chart, not the whole dashboard. "
+            "``dashboard_element_id`` is the element's ID — numeric for UDD "
+            "dashboards, ``model::dashboard::tile`` for LookML dashboards. "
+            "PDF is not supported by the underlying Looker endpoint."
+        ),
+    )
+    async def render_dashboard_tile(
+        dashboard_element_id: Annotated[
+            str,
+            "Dashboard element ID. UDD numeric or LookML 'model::dashboard::tile'.",
+        ],
+        width: Annotated[int, "Output width in pixels"],
+        height: Annotated[int, "Output height in pixels"],
+        result_format: Annotated[Literal["png", "jpg"], "Image format"] = "png",
+        max_wait_seconds: Annotated[
+            float,
+            "Polling deadline in seconds. On timeout the tool returns a "
+            "JSON escape hatch with the ``render_task_id``.",
+        ] = 120.0,
+        act_as_user: ActAsUser = None,
+    ) -> Image | File | str:
+        ctx = client.build_context(
+            "render_dashboard_tile",
+            "render",
+            {
+                "dashboard_element_id": dashboard_element_id,
+                "result_format": result_format,
+                "width": width,
+                "height": height,
+                "act_as_user": act_as_user,
+            },
+        )
+        try:
+            _validate_dimensions(width, height)
+            async with client.session(ctx) as session:
+                result = await _create_and_wait_for_render_task(
+                    session,
+                    create_path=(
+                        f"/render_tasks/dashboard_elements/"
+                        f"{_path_seg(dashboard_element_id)}/{result_format}"
+                    ),
+                    create_params={"width": width, "height": height},
+                    max_wait_seconds=max_wait_seconds,
+                )
+                return _build_result(
+                    result,
+                    result_format=result_format,
+                    subject_name="tile",
+                    subject_id=dashboard_element_id,
+                )
+        except Exception as e:
+            return format_api_error("render_dashboard_tile", e)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -89,6 +89,7 @@ class TestGroupConstants:
         expected = {
             "explore",
             "query",
+            "render",
             "schema",
             "content",
             "board",

--- a/tests/test_render_tools.py
+++ b/tests/test_render_tools.py
@@ -1,0 +1,554 @@
+"""Tests for the render tool group — RenderTask wrapping for Looker.
+
+Covers all four tools (``render_query``, ``render_look``,
+``render_dashboard``, ``render_dashboard_tile``) and all three return
+shapes (Image, File, timeout-/cap-escape-hatch JSON).
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastmcp import Client
+from mcp.types import EmbeddedResource, ImageContent, TextContent
+
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+# Minimal 1×1 PNG (valid header — enough for content-type sniffing /
+# round-trip assertions; tests never decode the pixels).
+PNG_BYTES = bytes.fromhex(
+    "89504E470D0A1A0A0000000D49484452000000010000000108060000001F15C4"
+    "890000000A49444154789C6300010000000500010D0A2DB40000000049454E44AE426082"
+)
+PDF_BYTES = b"%PDF-1.4\n%test-fixture\n%%EOF"
+
+
+def _mock_login_logout() -> None:
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+def _mock_render_task_success(
+    *,
+    create_path: str,
+    task_id: str,
+    result_bytes: bytes,
+    result_content_type: str,
+    create_response_extra: dict[str, Any] | None = None,
+) -> tuple[respx.Route, respx.Route, respx.Route]:
+    """Wire the three-call lifecycle to a single happy-path render."""
+    body = {"id": task_id, "status": "enqueued_for_query"}
+    if create_response_extra:
+        body.update(create_response_extra)
+    create = respx.post(f"{API_URL}{create_path}").mock(return_value=httpx.Response(200, json=body))
+    poll = respx.get(f"{API_URL}/render_tasks/{task_id}").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "id": task_id,
+                "status": "success",
+                "query_runtime": 0.12,
+                "render_runtime": 0.34,
+                "runtime": 0.46,
+            },
+        )
+    )
+    results = respx.get(f"{API_URL}/render_tasks/{task_id}/results").mock(
+        return_value=httpx.Response(
+            200,
+            content=result_bytes,
+            headers={"content-type": result_content_type},
+        )
+    )
+    return create, poll, results
+
+
+class TestRenderQuery:
+    """``render_query`` posts /queries first, then drives a queries-render-task."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_creates_query_then_renders_png(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/queries").mock(return_value=httpx.Response(201, json={"id": "q1"}))
+        create, poll, results = _mock_render_task_success(
+            create_path="/render_tasks/queries/q1/png",
+            task_id="rt-1",
+            result_bytes=PNG_BYTES,
+            result_content_type="image/png",
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_query",
+                    {
+                        "model": "ecommerce",
+                        "view": "orders",
+                        "fields": ["orders.region"],
+                        "width": 800,
+                        "height": 600,
+                        "result_format": "png",
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, ImageContent)
+                assert content.mimeType == "image/png"
+                assert base64.b64decode(content.data) == PNG_BYTES
+        finally:
+            await looker_client.close()
+
+        assert create.called
+        assert poll.called
+        assert results.called
+        # Width/height must reach Looker as query-string params on create.
+        assert create.calls.last.request.url.params["width"] == "800"
+        assert create.calls.last.request.url.params["height"] == "600"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_rejects_oversized_dimensions(self, config):
+        _mock_login_logout()
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_query",
+                    {
+                        "model": "ecommerce",
+                        "view": "orders",
+                        "fields": ["orders.region"],
+                        "width": 5000,
+                        "height": 5000,
+                        "result_format": "png",
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert "pixel cap" in payload["error"]
+        finally:
+            await looker_client.close()
+
+
+class TestRenderLook:
+    """Saved-Look path: no query POST, direct create-task."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_renders_jpg(self, config):
+        _mock_login_logout()
+        create, poll, results = _mock_render_task_success(
+            create_path="/render_tasks/looks/look-1/jpg",
+            task_id="rt-2",
+            result_bytes=PNG_BYTES,  # bytes opaque to FastMCP routing
+            result_content_type="image/jpeg",
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_look",
+                    {
+                        "look_id": "look-1",
+                        "width": 400,
+                        "height": 300,
+                        "result_format": "jpg",
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, ImageContent)
+                # FastMCP's Image(format="jpg") emits the literal
+                # "image/jpg" MIME — not "image/jpeg" — so the format
+                # round-trips through the MCP envelope unchanged.
+                assert content.mimeType == "image/jpg"
+        finally:
+            await looker_client.close()
+
+        assert create.called
+        assert poll.called
+        assert results.called
+
+
+class TestRenderDashboard:
+    """Dashboard renders cover the full param surface including PDF output."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_pdf_returns_embedded_resource(self, config):
+        _mock_login_logout()
+        create, poll, results = _mock_render_task_success(
+            create_path="/render_tasks/dashboards/42/pdf",
+            task_id="rt-3",
+            result_bytes=PDF_BYTES,
+            result_content_type="application/pdf",
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_dashboard",
+                    {
+                        "dashboard_id": "42",
+                        "width": 1024,
+                        "height": 768,
+                        "result_format": "pdf",
+                        "pdf_paper_size": "letter",
+                        "pdf_landscape": True,
+                        "long_tables": False,
+                        "theme": "corporate",
+                    },
+                )
+                content = result.content[0]
+                # FastMCP serializes File(format='pdf') to an
+                # EmbeddedResource with BlobResourceContents.
+                assert isinstance(content, EmbeddedResource)
+                blob_b64 = content.resource.blob  # type: ignore[union-attr]
+                assert base64.b64decode(blob_b64) == PDF_BYTES
+        finally:
+            await looker_client.close()
+
+        assert create.called
+        params = create.calls.last.request.url.params
+        assert params["width"] == "1024"
+        assert params["height"] == "768"
+        assert params["pdf_paper_size"] == "letter"
+        assert params["pdf_landscape"] == "true"
+        assert params["long_tables"] == "false"
+        assert params["theme"] == "corporate"
+        assert poll.called
+        assert results.called
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_dashboard_filters_url_encoded(self, config):
+        _mock_login_logout()
+        create, _poll, _results = _mock_render_task_success(
+            create_path="/render_tasks/dashboards/42/png",
+            task_id="rt-4",
+            result_bytes=PNG_BYTES,
+            result_content_type="image/png",
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "render_dashboard",
+                    {
+                        "dashboard_id": "42",
+                        "width": 800,
+                        "height": 600,
+                        "result_format": "png",
+                        "dashboard_filters": {
+                            "Region": "West",
+                            "Date Range": "30 days",
+                        },
+                    },
+                )
+        finally:
+            await looker_client.close()
+
+        params = create.calls.last.request.url.params
+        # urlencode preserves dict insertion order; both pairs round-trip
+        # through httpx's URL parser without further escaping.
+        assert "Region=West" in params["dashboard_filters"]
+        assert "Date+Range=30+days" in params["dashboard_filters"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_pdf_only_params_omitted_for_png_render(self, config):
+        """PDF-specific knobs (pdf_paper_size, pdf_landscape, long_tables)
+        must not reach Looker on PNG/JPG renders — Looker has no use for
+        page orientation or paper size on a raster. ``theme`` and
+        ``dashboard_filters`` are format-agnostic and must still
+        propagate. Pins the gating so future refactors can't regress it.
+        """
+        _mock_login_logout()
+        create, _poll, _results = _mock_render_task_success(
+            create_path="/render_tasks/dashboards/42/png",
+            task_id="rt-png-gated",
+            result_bytes=PNG_BYTES,
+            result_content_type="image/png",
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                await mcp_client.call_tool(
+                    "render_dashboard",
+                    {
+                        "dashboard_id": "42",
+                        "width": 800,
+                        "height": 600,
+                        "result_format": "png",
+                        # All four are set but only the first should
+                        # reach Looker for a PNG render.
+                        "theme": "corporate",
+                        "pdf_paper_size": "letter",
+                        "pdf_landscape": True,
+                        "long_tables": True,
+                    },
+                )
+        finally:
+            await looker_client.close()
+
+        params = create.calls.last.request.url.params
+        assert "pdf_paper_size" not in params
+        assert "pdf_landscape" not in params
+        assert "long_tables" not in params
+        # theme is format-agnostic — must still reach Looker.
+        assert params["theme"] == "corporate"
+
+
+class TestRenderDashboardTile:
+    """One-tile renders use the dashboard_elements endpoint."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_renders_png(self, config):
+        _mock_login_logout()
+        create, poll, results = _mock_render_task_success(
+            create_path="/render_tasks/dashboard_elements/elem-1/png",
+            task_id="rt-5",
+            result_bytes=PNG_BYTES,
+            result_content_type="image/png",
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_dashboard_tile",
+                    {
+                        "dashboard_element_id": "elem-1",
+                        "width": 320,
+                        "height": 240,
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, ImageContent)
+                assert content.mimeType == "image/png"
+        finally:
+            await looker_client.close()
+
+        assert create.called
+        assert poll.called
+        assert results.called
+
+
+class TestRenderLifecycle:
+    """End-to-end behaviours that span the create→poll→fetch flow."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_failure_status_propagates_status_detail(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/render_tasks/looks/L/png").mock(
+            return_value=httpx.Response(200, json={"id": "rt-fail", "status": "enqueued_for_query"})
+        )
+        respx.get(f"{API_URL}/render_tasks/rt-fail").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "id": "rt-fail",
+                    "status": "failure",
+                    "status_detail": "Query timed out after 60s",
+                },
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_look",
+                    {"look_id": "L", "width": 400, "height": 300},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                # The Looker error body must reach the caller verbatim
+                # so they can see WHY the render failed.
+                assert "Query timed out after 60s" in json.dumps(payload)
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_timeout_returns_escape_hatch_json(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/render_tasks/looks/L/png").mock(
+            return_value=httpx.Response(200, json={"id": "rt-slow"})
+        )
+        # Status never reaches a terminal state within max_wait_seconds.
+        respx.get(f"{API_URL}/render_tasks/rt-slow").mock(
+            return_value=httpx.Response(200, json={"id": "rt-slow", "status": "rendering"})
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_look",
+                    {
+                        "look_id": "L",
+                        "width": 400,
+                        "height": 300,
+                        # Zero seconds: first poll returns non-terminal,
+                        # deadline immediately blown, escape hatch fires.
+                        "max_wait_seconds": 0.0,
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["status"] == "timeout"
+                assert payload["render_task_id"] == "rt-slow"
+                assert payload["last_status"] == "rendering"
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_oversized_result_returns_too_large_escape_hatch(self, config):
+        """A render result bigger than the 10 MB transport cap must not
+        materialize in memory and must reach the caller as a JSON
+        escape-hatch payload carrying ``render_task_id`` + ``size_bytes``.
+
+        respx serves the full payload; ``get_bytes`` triggers its
+        Content-Length fast path because httpx auto-sets the header from
+        the byte length, so no body is actually buffered in the
+        oversized branch. This pins the byte-budget invariant.
+        """
+        _mock_login_logout()
+        respx.post(f"{API_URL}/render_tasks/looks/L/png").mock(
+            return_value=httpx.Response(200, json={"id": "rt-big"})
+        )
+        respx.get(f"{API_URL}/render_tasks/rt-big").mock(
+            return_value=httpx.Response(200, json={"id": "rt-big", "status": "success"})
+        )
+        # 10 MB + 1 — one byte over the cap is enough to exercise the
+        # truncated path without bloating the test process. respx serves
+        # the payload but the streaming helper never appends a chunk.
+        oversized_size = 10 * 1024 * 1024 + 1
+        respx.get(f"{API_URL}/render_tasks/rt-big/results").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"x" * oversized_size,
+                headers={"content-type": "image/png"},
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_look",
+                    {"look_id": "L", "width": 400, "height": 300, "result_format": "png"},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["status"] == "too_large"
+                assert payload["render_task_id"] == "rt-big"
+                assert payload["format"] == "png"
+                # Content-Length fast path → exact size signalled.
+                assert payload["size_bytes"] == oversized_size
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_oversized_result_streaming_fallback_escape_hatch(self, config):
+        """When the server omits Content-Length, the 10 MB cap is enforced
+        by the ``aiter_bytes()`` early-break in ``_request_bytes`` rather
+        than the header fast path. Same too_large escape-hatch contract;
+        only the lower-bound size signal differs (chunks read so far
+        rather than exact Content-Length). Pins the streaming branch
+        against regressions like a refactor reintroducing
+        ``response.content`` buffering.
+        """
+        _mock_login_logout()
+        respx.post(f"{API_URL}/render_tasks/looks/L/png").mock(
+            return_value=httpx.Response(200, json={"id": "rt-big-stream"})
+        )
+        respx.get(f"{API_URL}/render_tasks/rt-big-stream").mock(
+            return_value=httpx.Response(200, json={"id": "rt-big-stream", "status": "success"})
+        )
+
+        oversized_size = 10 * 1024 * 1024 + 1
+        chunk_size = 1024 * 1024
+
+        class _NoLengthStream(httpx.AsyncByteStream):
+            """Yields oversized_size bytes without setting Content-Length.
+
+            httpx auto-derives Content-Length when ``content=bytes`` is
+            used, but not when a custom ``stream=`` is provided — so
+            attaching this drives ``_request_bytes`` down the streaming
+            fallback branch.
+            """
+
+            async def __aiter__(self):
+                remaining = oversized_size
+                while remaining > 0:
+                    n = min(chunk_size, remaining)
+                    yield b"x" * n
+                    remaining -= n
+
+            async def aclose(self) -> None:
+                return
+
+        respx.get(f"{API_URL}/render_tasks/rt-big-stream/results").mock(
+            return_value=httpx.Response(
+                200,
+                stream=_NoLengthStream(),
+                headers={"content-type": "image/png"},
+            )
+        )
+
+        mcp, looker_client = create_server(config, enabled_groups={"render"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "render_look",
+                    {"look_id": "L", "width": 400, "height": 300, "result_format": "png"},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+                assert payload["status"] == "too_large"
+                assert payload["render_task_id"] == "rt-big-stream"
+                assert payload["format"] == "png"
+                # Streaming fallback only knows the lower bound: the
+                # loop breaks as soon as the running total passes the
+                # 10 MB cap, so the surfaced size is somewhere in
+                # (10 MB, 10 MB + chunk_size].
+                assert payload["size_bytes"] > 10 * 1024 * 1024
+        finally:
+            await looker_client.close()


### PR DESCRIPTION
## Summary

Adds a new `render` tool group wrapping Looker's `/render_tasks/*` API surface — the previously-uncovered async pattern for rendering Looker content as PNG, JPG, or PDF — and bundles the release prep into the same atomic change (CHANGELOG `[0.18.0]` entry + `pyproject.toml` version bump + `uv.lock` self-entry refresh).

Four new tools:

| Tool | Subject | Formats |
|---|---|---|
| `render_query` | ad-hoc explore (model+view+fields, same surface as `query`) | png, jpg |
| `render_look` | saved Look | png, jpg |
| `render_dashboard` | full dashboard | **pdf**, png, jpg |
| `render_dashboard_tile` | single dashboard element | png, jpg |

`render_dashboard` additionally exposes Looker's `pdf_paper_size`, `pdf_landscape`, `long_tables`, `theme`, and `dashboard_filters` knobs. PDF-only knobs are gated on `result_format == "pdf"` so image renders don't carry page-orientation hints Looker ignores.

## Design

All four tools share a `_create_and_wait_for_render_task` helper that owns the three-step Looker pattern in one place:

1. `POST /render_tasks/.../{format}` with the subject's path params and `width`/`height` query params → render task id.
2. `GET /render_tasks/{id}` polled on a 0.5s → 1s → 2s backoff (capped) until `status ∈ {success, failure}` or the wall-clock deadline passes. Malformed payloads (non-dict, missing or non-string `status`) raise immediately rather than burning poll cycles.
3. On `success`: `GET /render_tasks/{id}/results` streamed via the new `LookerSession.get_bytes` so the 10 MB transport cap is enforced during download. On `failure`: raise `LookerApiError` carrying the `status_detail` body Looker returned.

`LookerSession.get_bytes(path, *, max_bytes=…)` streams via `httpx.stream()` + `aiter_bytes()` and short-circuits via Content-Length when the server provides it; the streaming early-break is the fallback for servers that omit the header. Returns `(body_bytes, content_type, total_bytes, truncated)`.

### Return shape

Binary results use FastMCP's typed helpers so they serialize correctly through the MCP envelope:

- `png` / `jpg` → `fastmcp.utilities.types.Image(data=…, format=…)` → MCP `ImageContent` (LLM-visible)
- `pdf` → `fastmcp.utilities.types.File(data=…, format="pdf", name=…)` → MCP `EmbeddedResource` with `BlobResourceContents`

Three recoverable conditions return JSON escape-hatches rather than raising, so the caller never loses an in-flight render:

- **Deadline hit** (`max_wait_seconds` exhausted with a non-terminal status) → `{status: "timeout", render_task_id, last_status, runtime_meta}`.
- **Result too large** (> 10 MB, exact via Content-Length or lower-bound via streaming break) → `{status: "too_large", size_bytes, format, render_task_id}` — caller can fetch directly from Looker.
- **Dimension cap** (`width * height > 16M pixels`) → ValueError surfaced through the standard `format_api_error` JSON.

### Group registration

Adds `"render"` to `ALL_GROUPS` only — **not** to `DEFAULT_GROUPS`. Image rendering is opt-in: enable with `--groups …,render` or `--groups all`.

## Release bundling

This PR is self-contained for v0.18.0:

- `CHANGELOG.md` — new `[0.18.0] - 2026-05-19` section in the established narrative-then-`### Added` style, documenting the four tools, the `get_bytes` transport helper, and group registration.
- `pyproject.toml` — version `0.17.0` → `0.18.0` (semver minor: additive opt-in group, no breaking changes).
- `uv.lock` — project self-entry refreshed (single-line change, no transitive dep drift).

A `v0.18.0` tag push after merge triggers the existing PyPI release workflow.

## Tests

`tests/test_render_tools.py` covers (11 tests):

- happy-path PNG/JPG/PDF round-trips for all four subjects
- the create → poll → `/results` lifecycle (asserts on `respx` route hits)
- dashboard param surface (paper size, landscape, long_tables, theme)
- `dashboard_filters` dict → URL-encoded string round-trip
- PDF-only param gating (omitted on PNG/JPG renders; `theme` still propagates)
- terminal `failure` status propagates Looker's `status_detail`
- deadline-hit returns the timeout escape-hatch JSON with `render_task_id`
- oversized result via Content-Length fast path → `too_large` escape hatch with exact `size_bytes`
- oversized result via streaming fallback (no Content-Length, `httpx.AsyncByteStream`) → `too_large` escape hatch with lower-bound `size_bytes`
- dimension-cap rejection

Updates the existing `test_all_groups_includes_expected` pinning test.

381 tests pass; `ruff check`, `ruff format --check`, and `pyright` all green.

## API references

- Looker 4.0 OpenAPI spec (`looker-open-source/sdk-codegen` `spec/Looker.4.0.oas.json`):
  - `POST /render_tasks/queries/{query_id}/{result_format}` — `png`/`jpg`
  - `POST /render_tasks/looks/{look_id}/{result_format}` — `png`/`jpg`
  - `POST /render_tasks/dashboards/{dashboard_id}/{result_format}` — `png`/`jpg`/**`pdf`** (only subject with PDF support)
  - `POST /render_tasks/dashboard_elements/{dashboard_element_id}/{result_format}` — `png`/`jpg`
  - `GET /render_tasks/{render_task_id}` — status polling
  - `GET /render_tasks/{render_task_id}/results` — bytes

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pyright`
- [x] `uv run pytest tests/` — 381 passed
- [x] CHANGELOG `[0.18.0]` entry bundled atomically with the feature
- [x] `pyproject.toml` version bumped to 0.18.0
- [x] `uv.lock` self-entry refreshed
- [ ] Smoke-test against a real Looker instance: render a dashboard as PDF and a Look as PNG, verify the byte payload reaches the client end-to-end