### PR TITLE
chore(release): prepare v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-24
+
+Two changes targeting deployments where this server sits behind a
+gateway aggregator that fronts multiple MCP servers. First, a new
+host-root **`/_introspect`** route serves the MCP discovery slice
+(`initialize`, `notifications/initialized`, `tools/list`) without
+requiring a user JWT, so the aggregator can populate its tool
+catalog at registration time without holding service-account
+credentials at this backend — `tools/call` is rejected
+(`-32601`); execution still flows through `/mcp` where the user
+JWT validates. The route is open by default and operators are
+expected to compose at least one of (a) network controls
+restricting ingress to `/_introspect` to the trusted aggregator's
+pod or subnet, and (b) the optional `LOOKER_MCP_INTROSPECT_BEARER`
+env var, which when set requires `Authorization: Bearer <value>`
+on all three methods (POST, GET, DELETE) and 401s otherwise. The
+endpoint is mounted only on `streamable-http` transport; `stdio`
+deployments don't sit behind a gateway and don't get the route.
+Second, **`/readyz`** no longer requires `LOOKER_CLIENT_ID` /
+`LOOKER_CLIENT_SECRET` in external-identity deployments (OAuth
+pass-through, sudo-by-header) where per-request user tokens supply
+auth at tool-invoke time. With service-account credentials
+configured, behavior is unchanged (live login/logout cycle);
+without them, the probe issues a no-auth `HEAD` against
+`LOOKER_BASE_URL` and returns 503 only on transport-layer failures
+(DNS, connection refused, TLS error, timeout) — fixing a
+fail-closed bug where K8s readiness probes would 503 forever and
+roll back atomic Helm installs.
+
 ### Added
 
 - **Host-root `/_introspect` endpoint for gateway tool discovery

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.18.0"
+version = "0.19.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.18.0"
+version = "0.19.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Minor release. Two changes from this cycle, both targeting deployments
where this server sits behind a gateway aggregator:

- **`feat(server)`: host-root `/_introspect` endpoint for gateway tool
  discovery** (#47). New MCP discovery-slice route at host root —
  serves `initialize` + `notifications/initialized` + `tools/list`
  without requiring a user JWT. `tools/call` rejected; execution
  still flows through `/mcp`. Open by default; operators compose
  network controls and/or the optional `LOOKER_MCP_INTROSPECT_BEARER`
  shared-bearer env var. Mounted only on `streamable-http` transport.
- **`fix(server)`: `/readyz` no longer requires API3 credentials in
  external-identity mode** (#46). Probe branches on whether
  `LOOKER_CLIENT_ID` / `LOOKER_CLIENT_SECRET` are configured. With
  them, behavior is unchanged (live login/logout cycle); without
  them, the probe issues a no-auth `HEAD` against `LOOKER_BASE_URL`.
  Fixes a fail-closed bug where K8s readiness probes would 503
  forever and roll back atomic Helm installs.

## SemVer rationale

Minor bump (`0.18.0` → `0.19.0`):
- New public route (`/_introspect`) — additive.
- New environment variable (`LOOKER_MCP_INTROSPECT_BEARER`) — additive.
- New exported function and constants
  (`register_introspect_endpoint`, `MCP_PROTOCOL_VERSION`,
  `INTROSPECT_BEARER_ENV`) — additive.
- `/readyz` behavior change is bug-fix-shaped (fail-closed → correct
  branching), but folds into the minor.

No breaking changes.

## Mechanics

- `pyproject.toml`: `0.18.0` → `0.19.0`.
- `uv.lock`: regenerated via `uv sync --dev` (only the project's own
  version line changed).
- `CHANGELOG.md`: `## [Unreleased]` content promoted into a new
  `## [0.19.0] - 2026-05-24` section with a narrative summary
  prefix matching the PR45 / v0.18.0 release-prep pattern. A fresh
  empty `## [Unreleased]` is left above for future queueing.

## Post-merge

Tag `v0.19.0` on the merge commit and push — `release.yml` triggers
on `v*` tag push, runs the test matrix across Py 3.11/3.12/3.13,
and publishes to PyPI.

## Test plan

- [x] `uv run pytest` — 419 passed.
- [x] `uv run ruff format --check src tests` clean.
- [x] `uv run ruff check src tests` clean.
- [x] `uv run pyright src tests` — 0 errors, 0 warnings.
- [x] `tests/test_introspect.py::test_http_transport_mounts_introspect`
      passes — confirms `importlib.metadata.version("looker-mcp-server")`
      now resolves to `0.19.0` end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/_introspect` endpoint for MCP tool discovery
* **Improvements**
  * Updated `/readyz` endpoint to work without LOOKER_CLIENT_ID and LOOKER_CLIENT_SECRET in external-identity deployments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->