### PR TITLE
fix(server): /readyz no longer requires API3 credentials in external-identity mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/readyz` no longer requires API3 service-account credentials in
+  external-identity deployments.** The readiness probe previously
+  asserted that both `LOOKER_CLIENT_ID` and `LOOKER_CLIENT_SECRET`
+  were set and exercised a live login/logout cycle against the Looker
+  API. That contract is correct for service-account mode but wrong
+  for deployments where the server has no standing identity — OAuth
+  pass-through (`X-User-Token`) or sudo-by-header
+  (`X-User-Email`) flows where per-request user tokens supply auth at
+  tool-invoke time. Such deployments would deliberately omit the
+  service-account credentials, then fail `kubelet` readiness checks
+  forever and roll back atomic Helm releases.
+
+  The route now branches on whether both API3 credentials are
+  configured. With them, behavior is unchanged (live login/logout
+  cycle). Without them, the probe issues a no-auth `HEAD` against
+  `LOOKER_BASE_URL` via a new `LookerClient.check_reachability` —
+  any HTTP response (including `401`) proves the dependency is
+  reachable, only transport-layer failures (DNS, connection refused,
+  TLS error, timeout) return `503`. Auth is validated per-request at
+  tool-invoke time; readiness is a liveness-of-dependency check.
+
 ## [0.18.0] - 2026-05-19
 
 Adds a new opt-in **`render` tool group** wrapping Looker's

--- a/src/looker_mcp_server/client.py
+++ b/src/looker_mcp_server/client.py
@@ -500,6 +500,33 @@ class LookerClient:
         except Exception:
             return False
 
+    async def check_reachability(self) -> bool:
+        """Verify the configured ``base_url`` is network-reachable, no auth.
+
+        Issues a single HEAD against the Looker instance's web root. Any
+        HTTP response — including 401/403/404 — proves DNS resolution,
+        TCP connect, and TLS handshake all succeeded, which is all a
+        readiness probe needs to assert in deployments where the server
+        does not hold API3 service-account credentials (e.g. OAuth
+        pass-through, where per-request user tokens supply auth). Only
+        transport-layer failures (DNS, connection refused, TLS error,
+        timeout) return ``False``.
+
+        Per-request auth is validated at tool-invoke time; readiness is a
+        liveness-of-dependency check, not an auth check.
+        """
+        if not self._config.base_url:
+            return False
+        try:
+            response = await self._http.head(
+                self._config.base_url,
+                follow_redirects=False,
+                timeout=httpx.Timeout(5.0),
+            )
+            return 100 <= response.status_code < 600
+        except httpx.HTTPError:
+            return False
+
     async def lookup_user_by_email(self, email: str) -> str | None:
         """Resolve a Looker user ID from an email address.
 

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -264,16 +264,29 @@ def create_server(
                 {"status": "not_ready", "reason": "LOOKER_BASE_URL not configured"},
                 status_code=503,
             )
-        if not config.client_id or not config.client_secret:
-            return JSONResponse(
-                {"status": "not_ready", "reason": "LOOKER_CLIENT_ID/SECRET not configured"},
-                status_code=503,
-            )
 
-        ok = await client.check_connectivity()
+        # Two operating shapes are supported, gated on whether API3
+        # service-account credentials are configured:
+        #
+        # 1. Service-account mode (``client_id`` + ``client_secret``
+        #    both set): exercise a real login/logout cycle so readiness
+        #    asserts the creds are valid against this instance.
+        # 2. External-identity mode (creds absent): the server has no
+        #    standing identity at the Looker API — auth is supplied
+        #    per-request via an OAuth pass-through token or sudo
+        #    impersonation header. Readiness here is a
+        #    reachability-of-dependency check, not an auth check. Per-
+        #    request auth is validated at tool-invoke time.
+        if config.client_id and config.client_secret:
+            ok = await client.check_connectivity()
+            reason = "Cannot connect to Looker"
+        else:
+            ok = await client.check_reachability()
+            reason = "Looker base URL unreachable"
+
         if not ok:
             return JSONResponse(
-                {"status": "not_ready", "reason": "Cannot connect to Looker"},
+                {"status": "not_ready", "reason": reason},
                 status_code=503,
             )
         return JSONResponse({"status": "ready"})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -564,3 +564,64 @@ class TestCheckConnectivity:
         client = LookerClient(config, provider)
         assert await client.check_connectivity() is False
         await client.close()
+
+
+class TestCheckReachability:
+    """``check_reachability`` is the no-auth probe used by ``/readyz`` in
+    external-identity deployments (no API3 service-account credentials
+    configured). Any HTTP response from the configured ``base_url`` is
+    treated as proof the dependency is up — only transport-layer
+    failures return ``False``.
+    """
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_true_on_2xx(self, config):
+        respx.head(config.base_url).mock(return_value=httpx.Response(200))
+
+        provider = ApiKeyIdentityProvider("", "")
+        client = LookerClient(config, provider)
+        assert await client.check_reachability() is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_true_on_unauthenticated_response(self, config):
+        """A 401 from the Looker web root still proves the instance is
+        reachable. Readiness is a liveness-of-dependency check; auth is
+        validated per-request at tool-invoke time, not here.
+        """
+        respx.head(config.base_url).mock(return_value=httpx.Response(401))
+
+        provider = ApiKeyIdentityProvider("", "")
+        client = LookerClient(config, provider)
+        assert await client.check_reachability() is True
+        await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_false_on_connection_error(self, config):
+        respx.head(config.base_url).mock(side_effect=httpx.ConnectError("refused"))
+
+        provider = ApiKeyIdentityProvider("", "")
+        client = LookerClient(config, provider)
+        assert await client.check_reachability() is False
+        await client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_returns_false_on_timeout(self, config):
+        respx.head(config.base_url).mock(side_effect=httpx.ConnectTimeout("timed out"))
+
+        provider = ApiKeyIdentityProvider("", "")
+        client = LookerClient(config, provider)
+        assert await client.check_reachability() is False
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_without_base_url(self):
+        config = LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        provider = ApiKeyIdentityProvider("", "")
+        client = LookerClient(config, provider)
+        assert await client.check_reachability() is False
+        await client.close()

--- a/tests/test_health_endpoints.py
+++ b/tests/test_health_endpoints.py
@@ -1,0 +1,184 @@
+"""Tests for the ``/readyz`` route's two operating shapes.
+
+The route branches on whether API3 service-account credentials are
+configured:
+
+- both ``client_id`` and ``client_secret`` set → live login/logout cycle
+  via :meth:`LookerClient.check_connectivity` (service-account mode).
+- either credential missing → no-auth HEAD against ``base_url`` via
+  :meth:`LookerClient.check_reachability` (external-identity mode, e.g.
+  OAuth pass-through, where per-request user tokens supply auth).
+
+The route must always 503 when ``base_url`` itself is empty regardless
+of which mode applies.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.server import create_server
+
+
+def _config(**overrides: Any) -> LookerConfig:
+    base: dict[str, Any] = {
+        "base_url": "https://test.looker.com",
+        "client_id": "test-id",
+        "client_secret": "test-secret",
+        "sudo_as_user": False,
+    }
+    base.update(overrides)
+    return LookerConfig(_env_file=None, **base)  # type: ignore[call-arg]
+
+
+@pytest.fixture
+def starlette_app_factory():
+    """Build the Starlette ASGI app for a given config + close the
+    LookerClient at teardown so per-test httpx state doesn't leak.
+    """
+    pending: list[Any] = []
+
+    def _build(config: LookerConfig) -> Starlette:
+        mcp, client = create_server(config)
+        app = mcp.http_app()
+        assert isinstance(app, Starlette)
+        pending.append(client)
+        return app
+
+    yield _build
+
+    # The Starlette ``TestClient`` ``with`` block has already exited by
+    # the time fixture teardown runs, so no event loop is active here.
+    # ``asyncio.run`` is the simple, correct way to drive the async
+    # close from a synchronous teardown.
+    for client in pending:
+        asyncio.run(client.close())
+
+
+class TestReadyzBaseUrlGuard:
+    """``base_url`` is the one piece of config readyz enforces in every
+    mode — without it the server has nothing to probe at all.
+    """
+
+    def test_returns_503_when_base_url_unset(self, starlette_app_factory):
+        app = starlette_app_factory(_config(base_url=""))
+        with TestClient(app) as http:
+            resp = http.get("/readyz")
+        assert resp.status_code == 503
+        assert resp.json() == {
+            "status": "not_ready",
+            "reason": "LOOKER_BASE_URL not configured",
+        }
+
+
+class TestReadyzServiceAccountMode:
+    """When both API3 credentials are configured, readiness exercises
+    a real login/logout cycle so a broken credential pair fails the
+    probe early rather than at first tool invocation.
+    """
+
+    @respx.mock
+    def test_returns_ready_when_login_logout_succeeds(self, starlette_app_factory):
+        config = _config()
+        respx.post(f"{config.api_url}/login").mock(
+            return_value=httpx.Response(200, json={"access_token": "tok"})
+        )
+        respx.delete(f"{config.api_url}/logout").mock(return_value=httpx.Response(204))
+
+        app = starlette_app_factory(config)
+        with TestClient(app) as http:
+            resp = http.get("/readyz")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ready"}
+
+    @respx.mock
+    def test_returns_503_when_login_fails(self, starlette_app_factory):
+        config = _config()
+        respx.post(f"{config.api_url}/login").mock(
+            return_value=httpx.Response(401, json={"message": "bad creds"})
+        )
+
+        app = starlette_app_factory(config)
+        with TestClient(app) as http:
+            resp = http.get("/readyz")
+
+        assert resp.status_code == 503
+        assert resp.json() == {
+            "status": "not_ready",
+            "reason": "Cannot connect to Looker",
+        }
+
+
+class TestReadyzExternalIdentityMode:
+    """When API3 credentials are absent the server is operating in an
+    external-identity shape (OAuth pass-through / sudo header / etc.)
+    and has nothing to log in with. Readiness collapses to a no-auth
+    reachability check against the configured ``base_url``.
+    """
+
+    @respx.mock
+    def test_returns_ready_when_base_url_responds(self, starlette_app_factory):
+        config = _config(client_id="", client_secret="")
+        # Any HTTP response — including a 401 from the unauthenticated
+        # web root — proves the instance is reachable. Readiness does
+        # not care about the status code.
+        respx.head(config.base_url).mock(return_value=httpx.Response(401))
+
+        app = starlette_app_factory(config)
+        with TestClient(app) as http:
+            resp = http.get("/readyz")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ready"}
+
+    @respx.mock
+    def test_returns_ready_on_2xx(self, starlette_app_factory):
+        config = _config(client_id="", client_secret="")
+        respx.head(config.base_url).mock(return_value=httpx.Response(200))
+
+        app = starlette_app_factory(config)
+        with TestClient(app) as http:
+            resp = http.get("/readyz")
+
+        assert resp.status_code == 200
+
+    @respx.mock
+    def test_returns_503_when_base_url_unreachable(self, starlette_app_factory):
+        config = _config(client_id="", client_secret="")
+        respx.head(config.base_url).mock(side_effect=httpx.ConnectError("refused"))
+
+        app = starlette_app_factory(config)
+        with TestClient(app) as http:
+            resp = http.get("/readyz")
+
+        assert resp.status_code == 503
+        assert resp.json() == {
+            "status": "not_ready",
+            "reason": "Looker base URL unreachable",
+        }
+
+    @respx.mock
+    def test_succeeds_when_only_one_credential_is_set(self, starlette_app_factory):
+        """A half-configured cred pair (one field set, the other empty)
+        is still external-identity mode by the route's branch test —
+        the API3 login flow needs both halves to be usable. Readiness
+        therefore falls back to the reachability path rather than 503-ing
+        on a degenerate login attempt.
+        """
+        config = _config(client_id="only-id", client_secret="")
+        respx.head(config.base_url).mock(return_value=httpx.Response(200))
+
+        app = starlette_app_factory(config)
+        with TestClient(app) as http:
+            resp = http.get("/readyz")
+
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary

The `/readyz` route previously asserted that both `LOOKER_CLIENT_ID`
and `LOOKER_CLIENT_SECRET` were set and exercised a live login/logout
cycle against the Looker API. That contract is correct for
service-account mode but wrong for deployments where the server has
no standing identity:

- OAuth pass-through (`X-User-Token`)
- Sudo-by-header impersonation (`X-User-Email`)

In those flows per-request user tokens supply auth at tool-invoke
time, and the deployment deliberately omits service-account
credentials. Today such deployments fail `kubelet` readiness checks
forever and roll back atomic Helm releases on first install.

## What changed

`/readyz` now branches on whether both API3 credentials are
configured:

- **Service-account mode** (`client_id` + `client_secret` set):
  behavior unchanged — live login/logout cycle via
  `LookerClient.check_connectivity`.
- **External-identity mode** (either credential missing): no-auth
  `HEAD` against `LOOKER_BASE_URL` via a new
  `LookerClient.check_reachability`. Any HTTP response (including
  `401` from the unauthenticated web root) proves the dependency is
  reachable; only transport-layer failures (DNS, connection refused,
  TLS error, timeout) return `503`.

Auth is validated per-request at tool-invoke time. Readiness is a
liveness-of-dependency check, not an auth check.

## Test plan

- [x] `tests/test_health_endpoints.py` — 7 new tests covering both
      modes via Starlette `TestClient` driving the real route:
      `base_url` guard, login-succeeds, login-fails, reachable-401,
      reachable-200, unreachable, half-configured-creds.
- [x] `tests/test_client.py::TestCheckReachability` — 5 unit tests
      covering the new client method (2xx, unauthenticated, connection
      error, timeout, missing `base_url`).
- [x] Full suite: `uv run pytest` — 393 passed.
- [x] `uv run ruff format --check src tests` clean.
- [x] `uv run ruff check src tests` clean.
- [x] `uv run pyright src tests` — 0 errors, 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/readyz` readiness probe to support external-identity deployments. When API credentials are not configured, the probe now performs a lightweight network reachability check instead of failing immediately. Standard authentication-based checks are used when credentials are available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->