### PR TITLE
feat(server): mount unauthenticated /_introspect endpoint for gateway tool discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Host-root `/_introspect` endpoint for gateway tool discovery
+  (open by default; optional shared-bearer guard).** A new route at
+  `/_introspect` — mounted alongside but separate from the
+  authenticated `/mcp` route — serves the MCP discovery slice
+  (`initialize`, `notifications/initialized`, `tools/list`) so a
+  gateway aggregator that fronts multiple MCP servers can populate
+  its tool catalog at registration time without holding
+  service-account credentials at each backend. `tools/call` is
+  rejected (`-32601`); execution still flows through `/mcp` where
+  the user JWT validates.
+
+  **Security posture — operators must read.** The route is mounted
+  at host root (the `/mcp` OAuth 2.1 middleware deliberately does
+  not see it). It does NOT require a user JWT, and by default
+  accepts requests from any network-reachable caller. Operators
+  must compose at least one of the following defenses:
+
+  1. **Network controls (primary; recommended for cluster
+     deployments).** Restrict ingress to `/_introspect` so it is
+     reachable only from the trusted gateway aggregator's pod or
+     subnet. External ingress should expose only `/mcp/*` and the
+     well-known PRM document.
+  2. **Application-layer shared bearer.** Set
+     `LOOKER_MCP_INTROSPECT_BEARER` to any opaque token. When set,
+     all three methods (POST, GET, DELETE) require
+     `Authorization: Bearer <value>` and respond `401` otherwise;
+     the aggregator is configured with the same token out-of-band.
+     When unset (the default), the endpoint is **open** and the
+     operator is implicitly relying on network-layer isolation.
+
+  The route also accepts `GET` (204 — empty server-push stream
+  placeholder) and `DELETE` (200 — session teardown ack) so a
+  well-behaved MCP Streamable HTTP client doesn't log 405 errors on
+  every discovery cycle. The optional bearer guard, when configured,
+  applies uniformly to all three methods.
+
+  Wiring details: the route is mounted only on `streamable-http`
+  transport — `stdio` deployments don't sit behind a gateway and
+  don't get the route. The OAuth 2.1 resource-server middleware
+  (active in `LOOKER_MCP_MODE=public`) exempts `/_introspect` from
+  its token check, since the route enforces its own optional bearer
+  instead.
+
+  Cited precedent: [Strawberry GraphQL Federation](https://strawberry.rocks/docs/guides/federation),
+  [Apollo Federation v1 spec](https://www.apollographql.com/docs/federation/v1/federation-spec/).
+
 ### Fixed
 
 - **`/readyz` no longer requires API3 service-account credentials in

--- a/src/looker_mcp_server/introspect.py
+++ b/src/looker_mcp_server/introspect.py
@@ -1,0 +1,298 @@
+"""Unauthenticated tool-discovery endpoint at host-root ``/_introspect``.
+
+Mounts an MCP JSON-RPC handler at ``/_introspect`` that serves the
+**discovery slice** of the MCP protocol — ``initialize``,
+``notifications/initialized``, and ``tools/list`` — without requiring
+a user JWT. ``tools/call`` is deliberately rejected; execution must go
+through the authenticated ``/mcp`` route where token validation happens.
+
+Why a separate, unauthenticated route
+-------------------------------------
+A gateway aggregator that fronts multiple MCP servers needs to
+populate its tool catalog at registration time, before any user JWT
+exists. The aggregator has no bootstrap identity at each backend's
+authorization server. ``/_introspect`` resolves the chicken-and-egg:
+the aggregator can list a backend's tools without credentials, then
+forward the *user's* JWT on every subsequent ``tools/call`` it
+proxies through the backend's authenticated route.
+
+This pattern is canonical in federated/aggregated query architectures
+— Strawberry GraphQL Federation makes the same recommendation
+verbatim:
+
+    "If your federated service is reachable by untrusted clients, use
+    authentication, authorization, or network controls to restrict
+    access to federation fields and make sure entity resolvers enforce
+    their own access checks."
+    — https://strawberry.rocks/docs/guides/federation
+
+The "or network controls" clause is load-bearing here. Apollo
+Federation v1 has run gateway-aggregates-subgraph-schemas in
+production since 2019. Envoy AI Gateway uses the same two-tier
+pattern (service-tier credentials for transport, header forwarding
+for user identity).
+
+Trust model
+-----------
+The route is mounted at host root, NOT under ``/mcp`` where the auth
+middleware lives. It is reachable without an ``Authorization``
+header **by design**. Operators are expected to compose at least one
+of the following defenses:
+
+1. **Network controls** (recommended for cluster deployments): a
+   network policy or ingress configuration that only routes
+   ``/_introspect`` from the trusted aggregator's pod or subnet.
+   External ingress should expose only ``/mcp/*`` and the
+   well-known PRM document.
+
+2. **Application-layer shared bearer** (recommended when network
+   isolation is not available): set the ``LOOKER_MCP_INTROSPECT_BEARER``
+   environment variable. When set, the endpoint requires
+   ``Authorization: Bearer <value>`` and 401s otherwise. The
+   aggregator is configured with the same token out-of-band.
+
+3. **Both, for defense-in-depth.**
+
+When ``LOOKER_MCP_INTROSPECT_BEARER`` is unset (the default) the
+endpoint is unauthenticated and the operator is implicitly relying on
+network-layer isolation. That default is appropriate for cluster
+deployments where the network boundary is already drawn at the
+ingress layer; it is a footgun on a public network and operators
+should set the env var in that case.
+
+Transport surface
+-----------------
+The MCP Streamable HTTP transport opens a GET stream on connect (for
+server-initiated notifications) and sends a DELETE on session
+teardown. The discovery endpoint does not implement server-push and
+holds no cross-request session state, but it must accept GET and
+DELETE so a well-behaved MCP client doesn't log 405 errors on every
+discovery cycle:
+
+- ``GET /_introspect``    → 204 No Content (no notifications stream).
+- ``DELETE /_introspect`` → 200 OK (no session state to release).
+
+Each ``POST /_introspect`` is logically standalone; ``Mcp-Session-Id``
+is echoed when supplied (per the MCP convention) or freshly minted.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Final
+from uuid import uuid4
+
+import structlog
+
+logger = structlog.get_logger()
+
+
+# The MCP protocol revision this discovery endpoint advertises. Held
+# as a module constant so the handshake reply and any future references
+# agree on a single value. This SHOULD track whatever revision the
+# authenticated ``/mcp`` handler negotiates so a client sees consistent
+# capability semantics regardless of which endpoint it speaks to.
+MCP_PROTOCOL_VERSION: Final[str] = "2025-06-18"
+
+
+# Environment variable name for the optional shared-bearer guard. Kept
+# as a module-level constant so tests and operator docs reference the
+# same string.
+INTROSPECT_BEARER_ENV: Final[str] = "LOOKER_MCP_INTROSPECT_BEARER"
+
+
+def _jsonrpc_error(req_id: Any, code: int, message: str) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "error": {"code": code, "message": message}}
+
+
+def _jsonrpc_result(req_id: Any, result: dict[str, Any]) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": req_id, "result": result}
+
+
+def _bearer_guard_passes(authorization_header: str | None, configured_token: str | None) -> bool:
+    """Constant-time comparison of the request bearer against the
+    configured token. Returns ``True`` when no token is configured
+    (unauthenticated mode — operator relies on network isolation).
+    """
+    if not configured_token:
+        return True
+    if not authorization_header:
+        return False
+    scheme, _, presented = authorization_header.partition(" ")
+    if scheme.lower() != "bearer" or not presented:
+        return False
+    # ``secrets.compare_digest`` is the appropriate primitive for
+    # comparing a presented credential against a configured one — it
+    # is timing-attack resistant and the right answer even when both
+    # operands fit comfortably in cache.
+    import secrets
+
+    return secrets.compare_digest(presented.strip(), configured_token)
+
+
+def register_introspect_endpoint(
+    mcp: Any,
+    *,
+    server_name: str,
+    server_version: str,
+) -> None:
+    """Mount the ``/_introspect`` route on the FastMCP server's ASGI app.
+
+    Parameters
+    ----------
+    mcp:
+        A ``FastMCP`` server instance. Must expose the
+        ``custom_route`` decorator, the async ``list_tools`` coroutine,
+        and per-tool ``to_mcp_tool`` rendering — public surfaces on
+        FastMCP >=3.2.
+    server_name:
+        Identity returned in the ``initialize`` response's
+        ``serverInfo.name`` field. Should match the FastMCP
+        construction-time name so discovery clients see one consistent
+        identity across ``/mcp`` and ``/_introspect``.
+    server_version:
+        ``serverInfo.version`` value. The caller passes the package
+        version explicitly so this module avoids an ``importlib.metadata``
+        round trip and the test surface stays self-contained.
+
+    Trust composition is the caller's responsibility — see the module
+    docstring for the operator-facing guidance. This function reads
+    ``LOOKER_MCP_INTROSPECT_BEARER`` from the process environment at
+    *registration* time, not per-request, so the configured token is
+    pinned for the life of the server process.
+    """
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse, Response
+
+    server_info = {"name": server_name, "version": server_version}
+    configured_bearer = os.environ.get(INTROSPECT_BEARER_ENV) or None
+
+    @mcp.custom_route("/_introspect", methods=["POST"])
+    async def _introspect(request: Request) -> Response:
+        authz = request.headers.get("authorization")
+        if not _bearer_guard_passes(authz, configured_bearer):
+            return JSONResponse(
+                {"error": "unauthorized"},
+                status_code=401,
+                headers={"www-authenticate": 'Bearer realm="introspect"'},
+            )
+
+        try:
+            body = await request.json()
+        except Exception:
+            # JSON-RPC 2.0 §5.1 — ``-32700 Parse error`` on
+            # unparseable body. ``id`` is null per spec (we can't
+            # extract it from the payload we couldn't parse).
+            return JSONResponse(
+                _jsonrpc_error(None, -32700, "Parse error"),
+                status_code=400,
+            )
+
+        if not isinstance(body, dict):
+            return JSONResponse(
+                _jsonrpc_error(None, -32600, "Invalid Request"),
+                status_code=400,
+            )
+
+        method = body.get("method", "")
+        req_id = body.get("id")
+
+        # ``Mcp-Session-Id`` is echoed when supplied (case-insensitive
+        # via Starlette's header dict) or freshly minted. The endpoint
+        # tracks no cross-request session state — each call is
+        # logically standalone, and a discovery loop opens a fresh
+        # "session" per registration cycle.
+        incoming_session = request.headers.get("mcp-session-id")
+        session_id = incoming_session or str(uuid4())
+        response_headers = {"mcp-session-id": session_id}
+
+        if method == "initialize":
+            result = {
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "serverInfo": server_info,
+                "capabilities": {"tools": {"listChanged": False}},
+            }
+            return JSONResponse(
+                _jsonrpc_result(req_id, result),
+                headers=response_headers,
+            )
+
+        if method == "notifications/initialized":
+            # JSON-RPC notification — no response body. ``202``
+            # mirrors what FastMCP returns for the same notification
+            # on ``/mcp`` so a generic MCP client sees identical
+            # behavior across the two endpoints.
+            return Response(status_code=202, headers=response_headers)
+
+        if method == "tools/list":
+            try:
+                tools = await mcp.list_tools()
+                tools_payload = [t.to_mcp_tool().model_dump(exclude_none=True) for t in tools]
+            except Exception:
+                logger.exception("introspect.tools_list_failed")
+                return JSONResponse(
+                    _jsonrpc_error(req_id, -32603, "Internal error"),
+                    status_code=500,
+                    headers=response_headers,
+                )
+            return JSONResponse(
+                _jsonrpc_result(req_id, {"tools": tools_payload}),
+                headers=response_headers,
+            )
+
+        # Every other method — ``tools/call``, ``resources/*``,
+        # ``prompts/*``, etc. — is rejected. Discovery is read-only;
+        # execution must traverse the authenticated ``/mcp`` route
+        # where the user JWT validates and per-tool scope is enforced.
+        return JSONResponse(
+            _jsonrpc_error(req_id, -32601, "Method not found"),
+            status_code=405,
+            headers=response_headers,
+        )
+
+    @mcp.custom_route("/_introspect", methods=["GET"])
+    async def _introspect_stream(request: Request) -> Response:
+        """Server-push stream placeholder.
+
+        The MCP Streamable HTTP client opens a GET on the same URL on
+        connect to receive server-initiated notifications. The
+        discovery endpoint has none, so 204 No Content is the correct
+        empty response — the client sees the stream "complete" and
+        moves on. Without this handler the client logs a 405 on every
+        discovery cycle.
+        """
+        # The bearer guard applies to GET too — an attacker who can
+        # reach the endpoint shouldn't be able to enumerate it via
+        # GET even though no body is returned.
+        authz = request.headers.get("authorization")
+        if not _bearer_guard_passes(authz, configured_bearer):
+            return JSONResponse(
+                {"error": "unauthorized"},
+                status_code=401,
+                headers={"www-authenticate": 'Bearer realm="introspect"'},
+            )
+        return Response(status_code=204)
+
+    @mcp.custom_route("/_introspect", methods=["DELETE"])
+    async def _introspect_teardown(request: Request) -> Response:
+        """Session teardown ack.
+
+        MCP clients send DELETE on session close. The endpoint holds
+        no session state to release, so 200 OK is the correct ack.
+        Without this handler the client logs a 405 on every clean
+        teardown.
+        """
+        authz = request.headers.get("authorization")
+        if not _bearer_guard_passes(authz, configured_bearer):
+            return JSONResponse(
+                {"error": "unauthorized"},
+                status_code=401,
+                headers={"www-authenticate": 'Bearer realm="introspect"'},
+            )
+        return Response(status_code=200)
+
+    logger.info(
+        "introspect.endpoint_registered",
+        server_name=server_name,
+        bearer_guard=configured_bearer is not None,
+    )

--- a/src/looker_mcp_server/oidc/middleware.py
+++ b/src/looker_mcp_server/oidc/middleware.py
@@ -4,7 +4,11 @@ Sits in front of the MCP app and the PRM route. In ``LOOKER_MCP_MODE=
 public``:
 
 - Requests to unauthenticated paths (``/.well-known/*``, ``/healthz``,
-  ``/readyz``) pass straight through.
+  ``/readyz``, ``/_introspect``) pass straight through. The
+  ``/_introspect`` gateway-aggregator discovery route enforces its
+  own optional shared-bearer check (see
+  :mod:`looker_mcp_server.introspect`); this middleware deliberately
+  stays out of its way so discovery still works in public mode.
 - Requests carrying a bearer token in the URL query (``?access_token=``
   or ``?authorization=``) receive a 400 with an OAuth 2.1
   ``invalid_request`` body — OAuth 2.1 §5.1.1 bans URL-query-string
@@ -48,6 +52,7 @@ _BYPASS_PREFIXES: tuple[str, ...] = (
     "/.well-known/",
     "/healthz",
     "/readyz",
+    "/_introspect",
 )
 
 

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -148,6 +148,33 @@ def create_server(
         auth=auth,
     )
 
+    # ── Gateway-aggregator discovery endpoint ────────────────────────
+    # Mount the unauthenticated ``/_introspect`` host-root endpoint on
+    # HTTP transport. A gateway that fronts multiple MCP servers calls
+    # it at registration time to populate its routable tool catalog
+    # without holding service-account credentials at each backend.
+    # Execution still flows through ``/mcp`` with the user JWT.
+    #
+    # Trust composition (network controls and/or
+    # ``LOOKER_MCP_INTROSPECT_BEARER``) is the operator's responsibility
+    # — see ``looker_mcp_server.introspect`` for the operator-facing
+    # guidance. ``stdio`` transport doesn't need this route (no gateway,
+    # no discovery flow).
+    if config.is_http():
+        from importlib import metadata
+
+        from .introspect import register_introspect_endpoint
+
+        try:
+            pkg_version = metadata.version("looker-mcp-server")
+        except metadata.PackageNotFoundError:
+            pkg_version = "0.0.0"
+        register_introspect_endpoint(
+            mcp,
+            server_name="looker-mcp-server",
+            server_version=pkg_version,
+        )
+
     # ── Register tool groups ─────────────────────────────────────────
     groups = enabled_groups or DEFAULT_GROUPS
 

--- a/tests/test_introspect.py
+++ b/tests/test_introspect.py
@@ -1,0 +1,394 @@
+"""Tests for the unauthenticated ``/_introspect`` discovery endpoint.
+
+The endpoint serves the MCP discovery slice (``initialize`` +
+``notifications/initialized`` + ``tools/list``) so a gateway aggregator
+can populate its tool catalog without holding service-account
+credentials at the backend. ``tools/call`` is deliberately rejected
+here — execution must traverse the authenticated ``/mcp`` route.
+
+Coverage groups:
+
+- ``TestIntrospectHandshake`` — JSON-RPC ``initialize`` /
+  ``notifications/initialized`` / ``tools/list`` round-trips with the
+  expected response shapes and ``Mcp-Session-Id`` echo behavior.
+- ``TestIntrospectMethodGuard`` — non-discovery methods (``tools/call``
+  etc.) return JSON-RPC ``-32601`` with HTTP 405.
+- ``TestIntrospectMalformedInput`` — parse errors return ``-32700``,
+  non-object bodies return ``-32600``.
+- ``TestIntrospectTransportSurface`` — ``GET`` returns 204 (empty
+  server-push stream) and ``DELETE`` returns 200 (session teardown
+  ack). Without these, a well-behaved MCP client logs 405 on every
+  discovery cycle.
+- ``TestIntrospectBearerGuard`` — when
+  ``LOOKER_MCP_INTROSPECT_BEARER`` is set, unauthenticated requests
+  401; the configured bearer succeeds.
+- ``TestIntrospectMiddlewareBypass`` — the ``LOOKER_MCP_MODE=public``
+  OAuth 2.1 middleware lets ``/_introspect`` through without a JWT.
+- ``TestIntrospectFactoryWiring`` — ``create_server`` only mounts
+  the route on HTTP transport; ``stdio`` deployments don't get it.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+from fastmcp import FastMCP
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from looker_mcp_server.config import LookerConfig, LookerMcpMode
+from looker_mcp_server.introspect import (
+    INTROSPECT_BEARER_ENV,
+    MCP_PROTOCOL_VERSION,
+    register_introspect_endpoint,
+)
+from looker_mcp_server.server import create_server
+
+
+def _build_minimal_server(server_name: str = "test-server") -> FastMCP:
+    """Construct a FastMCP server with two tools and the introspect
+    route mounted, without going through the looker factory. Keeps
+    these tests independent of the rest of the looker codebase.
+    """
+    mcp = FastMCP(server_name)
+
+    @mcp.tool()
+    def add(x: int, y: int) -> int:
+        """Add two integers."""
+        return x + y
+
+    @mcp.tool()
+    def echo(message: str) -> str:
+        """Echo a message back unchanged."""
+        return message
+
+    register_introspect_endpoint(mcp, server_name=server_name, server_version="9.9.9")
+    return mcp
+
+
+def _http_app(mcp: FastMCP) -> Starlette:
+    app = mcp.http_app()
+    assert isinstance(app, Starlette)
+    return app
+
+
+class TestIntrospectHandshake:
+    def test_initialize_returns_protocol_and_server_info(self):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == 1
+        assert body["result"]["protocolVersion"] == MCP_PROTOCOL_VERSION
+        assert body["result"]["serverInfo"] == {"name": "test-server", "version": "9.9.9"}
+        assert body["result"]["capabilities"]["tools"] == {"listChanged": False}
+        # Session id is always present on a discovery handshake.
+        assert resp.headers.get("mcp-session-id")
+
+    def test_initialize_echoes_supplied_session_id(self):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 2, "method": "initialize"},
+                headers={"mcp-session-id": "client-supplied-id"},
+            )
+        assert resp.headers["mcp-session-id"] == "client-supplied-id"
+
+    def test_notifications_initialized_acks_with_202(self):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            )
+        assert resp.status_code == 202
+        assert resp.headers.get("mcp-session-id")
+
+    def test_tools_list_returns_registered_tools(self):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        tools = {t["name"]: t for t in body["result"]["tools"]}
+        assert {"add", "echo"} <= set(tools)
+        # Tool wire-format must carry a non-empty description and an
+        # ``inputSchema`` — the two fields the aggregator needs to
+        # route calls and prompt model tool selection.
+        assert tools["add"]["description"]
+        assert "inputSchema" in tools["add"]
+
+
+class TestIntrospectMethodGuard:
+    def test_tools_call_is_rejected_with_405(self):
+        """Execution must go through authenticated ``/mcp``. Discovery
+        is read-only."""
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {"name": "add", "arguments": {"x": 1, "y": 2}},
+                },
+            )
+        assert resp.status_code == 405
+        body = resp.json()
+        assert body["error"]["code"] == -32601
+
+    @pytest.mark.parametrize(
+        "method",
+        ["resources/list", "prompts/list", "ping", "totally/made/up"],
+    )
+    def test_unknown_methods_are_rejected_with_405(self, method: str):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 99, "method": method},
+            )
+        assert resp.status_code == 405
+        assert resp.json()["error"]["code"] == -32601
+
+
+class TestIntrospectMalformedInput:
+    def test_parse_error_returns_minus_32700(self):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                content=b"not-valid-json",
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == -32700
+        # JSON-RPC §5.1 — id MUST be ``null`` when not extractable.
+        assert body["id"] is None
+
+    @pytest.mark.parametrize("payload", [[], "string", 42, None])
+    def test_non_object_body_returns_minus_32600(self, payload: Any):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.post(
+                "/_introspect",
+                content=json.dumps(payload).encode(),
+                headers={"content-type": "application/json"},
+            )
+        assert resp.status_code == 400
+        body = resp.json()
+        assert body["error"]["code"] == -32600
+
+
+class TestIntrospectTransportSurface:
+    """The MCP Streamable HTTP transport opens a GET on connect and
+    sends a DELETE on close. Without handlers, a well-behaved client
+    logs 405 on every discovery cycle. The discovery endpoint has no
+    state to manage either way, so these are minimal stubs.
+    """
+
+    def test_get_returns_204(self):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.get("/_introspect")
+        assert resp.status_code == 204
+        assert resp.content == b""
+
+    def test_delete_returns_200(self):
+        with TestClient(_http_app(_build_minimal_server())) as http:
+            resp = http.delete("/_introspect")
+        assert resp.status_code == 200
+
+
+class TestIntrospectBearerGuard:
+    """When :data:`INTROSPECT_BEARER_ENV` is unset (the module default)
+    the endpoint is open and the operator implicitly relies on network
+    isolation. Setting the variable layers an application-layer guard:
+    requests must carry a matching ``Authorization: Bearer ...`` header.
+    """
+
+    @pytest.fixture
+    def app_with_bearer(self, monkeypatch):
+        monkeypatch.setenv(INTROSPECT_BEARER_ENV, "secret-token")
+        return _http_app(_build_minimal_server())
+
+    def test_request_without_bearer_returns_401(self, app_with_bearer):
+        with TestClient(app_with_bearer) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            )
+        assert resp.status_code == 401
+        assert resp.headers.get("www-authenticate", "").lower().startswith("bearer")
+
+    def test_request_with_wrong_bearer_returns_401(self, app_with_bearer):
+        with TestClient(app_with_bearer) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                headers={"authorization": "Bearer wrong-token"},
+            )
+        assert resp.status_code == 401
+
+    def test_request_with_correct_bearer_succeeds(self, app_with_bearer):
+        with TestClient(app_with_bearer) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                headers={"authorization": "Bearer secret-token"},
+            )
+        assert resp.status_code == 200
+
+    def test_request_with_non_bearer_scheme_returns_401(self, app_with_bearer):
+        with TestClient(app_with_bearer) as http:
+            resp = http.post(
+                "/_introspect",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                headers={"authorization": "Basic some-base64-thing"},
+            )
+        assert resp.status_code == 401
+
+    def test_get_is_also_bearer_guarded(self, app_with_bearer):
+        """The GET handler is part of the discovery surface and must
+        not leak existence (or its 204 ack) when the bearer guard is
+        configured. Without this an unauth caller could enumerate the
+        path via HEAD-equivalent probing."""
+        with TestClient(app_with_bearer) as http:
+            unauth = http.get("/_introspect")
+            authed = http.get("/_introspect", headers={"authorization": "Bearer secret-token"})
+        assert unauth.status_code == 401
+        assert authed.status_code == 204
+
+    def test_delete_is_also_bearer_guarded(self, app_with_bearer):
+        with TestClient(app_with_bearer) as http:
+            unauth = http.delete("/_introspect")
+            authed = http.delete("/_introspect", headers={"authorization": "Bearer secret-token"})
+        assert unauth.status_code == 401
+        assert authed.status_code == 200
+
+
+class TestIntrospectMiddlewareBypass:
+    """The OAuth 2.1 resource-server middleware in
+    :mod:`looker_mcp_server.oidc.middleware` exempts ``/_introspect``
+    from its token check so the gateway-aggregator discovery contract
+    survives in ``LOOKER_MCP_MODE=public`` deployments. The endpoint
+    enforces its own optional bearer instead.
+    """
+
+    def test_public_mode_lets_introspect_through(self):
+        from looker_mcp_server.oidc.middleware import _BYPASS_PREFIXES
+
+        # The constant is the authoritative bypass list — guarding
+        # against a future edit that drops the introspect entry.
+        assert "/_introspect" in _BYPASS_PREFIXES
+
+    @pytest.mark.asyncio
+    async def test_public_mode_drives_introspect_without_auth(self):
+        """End-to-end: install ``PublicModeAuthMiddleware`` and confirm
+        an unauthenticated ``POST /_introspect initialize`` lands on
+        the handler (responds 200) rather than being short-circuited
+        by the middleware's 401.
+        """
+        from looker_mcp_server.config import LookerConfig, LookerMcpMode
+        from looker_mcp_server.server import (
+            build_public_mode_middleware,
+            create_server,
+        )
+
+        config = LookerConfig(
+            base_url="https://test.looker.com",
+            client_id="test-id",
+            client_secret="test-secret",
+            sudo_as_user=False,
+            transport="streamable-http",
+            mcp_mode=LookerMcpMode.PUBLIC,
+            mcp_jwks_uri="https://as.example.com/.well-known/jwks.json",
+            mcp_issuer_url="https://as.example.com",
+            mcp_resource_uri="https://looker.example.com/mcp",
+            _env_file=None,  # type: ignore[call-arg]
+        )
+        mcp, client = create_server(config)
+        try:
+            mw = build_public_mode_middleware(config)
+            assert mw is not None
+            app = mcp.http_app(middleware=[mw])
+            assert isinstance(app, Starlette)
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as http:
+                resp = await http.post(
+                    "/_introspect",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                )
+            assert resp.status_code == 200
+            assert resp.json()["result"]["protocolVersion"] == MCP_PROTOCOL_VERSION
+        finally:
+            await client.close()
+
+
+class TestIntrospectFactoryWiring:
+    """``create_server`` mounts the introspect route only for HTTP
+    transport — stdio servers don't sit behind a gateway and don't
+    need it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_http_transport_mounts_introspect(self):
+        config = LookerConfig(
+            base_url="https://test.looker.com",
+            client_id="id",
+            client_secret="secret",
+            sudo_as_user=False,
+            transport="streamable-http",
+            _env_file=None,  # type: ignore[call-arg]
+        )
+        mcp, client = create_server(config)
+        try:
+            app = mcp.http_app()
+            assert isinstance(app, Starlette)
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as http:
+                resp = await http.post(
+                    "/_introspect",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                )
+            assert resp.status_code == 200
+            assert resp.json()["result"]["serverInfo"]["name"] == "looker-mcp-server"
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_stdio_transport_omits_introspect(self):
+        config = LookerConfig(
+            base_url="https://test.looker.com",
+            client_id="id",
+            client_secret="secret",
+            sudo_as_user=False,
+            transport="stdio",
+            _env_file=None,  # type: ignore[call-arg]
+        )
+        mcp, client = create_server(config)
+        try:
+            app = mcp.http_app()
+            assert isinstance(app, Starlette)
+            transport = httpx.ASGITransport(app=app)
+            async with httpx.AsyncClient(transport=transport, base_url="http://test") as http:
+                resp = await http.post(
+                    "/_introspect",
+                    json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+                )
+            # No route registered, so the FastMCP app surfaces a 404
+            # (Starlette default for unknown paths).
+            assert resp.status_code == 404
+        finally:
+            await client.close()
+
+
+# Suppress unused-import warnings when an import is legitimately
+# load-bearing for a fixture or class attribute but not directly
+# referenced in test bodies.
+_ = LookerConfig, LookerMcpMode


### PR DESCRIPTION
## Summary

Adds a host-root MCP JSON-RPC handler at `/_introspect` that serves
the discovery slice of the MCP protocol — `initialize`,
`notifications/initialized`, `tools/list` — without requiring a user
JWT. `tools/call` is deliberately rejected (`-32601`); execution
must traverse the authenticated `/mcp` route where the user token
is validated.

## Why

A gateway aggregator that fronts multiple MCP servers needs to
populate its tool catalog at registration time, before any user JWT
exists. The aggregator has no bootstrap identity at each backend's
authorization server, so the authenticated `/mcp` route can't be
used for discovery. Other gateway-fronted MCP servers that build on
a common framework auto-mount this endpoint; this PR brings the same
contract to `looker-mcp-server`.

## Trust model

Layered. The route is mounted at host root so the `/mcp` auth
middleware never sees it. Operators are expected to compose at
least one of:

1. **Network controls** — a network policy or ingress configuration
   that only routes `/_introspect` from the trusted aggregator's pod
   or subnet. External ingress should expose only `/mcp/*` and the
   well-known PRM document.
2. **Application-layer shared bearer** — set
   `LOOKER_MCP_INTROSPECT_BEARER`. When set, all three methods
   (POST / GET / DELETE) require `Authorization: Bearer <value>`
   and 401 otherwise. The aggregator is configured with the same
   token out-of-band.

When the env var is unset (default) the endpoint is open and the
operator is implicitly relying on network-layer isolation. That
default is appropriate for cluster deployments where the network
boundary is already drawn at the ingress layer.

## Transport surface

The MCP Streamable HTTP client opens a `GET` on connect (for
server-initiated notifications) and sends a `DELETE` on session
teardown. The discovery endpoint has no notifications and holds no
session state, but accepts both to avoid 405 log spam on every
discovery cycle:

- `GET /_introspect`    → 204 No Content
- `DELETE /_introspect` → 200 OK

## Wiring

- `create_server` mounts the route only on `streamable-http`
  transport — `stdio` deployments don't sit behind a gateway and
  don't need it.
- `PublicModeAuthMiddleware` exempts `/_introspect` from its
  OAuth 2.1 resource-server token check (the route enforces its own
  optional bearer instead).

## Cited precedent

- [Strawberry GraphQL Federation](https://strawberry.rocks/docs/guides/federation)
- Apollo Federation v1

## Test plan

- [x] `tests/test_introspect.py` — 26 new tests covering the JSON-RPC
      handshake, method guard, malformed-input handling, the
      GET/DELETE transport surface, bearer-guard composition,
      OAuth 2.1 middleware bypass, and `create_server` factory
      wiring (HTTP mounts, stdio omits).
- [x] Full suite: `uv run pytest` — 407 passed.
- [x] `uv run ruff format --check src tests` clean.
- [x] `uv run ruff check src tests` clean.
- [x] `uv run pyright src tests` — 0 errors, 0 warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a host-root `/_introspect` discovery endpoint for MCP clients (supports `initialize`, `notifications/initialized`, `tools/list`).
  * Optional shared-bearer protection configurable via env var; wrong/missing token returns `401`.
  * Endpoint behavior: `POST` JSON‑RPC responses, `GET` → `204`, `DELETE` → `200`.
  * Session ID echoed/tracked across requests.
  * Endpoint is available only for HTTP transport and remains accessible in public mode.

* **Documentation**
  * Changelog updated describing the new discovery endpoint and auth behavior.

* **Tests**
  * End-to-end tests added to validate discovery, errors, auth, and transport behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->