### PR TITLE
feat: add looker_oauth mode (Looker as its own authorization server, opaque per-user tokens)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-28
+
+Adds a third MCP-level authentication posture, `LOOKER_MCP_MODE=looker_oauth`,
+in which **Looker itself is the authorization server** and the MCP server
+holds **no admin API3 credentials and no sudo capability**. A client runs a
+Looker PKCE flow directly against the Looker instance, obtains an **opaque**
+per-user Looker access token, and presents it as `Authorization: Bearer
+<token>`. The server advertises Looker (the `LOOKER_BASE_URL`) as the
+authorization server in its RFC 9728 Protected Resource Metadata, verifies
+every inbound token by calling Looker's `GET /user` introspection endpoint
+(accept iff Looker returns a valid user; fail-closed otherwise), and forwards
+the verified token to Looker as the session token so the user's own Looker
+permissions govern every call. This sidesteps the `X-User-*` identity envelope
+entirely and requires `LOOKER_BASE_URL` plus `LOOKER_MCP_RESOURCE_URI` (this
+MCP server's own public URI) — no JWKS, issuer, or service-account
+configuration.
+
+### Added
+
+- **`LOOKER_MCP_MODE=looker_oauth` — Looker-as-its-own-authorization-server,
+  opaque-token, no-credential posture.** Selectable by configuration; requires
+  `LOOKER_BASE_URL` and `LOOKER_MCP_RESOURCE_URI` (both absolute `https://`
+  URLs — Looker's instance and this MCP server's own public URI). Concretely:
+  - **Provider selection** — `create_server` selects a no-credential
+    `OAuthIdentityProvider` that reads the bearer straight from the
+    `Authorization` header (stripping the `Bearer` scheme) and forwards it to
+    Looker as an `oauth`-mode session token. No fallback credentials and no
+    `act_as_user` admin-sudo wrapper (this posture has no admin identity to
+    impersonate with), so a tokenless request fails rather than borrowing a
+    shared identity.
+  - **PRM target** — the RFC 9728 Protected Resource Metadata document
+    advertises the Looker base URL as `authorization_servers[0]`, so MCP
+    clients auto-discover Looker's OAuth endpoints and run PKCE there. The
+    `resource` identifier is the required `LOOKER_MCP_RESOURCE_URI` (this MCP
+    server's own public URI — it must not point at Looker's host, since the
+    MCP server itself serves the PRM).
+  - **Opaque-token inbound** — a new ASGI gate
+    (`LookerOAuthAuthMiddleware`, in `oidc/looker_introspection.py`) verifies
+    each request's opaque bearer via Looker `GET /user` introspection
+    (`LookerUserIntrospector`). Accepted iff Looker returns a user; 401
+    `invalid_token` on rejected/expired tokens, non-200 responses, non-JSON
+    bodies, missing user id, or Looker transport failures (fail-closed). The
+    gate mirrors the `public`-mode contract: 400 on URL-query bearers (OAuth
+    2.1 §5.1.1), realm-bearing `WWW-Authenticate` challenges on 401, anonymous
+    `/.well-known/*` + `/healthz` + `/readyz` + `/_introspect`. On success the
+    `Authorization` header is left intact for the downstream identity provider.
+  - **Config posture validation** — a new `model_validator` requires
+    `LOOKER_BASE_URL` **and** `LOOKER_MCP_RESOURCE_URI` (both `https://`; the
+    resource URI is this MCP server's own canonical URI — the RFC 9728 PRM
+    `resource` and the host of the `resource_metadata` challenge URL — so it
+    cannot default to Looker's host), but **not** `LOOKER_MCP_JWKS_URI` /
+    `LOOKER_MCP_ISSUER_URL`. A static `LOOKER_MCP_AUTH_TOKEN` is rejected at
+    startup (it would defeat the per-user identity). New `PostureErrorKind`
+    values: `looker_oauth_missing_base_url`, `looker_oauth_base_url_not_https`,
+    `looker_oauth_base_url_invalid`, `looker_oauth_missing_resource_uri`,
+    `looker_oauth_static_bearer_forbidden`.
+
+  Note: the `looker_oauth` route is mounted only on `streamable-http`
+  transport, consistent with the `public`-mode auth gate; `stdio` deployments
+  are unaffected.
+
 ## [0.19.0] - 2026-05-24
 
 Two changes targeting deployments where this server sits behind a
@@ -936,6 +997,10 @@ infrastructure / deployment-posture release, not a tool surface expansion.
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
+[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.20.0...HEAD
+[0.20.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.19.0...v0.20.0
+[0.19.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.18.0...v0.19.0
+[0.18.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.14.0...v0.15.0
@@ -947,6 +1012,7 @@ infrastructure / deployment-posture release, not a tool surface expansion.
 [0.9.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ All settings are configured via environment variables with the `LOOKER_` prefix,
 | `LOOKER_MAX_ROWS` | `5000` | Default maximum rows for query tools |
 | `LOOKER_VERIFY_SSL` | `true` | Verify TLS certificates |
 | `LOOKER_LOG_LEVEL` | `INFO` | Logging level |
-| `LOOKER_MCP_MODE` | `dev` | `dev` (permissive) or `public` (OAuth 2.1 resource-server, MCP 2025-11-25). See [MCP-Level Authentication](#mcp-level-authentication). |
+| `LOOKER_MCP_MODE` | `dev` | `dev` (permissive), `public` (OAuth 2.1 resource-server, MCP 2025-11-25), or `looker_oauth` (Looker-as-authorization-server, opaque per-user tokens). See [MCP-Level Authentication](#mcp-level-authentication). |
 | `LOOKER_MCP_JWKS_URI` | | Authorization server JWK Set URL (RFC 7517). **Required when `LOOKER_MCP_MODE=public`.** Must be an `https://` URL. |
 | `LOOKER_MCP_ISSUER_URL` | | Expected `iss` claim (RFC 8414). **Required when `LOOKER_MCP_MODE=public`.** Must be an `https://` URL. |
-| `LOOKER_MCP_RESOURCE_URI` | | This server's canonical URI for RFC 8707 audience binding and the RFC 9728 PRM `resource` field. **Required when `LOOKER_MCP_MODE=public`.** Must be an `https://` URL without fragment. |
+| `LOOKER_MCP_RESOURCE_URI` | | This server's canonical URI for RFC 8707 audience binding and the RFC 9728 PRM `resource` field. **Required when `LOOKER_MCP_MODE=public` or `looker_oauth`** (in `looker_oauth` it is this MCP server's own public URI — the host of the `resource_metadata` PRM URL — and has no default, since it must not point at Looker's host). Must be an `https://` URL without fragment. |
 | `LOOKER_MCP_AUTH_TOKEN` | | Static bearer token for MCP-level authentication. **Deprecated** — emits a warning in `dev` mode, rejected outright in `public` mode (RFC 9068 §2.1 forbids symmetric static bearers for OAuth 2.1 access tokens). Scheduled for removal in a future major release; migrate to `LOOKER_MCP_MODE=public`. |
 
 ## Authentication & Impersonation
@@ -399,7 +399,7 @@ The `RequestContext` provides:
 
 ## MCP-Level Authentication
 
-MCP-level authentication (who can connect to the server) has two modes, selected by `LOOKER_MCP_MODE`.
+MCP-level authentication (who can connect to the server) has three modes, selected by `LOOKER_MCP_MODE`.
 
 ### `LOOKER_MCP_MODE=dev` (default) — permissive
 
@@ -431,6 +431,30 @@ export LOOKER_MCP_RESOURCE_URI="https://looker-mcp.example.com/mcp"
 ```
 
 All three URIs must be absolute `https://` URLs; the server fails closed at startup with a typed `DeploymentPostureError` if any are missing, malformed, or use `http://`. The `LOOKER_MCP_RESOURCE_URI` must not carry a fragment (RFC 9728 §3).
+
+### `LOOKER_MCP_MODE=looker_oauth` — Looker is the authorization server
+
+For deployments where you want **Looker itself** to be the authorization server and the MCP server to hold **no admin credentials and no sudo capability** at all. The client runs a Looker PKCE flow directly against the Looker instance, obtains an **opaque** per-user Looker access token, and presents it to the MCP server as `Authorization: Bearer <opaque-token>`. The server:
+
+- Advertises **Looker** (the `LOOKER_BASE_URL`) as the authorization server in its RFC 9728 Protected Resource Metadata, so MCP clients auto-discover the Looker OAuth endpoints to run PKCE against.
+- Verifies every inbound token by calling Looker's `GET /user` introspection endpoint — the request is accepted **iff** Looker returns a valid user, and rejected (401 `invalid_token`) on an expired / revoked / malformed token, a non-200 response, or a Looker transport failure (fail-closed).
+- Forwards the verified opaque token to Looker as the session token, so the **user's own Looker permissions** govern every API call. This sidesteps the `X-User-*` identity envelope entirely.
+- Keeps the same HTTP contract as `public` mode: 400 on URL-query bearers (OAuth 2.1 §5.1.1), realm-bearing `WWW-Authenticate` challenges on 401, anonymous `/.well-known/*` + `/healthz` + `/readyz` + `/_introspect`.
+- **Rejects `LOOKER_MCP_AUTH_TOKEN` outright** — a shared static bearer would defeat the per-user identity this posture exists to enforce.
+
+Required configuration (the Looker base URL + this MCP server's own public URI — no JWKS, issuer, or admin credentials):
+
+```bash
+export LOOKER_MCP_MODE=looker_oauth
+export LOOKER_BASE_URL="https://yourco.looker.com"   # Looker instance; must be https
+# This MCP server's own public URI: the RFC 9728 `resource` identifier and the
+# host of the `resource_metadata` PRM URL clients fetch. Must be this server,
+# NOT Looker — the MCP server serves the PRM. Required; no default.
+export LOOKER_MCP_RESOURCE_URI="https://looker-mcp.example.com/mcp"   # must be https
+export LOOKER_TRANSPORT=streamable-http
+```
+
+`LOOKER_BASE_URL` must be an absolute `https://` URL — opaque tokens travel over this connection and must not cross a plaintext hop. The server fails closed at startup with a typed `DeploymentPostureError` otherwise.
 
 #### Deprecation timeline for `LOOKER_MCP_AUTH_TOKEN`
 
@@ -490,7 +514,7 @@ When running in HTTP mode, the server exposes:
 
 - `GET /healthz` — liveness probe (always returns 200 if server is running)
 - `GET /readyz` — readiness probe (verifies Looker connectivity with a login/logout cycle)
-- `GET /.well-known/oauth-protected-resource` — RFC 9728 Protected Resource Metadata (only when `LOOKER_MCP_MODE=public`). When `LOOKER_MCP_RESOURCE_URI` has a path, the same document is also served at `/.well-known/oauth-protected-resource<resource-path>` — that is the spec-canonical URL per RFC 9728 §3, and the one referenced by `resource_metadata=...` in 401 `WWW-Authenticate` challenges.
+- `GET /.well-known/oauth-protected-resource` — RFC 9728 Protected Resource Metadata (served when `LOOKER_MCP_MODE=public` or `LOOKER_MCP_MODE=looker_oauth`). In `public` mode it advertises the configured `LOOKER_MCP_ISSUER_URL` as the authorization server; in `looker_oauth` mode it advertises the Looker base URL. When the resource identifier has a path, the same document is also served at `/.well-known/oauth-protected-resource<resource-path>` — that is the spec-canonical URL per RFC 9728 §3, and the one referenced by `resource_metadata=...` in 401 `WWW-Authenticate` challenges.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.19.0"
+version = "0.20.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/config.py
+++ b/src/looker_mcp_server/config.py
@@ -18,6 +18,7 @@ class LookerMcpMode(StrEnum):
 
     DEV = "dev"
     PUBLIC = "public"
+    LOOKER_OAUTH = "looker_oauth"
 
 
 class PostureErrorKind(StrEnum):
@@ -33,6 +34,11 @@ class PostureErrorKind(StrEnum):
     PUBLIC_RESOURCE_URI_NOT_HTTPS = "public_resource_uri_not_https"
     PUBLIC_RESOURCE_URI_MALFORMED = "public_resource_uri_malformed"
     PUBLIC_STATIC_BEARER_FORBIDDEN = "public_static_bearer_forbidden"
+    LOOKER_OAUTH_MISSING_BASE_URL = "looker_oauth_missing_base_url"
+    LOOKER_OAUTH_BASE_URL_NOT_HTTPS = "looker_oauth_base_url_not_https"
+    LOOKER_OAUTH_BASE_URL_INVALID = "looker_oauth_base_url_invalid"
+    LOOKER_OAUTH_MISSING_RESOURCE_URI = "looker_oauth_missing_resource_uri"
+    LOOKER_OAUTH_STATIC_BEARER_FORBIDDEN = "looker_oauth_static_bearer_forbidden"
 
 
 def _is_absolute_https_url(value: str) -> bool:
@@ -192,6 +198,22 @@ class LookerConfig(BaseSettings):
       authorization requirements — OAuth 2.1 resource server with RS256/ES256
       JWKS-based token validation. Static-bearer mode is rejected at
       startup; RFC 9068 §2.1 forbids symmetric signing for access tokens.
+    - ``looker_oauth``: Looker-as-its-own-authorization-server posture. The
+      MCP server holds NO admin API3 credentials and NO sudo capability. A
+      client runs a Looker PKCE flow directly against the Looker instance,
+      obtains an **opaque** per-user Looker access token, and presents it as
+      ``Authorization: Bearer <opaque-token>``. The server advertises Looker
+      (not a separate JWKS-backed OIDC issuer) as the authorization server in
+      its RFC 9728 Protected Resource Metadata, and verifies every inbound
+      token by calling Looker's ``GET /user`` introspection endpoint —
+      accepting iff Looker returns a valid user. The verified token is then
+      forwarded as the Looker session token, so the user's own Looker
+      permissions govern every API call. This sidesteps the ``X-User-*``
+      identity envelope and the JWKS/issuer machinery entirely; it requires
+      ``LOOKER_BASE_URL`` plus ``LOOKER_MCP_RESOURCE_URI`` (this MCP server's
+      own public URI — the PRM ``resource`` and the ``resource_metadata``
+      host; it has no default and must not point at Looker's host). Static-
+      bearer mode is rejected at startup (it would bypass per-user identity).
     """
 
     mcp_auth_token: str = ""
@@ -379,6 +401,102 @@ class LookerConfig(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _validate_looker_oauth_mode_posture(self) -> Self:
+        """Enforce the invariants of the Looker-as-authorization-server posture.
+
+        Only runs in :attr:`LookerMcpMode.LOOKER_OAUTH`. Unlike ``public``
+        mode, this posture does NOT require ``mcp_jwks_uri`` / ``mcp_issuer_url``
+        — Looker itself is the authorization server and the inbound token is an
+        opaque Looker access token verified via ``GET /user`` introspection, not
+        a JWKS-validated JWT. It DOES require ``mcp_resource_uri`` in addition to
+        ``LOOKER_BASE_URL``: the resource URI is this MCP server's own canonical
+        URI (the RFC 9728 ``resource`` and the host of the ``resource_metadata``
+        challenge URL) and cannot default to Looker's host, since the MCP
+        server — not Looker — serves the PRM. ``LOOKER_BASE_URL`` is the Looker
+        introspection target and the OAuth-endpoint base advertised in the PRM.
+        Static-bearer mode is forbidden because it would bypass the per-user
+        identity the whole posture exists to enforce.
+        """
+        if self.mcp_mode != LookerMcpMode.LOOKER_OAUTH:
+            return self
+
+        # A static bearer is a single shared credential with no per-user
+        # identity — the antithesis of this posture, where every request
+        # carries the calling user's own opaque Looker token. Fail closed.
+        if self.mcp_auth_token:
+            raise DeploymentPostureError(
+                PostureErrorKind.LOOKER_OAUTH_STATIC_BEARER_FORBIDDEN,
+                "LOOKER_MCP_AUTH_TOKEN is set but LOOKER_MCP_MODE=looker_oauth "
+                "forbids a shared static bearer: this posture authenticates "
+                "each request by its per-user opaque Looker token. Unset "
+                "LOOKER_MCP_AUTH_TOKEN, or switch to LOOKER_MCP_MODE=dev.",
+            )
+
+        # ``base_url`` is normalized by ``_strip_trailing_slash`` already, so
+        # the stored attribute IS the canonical value we validate against.
+        if not self.base_url:
+            raise DeploymentPostureError(
+                PostureErrorKind.LOOKER_OAUTH_MISSING_BASE_URL,
+                "LOOKER_MCP_MODE=looker_oauth requires LOOKER_BASE_URL — the "
+                "Looker instance is both the token-introspection target "
+                "(GET /user) and the authorization server advertised in the "
+                "RFC 9728 Protected Resource Metadata.",
+            )
+        if not _is_absolute_https_url(self.base_url):
+            raise DeploymentPostureError(
+                PostureErrorKind.LOOKER_OAUTH_BASE_URL_NOT_HTTPS,
+                f"LOOKER_BASE_URL={self.base_url!r} must be an absolute https "
+                "URL in looker_oauth mode — opaque access tokens travel over "
+                "this connection and MUST NOT cross a plaintext hop.",
+            )
+        base_parsed = urlparse(self.base_url)
+        if base_parsed.query or base_parsed.fragment:
+            raise DeploymentPostureError(
+                PostureErrorKind.LOOKER_OAUTH_BASE_URL_INVALID,
+                f"LOOKER_BASE_URL={self.base_url!r} must be an https origin "
+                "without query or fragment components — it is joined with "
+                "'/api/<ver>/user' for token introspection, which a query or "
+                "fragment would corrupt.",
+            )
+
+        # The MCP server's OWN canonical URI: the RFC 9728 ``resource`` and the
+        # host of the ``resource_metadata`` PRM URL advertised in 401
+        # challenges. REQUIRED in looker_oauth mode — the server cannot derive
+        # its own public URL, and defaulting to the Looker base URL would point
+        # clients at Looker's host for PRM discovery (the MCP server, not
+        # Looker, serves the PRM). Must be RFC 9728-safe when set.
+        if not self.mcp_resource_uri:
+            raise DeploymentPostureError(
+                PostureErrorKind.LOOKER_OAUTH_MISSING_RESOURCE_URI,
+                "LOOKER_MCP_MODE=looker_oauth requires LOOKER_MCP_RESOURCE_URI "
+                "— this MCP server's own public https URI. It is the RFC 9728 "
+                "`resource` identifier and the host of the `resource_metadata` "
+                "PRM URL clients fetch; it cannot default to LOOKER_BASE_URL "
+                "(that would direct clients to Looker's host for the PRM).",
+            )
+        parsed = urlparse(self.mcp_resource_uri)
+        if not parsed.scheme or not parsed.netloc:
+            raise DeploymentPostureError(
+                PostureErrorKind.PUBLIC_RESOURCE_URI_MALFORMED,
+                f"LOOKER_MCP_RESOURCE_URI={self.mcp_resource_uri!r} is not a valid absolute URI.",
+            )
+        if parsed.fragment:
+            raise DeploymentPostureError(
+                PostureErrorKind.PUBLIC_RESOURCE_URI_MALFORMED,
+                f"LOOKER_MCP_RESOURCE_URI={self.mcp_resource_uri!r} has a "
+                "fragment component; RFC 9728 §3 forbids fragments in the "
+                "resource identifier.",
+            )
+        if parsed.scheme != "https":
+            raise DeploymentPostureError(
+                PostureErrorKind.PUBLIC_RESOURCE_URI_NOT_HTTPS,
+                f"LOOKER_MCP_RESOURCE_URI={self.mcp_resource_uri!r} must use "
+                "the https scheme in looker_oauth mode — opaque tokens MUST "
+                "NOT cross a plaintext hop.",
+            )
+        return self
+
     def is_http(self) -> bool:
         return self.transport == "streamable-http"
 
@@ -386,3 +504,17 @@ class LookerConfig(BaseSettings):
     def api_url(self) -> str:
         """Full base URL for API requests (e.g. ``https://co.looker.com/api/4.0``)."""
         return f"{self.base_url}/api/{self.api_version}"
+
+    @property
+    def looker_oauth_resource_uri(self) -> str:
+        """This MCP server's canonical URI, advertised in the ``looker_oauth``
+        PRM as the RFC 9728 ``resource`` and used as the host of the
+        ``resource_metadata`` URL in 401 challenges.
+
+        Required via ``LOOKER_MCP_RESOURCE_URI`` (validated at startup) — it
+        must be the MCP server's OWN public URI, not Looker's: the MCP server
+        serves the PRM, so the challenge's ``resource_metadata`` URL must
+        resolve back to this server. Looker is advertised separately as the
+        authorization server.
+        """
+        return self.mcp_resource_uri

--- a/src/looker_mcp_server/identity.py
+++ b/src/looker_mcp_server/identity.py
@@ -306,7 +306,22 @@ class OAuthIdentityProvider:
     cannot be impersonated via sudo.  A gateway or MCP OAuth flow supplies
     the token.
 
-    Falls back to API-key mode when no token header is present.
+    Two carriage shapes are supported, selected by ``strip_bearer_scheme``:
+
+    - **Bare token** (default) — the header value IS the token. This is the
+      ``X-User-Token`` shape a gateway uses after exchanging the user's
+      identity for a Looker token out-of-band.
+    - **``Authorization: Bearer <token>``** (``strip_bearer_scheme=True``) —
+      the header carries the standard ``Bearer`` scheme prefix, which is
+      stripped before use. This is the ``LOOKER_MCP_MODE=looker_oauth``
+      shape, where the client presents its opaque Looker access token
+      directly in the ``Authorization`` header (no gateway exchange).
+
+    When ``fallback_client_id`` / ``fallback_client_secret`` are configured
+    and no token is present, the provider falls back to API-key mode.
+    Otherwise a missing token raises ``PermissionError`` — the no-credential
+    ``looker_oauth`` posture deliberately omits the fallback so an
+    unauthenticated request can never silently borrow a shared identity.
     """
 
     def __init__(
@@ -314,13 +329,33 @@ class OAuthIdentityProvider:
         token_header: str = "X-User-Token",
         fallback_client_id: str | None = None,
         fallback_client_secret: str | None = None,
+        *,
+        strip_bearer_scheme: bool = False,
     ) -> None:
         self._header = token_header.lower()
         self._fallback_id = fallback_client_id
         self._fallback_secret = fallback_client_secret
+        self._strip_bearer_scheme = strip_bearer_scheme
 
     async def resolve(self, context: RequestContext) -> LookerIdentity:
         token = context.headers.get(self._header)
+        if token and self._strip_bearer_scheme:
+            scheme, sep, rest = token.partition(" ")
+            if sep:
+                # A scheme prefix is present: it MUST be a non-empty Bearer
+                # token. A non-Bearer scheme (e.g. ``Basic abc``) or an empty
+                # bearer (``Bearer ``) is a failed auth attempt — reject it
+                # outright. Nulling the token instead would let a malformed
+                # header silently fall through to API-key / service-account
+                # fallback, downgrading a botched auth attempt to shared creds.
+                rest = rest.strip()
+                if scheme.lower() != "bearer" or not rest:
+                    raise PermissionError(
+                        "Malformed Authorization header: expected 'Bearer <token>'."
+                    )
+                token = rest
+            # A bare, schemeless token (no space) passes through unchanged —
+            # the documented convenience for clients that omit ``Bearer ``.
         if token:
             return LookerIdentity(mode="oauth", access_token=token)
 

--- a/src/looker_mcp_server/main.py
+++ b/src/looker_mcp_server/main.py
@@ -18,9 +18,14 @@ from typing import Any
 
 import structlog
 
-from .config import ALL_GROUPS, DEFAULT_GROUPS, LookerConfig
+from .config import ALL_GROUPS, DEFAULT_GROUPS, LookerConfig, LookerMcpMode
 from .middleware import HeaderCaptureMiddleware
-from .server import build_public_mode_middleware, create_server, parse_groups
+from .server import (
+    build_looker_oauth_mode_middleware,
+    build_public_mode_middleware,
+    create_server,
+    parse_groups,
+)
 
 logger = structlog.get_logger()
 
@@ -74,6 +79,21 @@ def cli() -> None:
 
 async def run(config: LookerConfig, groups: set[str]) -> None:
     """Start the server with graceful shutdown handling."""
+    # ``public`` and ``looker_oauth`` are HTTP-only auth postures: their
+    # authentication gate is mounted only on the streamable-http transport
+    # (below). Pairing either with stdio would silently start the server with
+    # NO MCP-layer authentication, so fail fast at startup rather than ship
+    # that misconfiguration and surface it as unauthenticated access.
+    if (
+        config.mcp_mode in (LookerMcpMode.PUBLIC, LookerMcpMode.LOOKER_OAUTH)
+        and not config.is_http()
+    ):
+        raise SystemExit(
+            f"LOOKER_MCP_MODE={config.mcp_mode.value} requires "
+            "LOOKER_TRANSPORT=streamable-http — its authentication gate is "
+            "HTTP-only; stdio would run unauthenticated."
+        )
+
     # ── MCP-level auth (optional bearer token) ───────────────────────
     auth: Any = None
     if config.mcp_auth_token:
@@ -103,15 +123,20 @@ async def run(config: LookerConfig, groups: set[str]) -> None:
         kwargs["transport"] = "streamable-http"
         kwargs["host"] = config.host
         kwargs["port"] = config.port
-        # Composition order matters: PublicModeAuthMiddleware (when
+        # Composition order matters: the mode-specific auth gate (when
         # present) runs FIRST so unauthenticated requests are rejected
         # before HeaderCaptureMiddleware copies anything into the
-        # request-scoped ContextVar. In dev mode the returned value is
-        # None and the chain is just [HeaderCaptureMiddleware] as before.
+        # request-scoped ContextVar. ``public`` mode validates a JWKS-backed
+        # JWT; ``looker_oauth`` mode introspects an opaque Looker token via
+        # ``GET /user``. At most one is non-None for a given config. In dev
+        # mode both return None and the chain is just
+        # [HeaderCaptureMiddleware] as before.
         middleware: list[Middleware] = []
-        public_auth = build_public_mode_middleware(config)
-        if public_auth is not None:
-            middleware.append(public_auth)
+        auth_gate = build_public_mode_middleware(config) or build_looker_oauth_mode_middleware(
+            config
+        )
+        if auth_gate is not None:
+            middleware.append(auth_gate)
         middleware.append(Middleware(HeaderCaptureMiddleware))
         kwargs["middleware"] = middleware
     else:

--- a/src/looker_mcp_server/oidc/__init__.py
+++ b/src/looker_mcp_server/oidc/__init__.py
@@ -9,18 +9,31 @@ Modules:
   per RFC 8707 §2. Issuer binding per RFC 8414.
 - :mod:`looker_mcp_server.oidc.prm` — Protected Resource Metadata document
   (RFC 9728 §2) + route factory.
+- :mod:`looker_mcp_server.oidc.looker_introspection` — opaque-token verifier
+  + ASGI gate for ``LOOKER_MCP_MODE=looker_oauth``, where Looker is its own
+  authorization server and the inbound bearer is an opaque Looker access
+  token verified via ``GET /user`` (this module IS Looker-specific, unlike
+  the rest of the package — see below).
 - :mod:`looker_mcp_server.oidc.www_authenticate` — 401/403 challenge
   builders. ``realm=`` is mandatory per RFC 7235 §4.1; ``quoted-string``
   escaping follows RFC 7230 §3.2.6.
 
-Nothing in this package imports Looker-specific types — the primitives
-are vendor-neutral and suitable for reuse by adopters building their own
-resource servers against the same spec family.
+With the sole exception of :mod:`~looker_mcp_server.oidc.looker_introspection`
+(the ``looker_oauth``-mode opaque-token verifier, which is inherently
+Looker-specific), nothing in this package imports Looker types — the JWT /
+JWKS / PRM primitives are vendor-neutral and suitable for reuse by adopters
+building their own resource servers against the same spec family.
 """
 
 from __future__ import annotations
 
 from .jwks import ALLOWED_SIGNING_ALGORITHMS, JWKSCache, JWKSError
+from .looker_introspection import (
+    LookerOAuthAuthMiddleware,
+    LookerUser,
+    LookerUserIntrospector,
+    OpaqueTokenVerificationError,
+)
 from .middleware import PublicModeAuthMiddleware
 from .prm import ProtectedResourceMetadata, build_prm_document
 from .resource_server import (
@@ -38,7 +51,11 @@ __all__ = [
     "ALLOWED_SIGNING_ALGORITHMS",
     "JWKSCache",
     "JWKSError",
+    "LookerOAuthAuthMiddleware",
+    "LookerUser",
+    "LookerUserIntrospector",
     "OAuth21ResourceServer",
+    "OpaqueTokenVerificationError",
     "ProtectedResourceMetadata",
     "PublicModeAuthMiddleware",
     "TokenVerificationError",

--- a/src/looker_mcp_server/oidc/looker_introspection.py
+++ b/src/looker_mcp_server/oidc/looker_introspection.py
@@ -1,0 +1,321 @@
+"""Opaque-token introspection for ``LOOKER_MCP_MODE=looker_oauth``.
+
+In the Looker-as-authorization-server posture the inbound bearer is an
+**opaque** Looker access token, not a JWT — there is no signature to verify
+against a JWKS, no ``iss``/``aud`` claims to bind. The token is validated the
+way Looker itself validates it: by presenting it to the Looker API and asking
+"who is this?" via ``GET /user`` (RFC 7662-style introspection against the
+resource owner). Looker answers 200 with the user record when the token is
+live and authorized, and 401/403 when it is expired, revoked, or malformed.
+
+The two pieces here:
+
+- :class:`LookerUserIntrospector` — the vendor-specific verifier. Calls
+  ``GET {base_url}/api/{api_version}/user`` with the presented bearer and
+  returns a :class:`LookerUser` on success, raising
+  :class:`OpaqueTokenVerificationError` otherwise.
+- :class:`LookerOAuthAuthMiddleware` — the ASGI gate. Mirrors
+  :class:`~looker_mcp_server.oidc.middleware.PublicModeAuthMiddleware`'s
+  contract (same bypass paths, same bearer-in-query 400, same 401 challenge
+  shape) but swaps JWT validation for opaque-token introspection. On success
+  it leaves the ``Authorization`` header untouched so the downstream
+  identity provider can forward the same token to Looker as the session
+  token — the user's own Looker permissions then govern every API call.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import parse_qs
+
+import httpx
+
+from .www_authenticate import invalid_token_challenge
+
+logger = logging.getLogger(__name__)
+
+# ASGI 3.0 type aliases, spelled out so the module is self-contained.
+Scope = dict[str, Any]
+Receive = Callable[[], Awaitable[dict[str, Any]]]
+Send = Callable[[dict[str, Any]], Awaitable[None]]
+ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
+
+
+# Paths that bypass token validation — parity with the public-mode gate.
+# Public by design (discovery / health probes) or self-guarding
+# (``/_introspect`` runs its own optional shared-bearer check).
+_BYPASS_PREFIXES: tuple[str, ...] = (
+    "/.well-known/",
+    "/healthz",
+    "/readyz",
+    "/_introspect",
+)
+
+
+class OpaqueTokenVerificationError(Exception):
+    """Raised when an opaque Looker token fails introspection.
+
+    Deliberately coarse — the HTTP boundary collapses every failure mode
+    (expired, revoked, malformed, Looker unreachable) into a single
+    ``invalid_token`` 401 so an unauthenticated caller learns nothing about
+    which specific check failed.
+    """
+
+
+@dataclass(frozen=True)
+class LookerUser:
+    """The minimal identity slice :class:`LookerUserIntrospector` extracts.
+
+    Looker's ``/user`` response is large; we keep only the fields a caller
+    plausibly needs for audit/logging. ``id`` is always present on a valid
+    response; the rest are best-effort.
+    """
+
+    id: str
+    email: str | None = None
+    display_name: str | None = None
+
+
+class LookerUserIntrospector:
+    """Verify an opaque Looker access token by calling ``GET /user``.
+
+    Args:
+        base_url: Looker instance base URL (e.g. ``https://co.looker.com``).
+            Combined with ``api_version`` to form the introspection URL.
+        api_version: Looker API version path segment (default ``4.0``).
+        verify_ssl: Verify TLS on the introspection call. Mirrors the
+            client-wide ``LOOKER_VERIFY_SSL`` setting.
+        timeout_seconds: Per-introspection HTTP timeout.
+        http_client: Optional pre-built ``httpx.AsyncClient`` (tests inject
+            one; production lets the introspector lazily own a single reused
+            client for its lifetime).
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        api_version: str = "4.0",
+        verify_ssl: bool = True,
+        timeout_seconds: float = 10.0,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url must not be empty")
+        self._user_url = f"{base_url.rstrip('/')}/api/{api_version}/user"
+        self._verify_ssl = verify_ssl
+        self._timeout = timeout_seconds
+        self._client = http_client
+
+    async def verify(self, token: str) -> LookerUser:
+        """Introspect ``token`` against Looker. Returns the :class:`LookerUser`.
+
+        Raises:
+            OpaqueTokenVerificationError: On any failure — empty token,
+                Looker rejecting the token (401/403), Looker unreachable, or
+                a 200 response that doesn't carry a usable user ``id``.
+        """
+        if not token:
+            raise OpaqueTokenVerificationError("empty token")
+
+        headers = {"Authorization": f"token {token}"}
+        try:
+            # Reuse a single AsyncClient across introspections — a fresh client
+            # per token pays a new TCP+TLS handshake on every call. Lazily
+            # created on first use (race-free under asyncio: no await between
+            # the None-check and the assignment) and reused for the
+            # introspector's lifetime; an injected client (tests) is reused
+            # as-is. Never closed here — closing a shared client would break
+            # subsequent calls; it is released on process shutdown.
+            if self._client is None:
+                self._client = httpx.AsyncClient(timeout=self._timeout, verify=self._verify_ssl)
+            resp = await self._client.get(self._user_url, headers=headers, timeout=self._timeout)
+        except httpx.HTTPError as exc:
+            # Looker unreachable / TLS / timeout. Fail closed — never admit a
+            # token we couldn't actually verify.
+            logger.warning(
+                "looker_oauth.introspect.unreachable",
+                extra={"url": self._user_url, "error": str(exc)},
+            )
+            raise OpaqueTokenVerificationError("introspection request failed") from exc
+
+        if resp.status_code in (401, 403):
+            logger.info(
+                "looker_oauth.introspect.rejected",
+                extra={"status": resp.status_code},
+            )
+            raise OpaqueTokenVerificationError("token rejected by Looker")
+        if resp.status_code != 200:
+            logger.warning(
+                "looker_oauth.introspect.unexpected_status",
+                extra={"status": resp.status_code},
+            )
+            raise OpaqueTokenVerificationError(
+                f"unexpected introspection status {resp.status_code}"
+            )
+
+        try:
+            payload = resp.json()
+        except ValueError as exc:
+            raise OpaqueTokenVerificationError("introspection response not JSON") from exc
+
+        if not isinstance(payload, dict) or payload.get("id") is None:
+            raise OpaqueTokenVerificationError("introspection response missing user id")
+
+        return LookerUser(
+            id=str(payload["id"]),
+            email=payload.get("email"),
+            display_name=payload.get("display_name"),
+        )
+
+
+class LookerOAuthAuthMiddleware:
+    """ASGI gate for ``looker_oauth`` mode — opaque-token introspection.
+
+    Constructed with a :class:`LookerUserIntrospector` and the ``realm`` +
+    ``prm_url`` used to build ``WWW-Authenticate`` challenges. Behavior
+    mirrors :class:`~looker_mcp_server.oidc.middleware.PublicModeAuthMiddleware`
+    so operators see one consistent HTTP contract across postures:
+
+    - bearer-in-query → 400 ``invalid_request`` (OAuth 2.1 §5.1.1),
+    - bypass paths pass through anonymously,
+    - missing / malformed bearer → 401 with PRM-pointing challenge,
+    - failed introspection → 401 ``invalid_token``,
+    - success → request proceeds with the ``Authorization`` header intact so
+      the identity provider can forward the verified opaque token to Looker.
+      The resolved :class:`LookerUser` is stashed on
+      ``scope["state"]["looker_user"]`` for downstream audit/logging.
+    """
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        introspector: LookerUserIntrospector,
+        realm: str,
+        prm_url: str,
+    ) -> None:
+        if not realm:
+            raise ValueError("realm must not be empty")
+        if not prm_url:
+            raise ValueError("prm_url must not be empty")
+        self._app = app
+        self._introspector = introspector
+        self._realm = realm
+        self._prm_url = prm_url
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope.get("type") != "http":
+            await self._app(scope, receive, send)
+            return
+
+        # Bearer-in-query is a protocol violation regardless of path —
+        # checked before the bypass paths so /.well-known/* can't be used to
+        # sneak a forbidden query-string bearer past the gate.
+        if await self._reject_bearer_in_query(scope, send):
+            return
+
+        path: str = scope.get("path") or ""
+        if self._is_bypass_path(path):
+            await self._app(scope, receive, send)
+            return
+
+        header_value = _get_header(scope, b"authorization")
+        if header_value is None:
+            await self._reply_401(send, body_message="missing authorization")
+            return
+
+        scheme, _, token = header_value.partition(" ")
+        if scheme.lower() != "bearer" or not token:
+            await self._reply_401(send, body_message="missing or malformed Bearer token")
+            return
+
+        try:
+            user = await self._introspector.verify(token.strip())
+        except OpaqueTokenVerificationError:
+            await self._reply_401(send, body_message="invalid token")
+            return
+
+        state = scope.setdefault("state", {})
+        state["looker_user"] = user
+
+        await self._app(scope, receive, send)
+
+    @staticmethod
+    def _is_bypass_path(path: str) -> bool:
+        """Match-or-proper-sub-path check against the bypass prefixes.
+
+        A naive ``startswith`` would false-match ``/healthzfoo`` against
+        ``/healthz``; require either exact equality (trailing slash stripped)
+        or a ``/`` separator after the prefix.
+        """
+        for raw in _BYPASS_PREFIXES:
+            exact = raw.rstrip("/")
+            with_sep = exact + "/"
+            if path == exact or path.startswith(with_sep):
+                return True
+        return False
+
+    async def _reject_bearer_in_query(self, scope: Scope, send: Send) -> bool:
+        """OAuth 2.1 §5.1.1: bearer tokens in the URL query are forbidden.
+
+        Returns True when a rejection was sent (caller should return).
+        Parses parameter NAMES (not a substring match) so a benign value
+        containing ``access_token`` doesn't false-positive.
+        """
+        query_string: bytes = scope.get("query_string") or b""
+        if not query_string:
+            return False
+        params = parse_qs(query_string.decode("latin-1"), keep_blank_values=True)
+        if "access_token" in params or "authorization" in params:
+            body = json.dumps(
+                {
+                    "error": "invalid_request",
+                    "error_description": (
+                        "bearer tokens in the URL query string are forbidden "
+                        "(OAuth 2.1 §5.1.1); use the Authorization header"
+                    ),
+                }
+            ).encode("utf-8")
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 400,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send({"type": "http.response.body", "body": body})
+            return True
+        return False
+
+    async def _reply_401(self, send: Send, *, body_message: str) -> None:
+        challenge = invalid_token_challenge(realm=self._realm, resource_metadata_url=self._prm_url)
+        body = json.dumps({"error": "invalid_token", "error_description": body_message}).encode(
+            "utf-8"
+        )
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"www-authenticate", challenge.encode("latin-1")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+
+def _get_header(scope: Scope, name: bytes) -> str | None:
+    """Return the first header matching ``name`` (lowercase-compared)."""
+    for k, v in scope.get("headers") or []:
+        if k.lower() == name:
+            try:
+                return v.decode("latin-1")
+            except UnicodeDecodeError:  # pragma: no cover — HTTP headers are latin-1
+                return None
+    return None

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -15,6 +15,7 @@ from .identity import (
     ArgumentSudoIdentityProvider,
     DualModeIdentityProvider,
     IdentityProvider,
+    OAuthIdentityProvider,
 )
 
 logger = structlog.get_logger()
@@ -100,7 +101,21 @@ def create_server(
     caller_provided_provider = identity_provider is not None
 
     if identity_provider is None:
-        if config.sudo_as_user and config.client_id and config.client_secret:
+        if config.mcp_mode == LookerMcpMode.LOOKER_OAUTH:
+            # Looker-as-authorization-server posture: the server holds NO
+            # admin credentials and NO sudo. The inbound opaque Looker token
+            # (already introspected by the auth middleware) arrives in the
+            # standard ``Authorization: Bearer`` header; forward it verbatim
+            # as the Looker session token so the user's own permissions
+            # govern the call. No fallback credentials — a request that
+            # reaches a tool with no token must fail, never silently borrow a
+            # shared identity. The argument-sudo wrapper is intentionally
+            # skipped (it requires admin creds this posture doesn't have).
+            identity_provider = OAuthIdentityProvider(
+                token_header="Authorization",
+                strip_bearer_scheme=True,
+            )
+        elif config.sudo_as_user and config.client_id and config.client_secret:
             identity_provider = DualModeIdentityProvider(
                 client_id=config.client_id,
                 client_secret=config.client_secret,
@@ -125,7 +140,15 @@ def create_server(
         # would then see ``act_as_user`` calls succeed as the wrong
         # user). Transparent when ``act_as_user`` is absent; skipped
         # entirely for caller-supplied providers (caller owns auth chain).
-        if config.client_id and config.client_secret:
+        # ``looker_oauth`` is a no-credential / no-sudo posture: even if API3
+        # creds happen to be present in the environment, the OAuth provider
+        # must stay unwrapped, or act_as_user escalation would silently
+        # re-enable the very capability the posture exists to forbid.
+        if (
+            config.mcp_mode != LookerMcpMode.LOOKER_OAUTH
+            and config.client_id
+            and config.client_secret
+        ):
             identity_provider = ArgumentSudoIdentityProvider(
                 inner=identity_provider,
                 client_id=config.client_id,
@@ -224,14 +247,15 @@ def create_server(
 
     logger.info("looker.server.created", groups=registered)
 
-    # ── OIDC public-mode PRM route ──────────────────────────────────
-    # In ``LOOKER_MCP_MODE=public`` we serve the RFC 9728 Protected
-    # Resource Metadata document so MCP clients can auto-discover the
-    # authorization server after a 401. The token gate itself lives in
-    # ``PublicModeAuthMiddleware`` (wired into the HTTP transport by
-    # ``main.py`` via :func:`build_public_mode_middleware`); these
-    # routes are deliberately bypassed by that middleware's
-    # ``/.well-known/`` allowlist so discovery stays anonymous.
+    # ── OIDC PRM route (public + looker_oauth modes) ────────────────
+    # In ``LOOKER_MCP_MODE=public`` and ``LOOKER_MCP_MODE=looker_oauth`` we
+    # serve the RFC 9728 Protected Resource Metadata document so MCP clients
+    # can auto-discover the authorization server after a 401. The token gate
+    # itself lives in the mode-specific auth middleware (wired into the HTTP
+    # transport by ``main.py`` via :func:`build_public_mode_middleware` /
+    # :func:`build_looker_oauth_mode_middleware`); these routes are
+    # deliberately bypassed by that middleware's ``/.well-known/`` allowlist
+    # so discovery stays anonymous.
     #
     # RFC 9728 §3 constructs the PRM URL by inserting
     # ``/.well-known/oauth-protected-resource`` between the authority
@@ -245,15 +269,30 @@ def create_server(
     # - The root ``PRM_PATH`` stays available as a defensive fallback
     #   for clients that probe the origin well-known location before
     #   following the challenge hint.
-    if config.mcp_mode == LookerMcpMode.PUBLIC:
+    # ``looker_oauth`` mode also serves a PRM, but with Looker itself as the
+    # advertised authorization server (so the client runs a Looker PKCE flow)
+    # and the MCP server's own URI as the resource. ``public`` mode advertises
+    # the configured JWKS-backed OIDC issuer instead. Both share the same
+    # route-mounting + caching shape below.
+    if config.mcp_mode in (LookerMcpMode.PUBLIC, LookerMcpMode.LOOKER_OAUTH):
         from .oidc import build_prm_document
+
+        if config.mcp_mode == LookerMcpMode.PUBLIC:
+            prm_resource_uri = config.mcp_resource_uri
+            prm_authorization_server = config.mcp_issuer_url
+        else:
+            # In looker_oauth mode Looker is the authorization server — point
+            # clients at the Looker base URL so PKCE discovery resolves to
+            # Looker's own OAuth endpoints (RFC 8414 metadata under the base).
+            prm_resource_uri = config.looker_oauth_resource_uri
+            prm_authorization_server = config.base_url
 
         def _prm_response() -> Any:
             from starlette.responses import JSONResponse
 
             doc = build_prm_document(
-                resource_uri=config.mcp_resource_uri,
-                authorization_server_issuer_url=config.mcp_issuer_url,
+                resource_uri=prm_resource_uri,
+                authorization_server_issuer_url=prm_authorization_server,
             )
             return JSONResponse(
                 doc,
@@ -268,7 +307,7 @@ def create_server(
         async def prm_root(request: Any) -> Any:
             return _prm_response()
 
-        suffix_path = _well_known_prm_path(config.mcp_resource_uri)
+        suffix_path = _well_known_prm_path(prm_resource_uri)
         if suffix_path != PRM_PATH:
 
             @mcp.custom_route(suffix_path, methods=["GET"])
@@ -304,7 +343,14 @@ def create_server(
         #    impersonation header. Readiness here is a
         #    reachability-of-dependency check, not an auth check. Per-
         #    request auth is validated at tool-invoke time.
-        if config.client_id and config.client_secret:
+        # ``looker_oauth`` is credential-free end-to-end: leftover API3 creds in
+        # the environment must NOT turn readiness into a service-account login
+        # check. Force the reachability path in that mode regardless of creds.
+        if (
+            config.mcp_mode != LookerMcpMode.LOOKER_OAUTH
+            and config.client_id
+            and config.client_secret
+        ):
             ok = await client.check_connectivity()
             reason = "Cannot connect to Looker"
         else:
@@ -380,5 +426,57 @@ def build_public_mode_middleware(config: LookerConfig) -> Any | None:
         PublicModeAuthMiddleware,
         resource_server=resource_server,
         realm=config.mcp_resource_uri,
+        prm_url=prm_url,
+    )
+
+
+def build_looker_oauth_mode_middleware(config: LookerConfig) -> Any | None:
+    """Build the opaque-token introspection middleware for HTTP transport.
+
+    Returns a :class:`starlette.middleware.Middleware` wrapper ready for
+    FastMCP's ``run_async(middleware=[...])`` kwarg when
+    ``config.mcp_mode == LookerMcpMode.LOOKER_OAUTH``, or ``None`` in any
+    other mode.
+
+    Unlike :func:`build_public_mode_middleware`, the inbound bearer is an
+    **opaque** Looker access token (no JWT structure), so the gate verifies
+    it by calling Looker ``GET /user`` (introspection against the resource
+    owner) rather than validating a JWKS signature. The contract otherwise
+    matches the public-mode gate:
+
+    - 400 on URL-query bearer tokens (OAuth 2.1 §5.1.1).
+    - 401 (+ ``WWW-Authenticate`` challenge pointing at the PRM) on missing /
+      malformed / unverifiable tokens.
+    - Pass-through on ``/.well-known/*``, ``/healthz``, ``/readyz``,
+      ``/_introspect``.
+
+    On success the request proceeds with the ``Authorization`` header intact
+    so the no-credential ``OAuthIdentityProvider`` can forward the verified
+    token to Looker as the session token.
+
+    Like its public-mode sibling this is a pure helper so ``main.py`` can
+    thread the returned value into the middleware chain ahead of
+    :class:`HeaderCaptureMiddleware` (auth gate must run outermost).
+    """
+    if config.mcp_mode != LookerMcpMode.LOOKER_OAUTH:
+        return None
+
+    from starlette.middleware import Middleware
+
+    from .oidc import LookerOAuthAuthMiddleware, LookerUserIntrospector
+
+    introspector = LookerUserIntrospector(
+        base_url=config.base_url,
+        api_version=config.api_version,
+        verify_ssl=config.verify_ssl,
+        timeout_seconds=config.timeout,
+    )
+    resource_uri = config.looker_oauth_resource_uri
+    prm_url = _well_known_prm_url(resource_uri)
+
+    return Middleware(
+        LookerOAuthAuthMiddleware,
+        introspector=introspector,
+        realm=resource_uri,
         prm_url=prm_url,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -387,6 +387,79 @@ class TestMcpModePosture:
             config = LookerConfig(_env_file=None)  # type: ignore[call-arg]
         assert config.mcp_resource_uri == "https://looker.example.com/mcp"
 
+    def test_looker_oauth_mode_rejects_http_resource_uri(self):
+        """An operator-pinned LOOKER_MCP_RESOURCE_URI must be https in
+        looker_oauth mode even though it is optional there."""
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import PostureErrorKind
+
+        with patch.dict(
+            os.environ,
+            self._env(
+                LOOKER_MCP_MODE="looker_oauth",
+                LOOKER_MCP_RESOURCE_URI="http://looker.example.com/mcp",
+            ),
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc:
+                LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert self._extract_posture_kind(exc) == PostureErrorKind.PUBLIC_RESOURCE_URI_NOT_HTTPS
+
+    def test_looker_oauth_mode_rejects_resource_uri_with_fragment(self):
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import PostureErrorKind
+
+        with patch.dict(
+            os.environ,
+            self._env(
+                LOOKER_MCP_MODE="looker_oauth",
+                LOOKER_MCP_RESOURCE_URI="https://looker.example.com/mcp#frag",
+            ),
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc:
+                LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert self._extract_posture_kind(exc) == PostureErrorKind.PUBLIC_RESOURCE_URI_MALFORMED
+
+    def test_looker_oauth_mode_requires_resource_uri(self):
+        """The resource URI is REQUIRED in looker_oauth — it is the MCP
+        server's own URI and the host of the ``resource_metadata`` PRM URL,
+        which must not default to Looker's host."""
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import PostureErrorKind
+
+        with patch.dict(
+            os.environ,
+            self._env(LOOKER_MCP_MODE="looker_oauth"),
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc:
+                LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert self._extract_posture_kind(exc) == PostureErrorKind.LOOKER_OAUTH_MISSING_RESOURCE_URI
+
+    def test_looker_oauth_mode_rejects_base_url_with_query_or_fragment(self):
+        """LOOKER_BASE_URL must be a bare https origin — a query/fragment would
+        corrupt the ``/api/<ver>/user`` introspection URL."""
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import PostureErrorKind
+
+        with patch.dict(
+            os.environ,
+            self._env(
+                LOOKER_BASE_URL="https://example.looker.com/?x=1",
+                LOOKER_MCP_MODE="looker_oauth",
+                LOOKER_MCP_RESOURCE_URI="https://mcp.example.com",
+            ),
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc:
+                LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert self._extract_posture_kind(exc) == PostureErrorKind.LOOKER_OAUTH_BASE_URL_INVALID
+
     def test_public_mode_happy_path(self):
         """All required env set + https resource URI → config resolves cleanly."""
         from looker_mcp_server.config import LookerMcpMode
@@ -415,3 +488,142 @@ class TestMcpModePosture:
         assert "detail" in str(err)
         # Backwards-compat with Pydantic validators expecting ValueError.
         assert isinstance(err, ValueError)
+
+
+class TestLookerOAuthModePosture:
+    """Tests for ``LOOKER_MCP_MODE=looker_oauth`` — the Looker-as-its-own-
+    authorization-server, opaque-token posture.
+
+    Unlike ``public`` mode, this posture does NOT require
+    ``LOOKER_MCP_JWKS_URI`` / ``LOOKER_MCP_ISSUER_URL`` / ``LOOKER_MCP_RESOURCE_URI``.
+    Looker is the authorization server and the inbound bearer is an opaque
+    Looker token verified via ``GET /user`` introspection. The only hard
+    requirement is a usable ``LOOKER_BASE_URL``; a shared static bearer is
+    forbidden because it would defeat the per-user identity.
+    """
+
+    def _env(self, **overrides: str) -> dict[str, str]:
+        base = {"LOOKER_BASE_URL": "https://example.looker.com"}
+        base.update(overrides)
+        return base
+
+    @staticmethod
+    def _extract_posture_kind(exc_info):
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import DeploymentPostureError
+
+        err = exc_info.value
+        assert isinstance(err, ValidationError), f"expected ValidationError, got {type(err)}"
+        details = err.errors()
+        # The looker_oauth validator is one of several model_validators; the
+        # one that raises is the only error reported.
+        ctx = details[0].get("ctx", {})
+        inner = ctx.get("error")
+        assert isinstance(inner, DeploymentPostureError), (
+            f"expected DeploymentPostureError inside ctx, got {type(inner)}"
+        )
+        return inner.kind
+
+    def test_looker_oauth_happy_path(self):
+        """``LOOKER_BASE_URL`` + ``LOOKER_MCP_RESOURCE_URI`` + the mode flag
+        resolve cleanly — no JWKS / issuer machinery needed."""
+        from looker_mcp_server.config import LookerMcpMode
+
+        with patch.dict(
+            os.environ,
+            self._env(
+                LOOKER_MCP_MODE="looker_oauth",
+                LOOKER_MCP_RESOURCE_URI="https://mcp.example.com",
+            ),
+            clear=True,
+        ):
+            config = LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert config.mcp_mode == LookerMcpMode.LOOKER_OAUTH
+        # The OIDC-mode (JWKS/issuer) fields stay empty and are not required.
+        assert config.mcp_jwks_uri == ""
+        assert config.mcp_issuer_url == ""
+        assert config.looker_oauth_resource_uri == "https://mcp.example.com"
+
+    def test_looker_oauth_does_not_require_jwks_or_issuer(self):
+        """Regression guard: the public-mode validator MUST NOT fire in
+        looker_oauth mode (it would demand JWKS/issuer this posture omits)."""
+        with patch.dict(
+            os.environ,
+            self._env(
+                LOOKER_MCP_MODE="looker_oauth",
+                LOOKER_MCP_RESOURCE_URI="https://mcp.example.com",
+            ),
+            clear=True,
+        ):
+            # Must not raise — no JWKS/issuer configured (resource URI is the
+            # only looker_oauth requirement beyond base_url).
+            LookerConfig(_env_file=None)  # type: ignore[call-arg]
+
+    def test_looker_oauth_requires_base_url(self):
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import PostureErrorKind
+
+        with patch.dict(
+            os.environ,
+            {"LOOKER_MCP_MODE": "looker_oauth"},  # no LOOKER_BASE_URL
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc:
+                LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert self._extract_posture_kind(exc) == PostureErrorKind.LOOKER_OAUTH_MISSING_BASE_URL
+
+    @pytest.mark.parametrize(
+        "bad_base_url",
+        [
+            "http://example.looker.com",  # plaintext — opaque tokens must not cross it
+            "example.looker.com",  # no scheme
+            "https://",  # no host
+        ],
+    )
+    def test_looker_oauth_rejects_non_https_base_url(self, bad_base_url: str):
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import PostureErrorKind
+
+        with patch.dict(
+            os.environ,
+            {"LOOKER_MCP_MODE": "looker_oauth", "LOOKER_BASE_URL": bad_base_url},
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc:
+                LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert self._extract_posture_kind(exc) == PostureErrorKind.LOOKER_OAUTH_BASE_URL_NOT_HTTPS
+
+    def test_looker_oauth_rejects_static_bearer(self):
+        """A shared static bearer is the antithesis of per-user opaque tokens."""
+        from pydantic import ValidationError
+
+        from looker_mcp_server.config import PostureErrorKind
+
+        with patch.dict(
+            os.environ,
+            self._env(
+                LOOKER_MCP_MODE="looker_oauth",
+                LOOKER_MCP_AUTH_TOKEN="shared-secret",
+            ),
+            clear=True,
+        ):
+            with pytest.raises(ValidationError) as exc:
+                LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert (
+            self._extract_posture_kind(exc) == PostureErrorKind.LOOKER_OAUTH_STATIC_BEARER_FORBIDDEN
+        )
+
+    def test_looker_oauth_resource_uri_honors_explicit_override(self):
+        with patch.dict(
+            os.environ,
+            self._env(
+                LOOKER_MCP_MODE="looker_oauth",
+                LOOKER_MCP_RESOURCE_URI="https://looker-mcp.example.com/mcp",
+            ),
+            clear=True,
+        ):
+            config = LookerConfig(_env_file=None)  # type: ignore[call-arg]
+        assert config.looker_oauth_resource_uri == "https://looker-mcp.example.com/mcp"

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -138,6 +138,98 @@ class TestOAuthIdentityProvider:
             await provider.resolve(ctx)
 
 
+class TestOAuthIdentityProviderBearerScheme:
+    """The ``looker_oauth``-mode shape: read the opaque token straight from
+    the ``Authorization`` header, stripping the ``Bearer`` scheme prefix, with
+    NO fallback credentials configured."""
+
+    def _provider(self) -> OAuthIdentityProvider:
+        return OAuthIdentityProvider(
+            token_header="Authorization",
+            strip_bearer_scheme=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_strips_bearer_scheme_from_authorization_header(self):
+        ctx = RequestContext(
+            headers={"authorization": "Bearer opaque-looker-token"},
+            tool_name="query",
+            tool_group="query",
+        )
+        identity = await self._provider().resolve(ctx)
+        assert identity.mode == "oauth"
+        assert identity.access_token == "opaque-looker-token"
+
+    @pytest.mark.asyncio
+    async def test_bearer_scheme_case_insensitive(self):
+        ctx = RequestContext(
+            headers={"authorization": "bearer opaque-looker-token"},
+            tool_name="query",
+            tool_group="query",
+        )
+        identity = await self._provider().resolve(ctx)
+        assert identity.access_token == "opaque-looker-token"
+
+    @pytest.mark.asyncio
+    async def test_bare_token_without_scheme_passes_through(self):
+        """A token with no ``Bearer `` prefix (no space) is used verbatim."""
+        ctx = RequestContext(
+            headers={"authorization": "opaque-looker-token"},
+            tool_name="query",
+            tool_group="query",
+        )
+        identity = await self._provider().resolve(ctx)
+        assert identity.access_token == "opaque-looker-token"
+
+    @pytest.mark.asyncio
+    async def test_non_bearer_scheme_rejected(self):
+        """A non-Bearer scheme (e.g. ``Basic``) is never forwarded as a token."""
+        ctx = RequestContext(
+            headers={"authorization": "Basic dXNlcjpwYXNz"},
+            tool_name="query",
+            tool_group="query",
+        )
+        with pytest.raises(PermissionError):
+            await self._provider().resolve(ctx)
+
+    @pytest.mark.asyncio
+    async def test_empty_bearer_rejected(self):
+        """``Bearer `` with no token is rejected, not forwarded as an empty token."""
+        ctx = RequestContext(
+            headers={"authorization": "Bearer "},
+            tool_name="query",
+            tool_group="query",
+        )
+        with pytest.raises(PermissionError):
+            await self._provider().resolve(ctx)
+
+    @pytest.mark.asyncio
+    async def test_malformed_scheme_rejected_even_with_fallback(self):
+        """A malformed scheme-bearing header is rejected outright — never
+        silently downgraded to API-key fallback creds."""
+        provider = OAuthIdentityProvider(
+            token_header="Authorization",
+            fallback_client_id="fallback-id",
+            fallback_client_secret="fallback-secret",
+            strip_bearer_scheme=True,
+        )
+        ctx = RequestContext(
+            headers={"authorization": "Basic dXNlcjpwYXNz"},
+            tool_name="query",
+            tool_group="query",
+        )
+        with pytest.raises(PermissionError):
+            await provider.resolve(ctx)
+
+    @pytest.mark.asyncio
+    async def test_no_fallback_raises_without_token(self):
+        """The no-credential posture omits fallback creds — a missing token
+        must raise, never silently borrow a shared identity."""
+        ctx = RequestContext(headers={}, tool_name="query", tool_group="query")
+        with pytest.raises(PermissionError):
+            await self._provider().resolve(ctx)
+
+
 class TestDualModeIdentityProvider:
     @pytest.mark.asyncio
     async def test_self_hosted_uses_sudo_path(self):

--- a/tests/test_looker_oauth_mode.py
+++ b/tests/test_looker_oauth_mode.py
@@ -1,0 +1,501 @@
+"""Tests for ``LOOKER_MCP_MODE=looker_oauth`` — Looker-as-its-own-authorization-
+server, opaque-token posture.
+
+Covers:
+- :class:`LookerUserIntrospector` — opaque-token verification via Looker
+  ``GET /user`` (accept iff Looker returns a user; reject on 401/403, non-200,
+  non-JSON, missing id, or transport failure).
+- :class:`LookerOAuthAuthMiddleware` — the ASGI gate (valid token passes
+  through with the user stashed; missing/malformed/invalid → 401; bearer-in-
+  query → 400; bypass paths anonymous).
+- ``create_server`` provider selection (no-cred ``OAuthIdentityProvider``).
+- ``create_server`` PRM advertises Looker as the authorization server.
+- ``build_looker_oauth_mode_middleware`` wiring.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+
+from looker_mcp_server.config import LookerConfig, LookerMcpMode
+from looker_mcp_server.identity import OAuthIdentityProvider
+from looker_mcp_server.oidc import (
+    LookerOAuthAuthMiddleware,
+    LookerUserIntrospector,
+    OpaqueTokenVerificationError,
+)
+from looker_mcp_server.server import (
+    PRM_PATH,
+    build_looker_oauth_mode_middleware,
+    build_public_mode_middleware,
+    create_server,
+)
+
+BASE_URL = "https://test.looker.com"
+USER_URL = f"{BASE_URL}/api/4.0/user"
+# This MCP server's own public URI (RFC 9728 resource) — distinct from Looker.
+RESOURCE_URI = "https://mcp.test.example.com"
+
+
+def _looker_oauth_config(**overrides: Any) -> LookerConfig:
+    base: dict[str, Any] = {
+        "base_url": BASE_URL,
+        "mcp_mode": LookerMcpMode.LOOKER_OAUTH,
+        "mcp_resource_uri": RESOURCE_URI,
+    }
+    base.update(overrides)
+    return LookerConfig(_env_file=None, **base)  # type: ignore[call-arg]
+
+
+# ── Introspector ─────────────────────────────────────────────────────
+
+
+class TestLookerUserIntrospector:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_valid_token_returns_user(self):
+        respx.get(USER_URL).respond(
+            status_code=200,
+            json={"id": 123, "email": "user@example.com", "display_name": "Test User"},
+        )
+        introspector = LookerUserIntrospector(BASE_URL)
+        user = await introspector.verify("good-token")
+        assert user.id == "123"
+        assert user.email == "user@example.com"
+        assert user.display_name == "Test User"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_forwards_token_as_looker_auth_header(self):
+        """The introspection call presents the opaque token in the Looker
+        ``Authorization: token <...>`` form."""
+        route = respx.get(USER_URL).respond(status_code=200, json={"id": 1})
+        introspector = LookerUserIntrospector(BASE_URL)
+        await introspector.verify("the-opaque-token")
+        assert route.called
+        sent = route.calls.last.request
+        assert sent.headers["authorization"] == "token the-opaque-token"
+
+    @pytest.mark.asyncio
+    async def test_empty_token_rejected(self):
+        introspector = LookerUserIntrospector(BASE_URL)
+        with pytest.raises(OpaqueTokenVerificationError):
+            await introspector.verify("")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @pytest.mark.parametrize("status", [401, 403])
+    async def test_looker_rejects_token(self, status: int):
+        respx.get(USER_URL).respond(status_code=status, json={"message": "Not authenticated"})
+        introspector = LookerUserIntrospector(BASE_URL)
+        with pytest.raises(OpaqueTokenVerificationError):
+            await introspector.verify("expired-token")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unexpected_status_rejected(self):
+        respx.get(USER_URL).respond(status_code=500, text="boom")
+        introspector = LookerUserIntrospector(BASE_URL)
+        with pytest.raises(OpaqueTokenVerificationError):
+            await introspector.verify("token")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_non_json_response_rejected(self):
+        respx.get(USER_URL).respond(status_code=200, text="<html>not json</html>")
+        introspector = LookerUserIntrospector(BASE_URL)
+        with pytest.raises(OpaqueTokenVerificationError):
+            await introspector.verify("token")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_missing_user_id_rejected(self):
+        respx.get(USER_URL).respond(status_code=200, json={"email": "x@example.com"})
+        introspector = LookerUserIntrospector(BASE_URL)
+        with pytest.raises(OpaqueTokenVerificationError):
+            await introspector.verify("token")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_transport_failure_fails_closed(self):
+        respx.get(USER_URL).mock(side_effect=httpx.ConnectError("refused"))
+        introspector = LookerUserIntrospector(BASE_URL)
+        with pytest.raises(OpaqueTokenVerificationError):
+            await introspector.verify("token")
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_honors_api_version(self):
+        url = f"{BASE_URL}/api/4.1/user"
+        respx.get(url).respond(status_code=200, json={"id": 7})
+        introspector = LookerUserIntrospector(BASE_URL, api_version="4.1")
+        user = await introspector.verify("token")
+        assert user.id == "7"
+
+
+# ── Middleware ───────────────────────────────────────────────────────
+
+
+async def _echo_app(scope, receive, send):
+    """Tiny ASGI app: emits 200 with the stashed looker user id (if present)."""
+    user = (scope.get("state") or {}).get("looker_user")
+    body = json.dumps({"looker_user_id": user.id if user is not None else None}).encode()
+    await send(
+        {
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json")],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+async def _drive(
+    mw, *, method: str = "POST", path: str = "/mcp", headers=None, query_string: bytes = b""
+):
+    """Minimal ASGI driver — return (status, response_headers_dict, body_bytes)."""
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "method": method,
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": query_string,
+        "headers": [(k.encode().lower(), v.encode()) for k, v in (headers or {}).items()],
+    }
+    received: dict[str, Any] = {"status": None, "headers": {}, "body": b""}
+
+    async def _recv():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _send(message):
+        if message["type"] == "http.response.start":
+            received["status"] = message["status"]
+            received["headers"] = {k.decode(): v.decode() for k, v in message["headers"]}
+        elif message["type"] == "http.response.body":
+            received["body"] += message.get("body", b"")
+
+    await mw(scope, _recv, _send)
+    return received["status"], received["headers"], received["body"]
+
+
+def _mw() -> LookerOAuthAuthMiddleware:
+    return LookerOAuthAuthMiddleware(
+        _echo_app,
+        introspector=LookerUserIntrospector(BASE_URL),
+        realm=BASE_URL,
+        prm_url=f"{BASE_URL}{PRM_PATH}",
+    )
+
+
+class TestLookerOAuthAuthMiddleware:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_valid_token_passes_through_with_user_stashed(self):
+        respx.get(USER_URL).respond(status_code=200, json={"id": 55})
+        status, _, body = await _drive(_mw(), headers={"Authorization": "Bearer good-token"})
+        assert status == 200
+        assert json.loads(body) == {"looker_user_id": "55"}
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_authorization_header_intact_for_downstream(self):
+        """The gate must NOT strip/mutate the Authorization header — the
+        identity provider downstream forwards the same opaque token to
+        Looker as the session token."""
+        respx.get(USER_URL).respond(status_code=200, json={"id": 1})
+
+        captured: dict[str, Any] = {}
+
+        async def _capture_app(scope, receive, send):
+            captured["authorization"] = None
+            for k, v in scope.get("headers") or []:
+                if k.lower() == b"authorization":
+                    captured["authorization"] = v.decode()
+            await send({"type": "http.response.start", "status": 200, "headers": []})
+            await send({"type": "http.response.body", "body": b""})
+
+        mw = LookerOAuthAuthMiddleware(
+            _capture_app,
+            introspector=LookerUserIntrospector(BASE_URL),
+            realm=BASE_URL,
+            prm_url=f"{BASE_URL}{PRM_PATH}",
+        )
+        status, _, _ = await _drive(mw, headers={"Authorization": "Bearer keep-me"})
+        assert status == 200
+        assert captured["authorization"] == "Bearer keep-me"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_looker_rejected_token_401(self):
+        respx.get(USER_URL).respond(status_code=401, json={"message": "no"})
+        status, headers, body = await _drive(_mw(), headers={"Authorization": "Bearer bad-token"})
+        assert status == 401
+        assert json.loads(body)["error"] == "invalid_token"
+        www = headers.get("www-authenticate") or ""
+        assert www.startswith("Bearer ")
+        assert f'realm="{BASE_URL}"' in www
+        assert f'resource_metadata="{BASE_URL}{PRM_PATH}"' in www
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_missing_authorization_401_with_challenge(self):
+        status, headers, body = await _drive(_mw())
+        assert status == 401
+        assert (headers.get("www-authenticate") or "").startswith("Bearer ")
+        assert json.loads(body)["error"] == "invalid_token"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_malformed_scheme_401(self):
+        status, _, _ = await _drive(_mw(), headers={"Authorization": "Basic abcd"})
+        assert status == 401
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_transport_failure_yields_401(self):
+        respx.get(USER_URL).mock(side_effect=httpx.ConnectError("refused"))
+        status, _, body = await _drive(_mw(), headers={"Authorization": "Bearer x"})
+        assert status == 401
+        assert json.loads(body)["error"] == "invalid_token"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_bearer_in_query_rejected_400(self):
+        status, _, body = await _drive(_mw(), query_string=b"access_token=attacker")
+        assert status == 400
+        assert json.loads(body)["error"] == "invalid_request"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_well_known_bypasses_auth(self):
+        status, _, _ = await _drive(_mw(), path="/.well-known/oauth-protected-resource")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_healthz_bypasses_auth(self):
+        status, _, _ = await _drive(_mw(), path="/healthz")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_introspect_bypasses_auth(self):
+        """The gateway-discovery ``/_introspect`` route runs its own guard."""
+        status, _, _ = await _drive(_mw(), path="/_introspect")
+        assert status == 200
+
+    @pytest.mark.asyncio
+    async def test_lifespan_scope_passes_through(self):
+        mw = _mw()
+        received: list[dict] = []
+
+        async def recv():
+            return {"type": "lifespan.startup"}
+
+        async def send(msg):
+            received.append(msg)
+
+        await mw({"type": "lifespan"}, recv, send)
+        statuses = [m.get("status") for m in received if m.get("type") == "http.response.start"]
+        assert 401 not in statuses
+        assert 400 not in statuses
+
+    def test_empty_realm_rejected_at_construct(self):
+        with pytest.raises(ValueError, match="realm"):
+            LookerOAuthAuthMiddleware(
+                _echo_app,
+                introspector=LookerUserIntrospector(BASE_URL),
+                realm="",
+                prm_url=f"{BASE_URL}{PRM_PATH}",
+            )
+
+
+# ── build_looker_oauth_mode_middleware ───────────────────────────────
+
+
+class TestBuildLookerOAuthModeMiddleware:
+    def test_non_looker_oauth_mode_returns_none(self):
+        dev = LookerConfig(_env_file=None, base_url=BASE_URL, mcp_mode=LookerMcpMode.DEV)  # type: ignore[call-arg]
+        assert build_looker_oauth_mode_middleware(dev) is None
+
+    def test_public_mode_returns_none(self):
+        """The two gates are mutually exclusive — public-mode config does not
+        produce a looker_oauth gate (and vice versa)."""
+        pub = LookerConfig(
+            _env_file=None,  # type: ignore[call-arg]
+            base_url=BASE_URL,
+            mcp_mode=LookerMcpMode.PUBLIC,
+            mcp_jwks_uri="https://as.example.com/.well-known/jwks.json",
+            mcp_issuer_url="https://as.example.com",
+            mcp_resource_uri="https://looker.example.com/mcp",
+        )
+        assert build_looker_oauth_mode_middleware(pub) is None
+        # And the public-mode builder returns None for a looker_oauth config.
+        assert build_public_mode_middleware(_looker_oauth_config()) is None
+
+    def test_looker_oauth_mode_returns_wrapped_middleware(self):
+        mw = build_looker_oauth_mode_middleware(_looker_oauth_config())
+        assert mw is not None
+        assert mw.cls is LookerOAuthAuthMiddleware
+        # realm + PRM URL are built from the MCP server's own resource URI
+        # (NOT Looker's base URL — the MCP server serves the PRM).
+        assert mw.kwargs["realm"] == RESOURCE_URI
+        assert mw.kwargs["prm_url"] == f"{RESOURCE_URI}{PRM_PATH}"
+        assert mw.kwargs["introspector"] is not None
+
+
+# ── create_server: provider selection + PRM ──────────────────────────
+
+
+class TestLookerOAuthProviderSelection:
+    def test_selects_no_cred_oauth_provider(self):
+        """In looker_oauth mode, the default identity provider is a no-cred
+        ``OAuthIdentityProvider`` reading the Authorization-header bearer —
+        NOT a DualMode/ApiKey/ArgumentSudo chain that needs admin creds."""
+        mcp, client = create_server(_looker_oauth_config())
+        try:
+            provider = client._identity_provider  # type: ignore[attr-defined]
+            assert isinstance(provider, OAuthIdentityProvider)
+            # No fallback credentials — a tokenless request must fail.
+            assert provider._fallback_id is None  # type: ignore[attr-defined]
+            assert provider._fallback_secret is None  # type: ignore[attr-defined]
+            # Reads the standard Authorization header and strips Bearer.
+            assert provider._header == "authorization"  # type: ignore[attr-defined]
+            assert provider._strip_bearer_scheme is True  # type: ignore[attr-defined]
+        finally:
+            import asyncio
+
+            asyncio.run(client.close())
+
+    @pytest.mark.asyncio
+    async def test_resolves_opaque_token_to_oauth_identity(self):
+        """End-to-end through the provider: an Authorization-header bearer
+        resolves to a Looker ``oauth`` identity carrying the bare token."""
+        from looker_mcp_server.identity import RequestContext
+
+        mcp, client = create_server(_looker_oauth_config())
+        try:
+            provider = client._identity_provider  # type: ignore[attr-defined]
+            ctx = RequestContext(
+                headers={"authorization": "Bearer opaque-xyz"},
+                tool_name="run_query",
+                tool_group="query",
+            )
+            identity = await provider.resolve(ctx)
+            assert identity.mode == "oauth"
+            assert identity.access_token == "opaque-xyz"
+        finally:
+            await client.close()
+
+    def test_api3_creds_do_not_re_enable_sudo_wrapper(self):
+        """Security: even with admin API3 creds present, looker_oauth must NOT
+        wrap the provider in ``ArgumentSudoIdentityProvider`` — doing so would
+        re-enable the ``act_as_user`` escalation the posture forbids."""
+        from looker_mcp_server.identity import ArgumentSudoIdentityProvider
+
+        mcp, client = create_server(
+            _looker_oauth_config(
+                client_id="admin-id",
+                client_secret="admin-secret",
+                sudo_as_user=True,
+            )
+        )
+        try:
+            provider = client._identity_provider  # type: ignore[attr-defined]
+            assert isinstance(provider, OAuthIdentityProvider)
+            assert not isinstance(provider, ArgumentSudoIdentityProvider)
+        finally:
+            import asyncio
+
+            asyncio.run(client.close())
+
+
+class TestLookerOAuthPrmRoute:
+    @pytest.mark.asyncio
+    async def test_prm_advertises_looker_as_authorization_server(self):
+        """The looker_oauth-mode PRM lists the Looker base URL as the
+        authorization server so the client runs a Looker PKCE flow."""
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        mcp, client = create_server(_looker_oauth_config())
+        try:
+            app = mcp.http_app()
+            assert isinstance(app, Starlette)
+            with TestClient(app) as http:
+                resp = http.get(PRM_PATH)
+                assert resp.status_code == 200
+                doc = resp.json()
+                # Looker IS the authorization server in this posture.
+                assert doc["authorization_servers"] == [BASE_URL]
+                # Resource defaults to the Looker base URL when unset.
+                assert doc["resource"] == RESOURCE_URI
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_prm_honors_explicit_resource_uri(self):
+        from starlette.applications import Starlette
+        from starlette.testclient import TestClient
+
+        resource = "https://looker-mcp.example.com/mcp"
+        mcp, client = create_server(_looker_oauth_config(mcp_resource_uri=resource))
+        try:
+            app = mcp.http_app()
+            assert isinstance(app, Starlette)
+            with TestClient(app) as http:
+                # Suffix-variant path (RFC 9728 §3) for a path-qualified resource.
+                resp = http.get(f"{PRM_PATH}/mcp")
+                assert resp.status_code == 200
+                doc = resp.json()
+                assert doc["resource"] == resource
+                assert doc["authorization_servers"] == [BASE_URL]
+        finally:
+            await client.close()
+
+    @pytest.mark.asyncio
+    async def test_dev_mode_does_not_register_prm(self):
+        dev = LookerConfig(_env_file=None, base_url=BASE_URL, mcp_mode=LookerMcpMode.DEV)  # type: ignore[call-arg]
+        mcp, client = create_server(dev)
+        try:
+            app = mcp.http_app() if hasattr(mcp, "http_app") else None
+            if app is not None:
+                route_paths = {getattr(r, "path", None) for r in getattr(app, "routes", [])}
+                assert PRM_PATH not in route_paths
+        finally:
+            await client.close()
+
+
+class TestRunTransportGuard:
+    """``run()`` fails fast when an HTTP-only auth posture is paired with a
+    non-HTTP transport — otherwise the auth gate would be silently omitted."""
+
+    @pytest.mark.asyncio
+    async def test_looker_oauth_with_stdio_transport_aborts(self):
+        from looker_mcp_server.main import run
+
+        cfg = _looker_oauth_config(transport="stdio")
+        with pytest.raises(SystemExit):
+            await run(cfg, set())
+
+    @pytest.mark.asyncio
+    async def test_public_with_stdio_transport_aborts(self):
+        from looker_mcp_server.main import run
+
+        pub = LookerConfig(
+            _env_file=None,  # type: ignore[call-arg]
+            base_url=BASE_URL,
+            transport="stdio",
+            mcp_mode=LookerMcpMode.PUBLIC,
+            mcp_jwks_uri="https://as.example.com/.well-known/jwks.json",
+            mcp_issuer_url="https://as.example.com",
+            mcp_resource_uri="https://mcp.test.example.com",
+        )
+        with pytest.raises(SystemExit):
+            await run(pub, set())

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

Adds a third MCP-level authentication posture, `LOOKER_MCP_MODE=looker_oauth`, in which **Looker itself is the authorization server** and the MCP server holds **no admin API3 credentials and no sudo capability**.

A client runs a Looker PKCE flow directly against the Looker instance, obtains an **opaque** per-user Looker access token, and presents it as `Authorization: Bearer <token>`. The server:

- **Advertises Looker as the authorization server** in its RFC 9728 Protected Resource Metadata (the `LOOKER_BASE_URL`), so MCP clients auto-discover Looker's OAuth endpoints and run PKCE there.
- **Verifies every inbound token by calling Looker `GET /user`** — accepted iff Looker returns a valid user; 401 `invalid_token` on rejected/expired tokens, non-200 responses, non-JSON bodies, missing user id, or transport failures (fail-closed).
- **Forwards the verified opaque token to Looker as the session token**, so the user's own Looker permissions govern every API call.

Only `LOOKER_BASE_URL` (an absolute `https://` URL) is required — no JWKS, issuer, or service-account configuration.

## Changes
- `config.py` — new `LookerMcpMode.LOOKER_OAUTH` + posture validator (requires `https://` `LOOKER_BASE_URL`, rejects static `LOOKER_MCP_AUTH_TOKEN`, does NOT require JWKS/issuer/resource URI) + `looker_oauth_resource_uri` property.
- `identity.py` — `OAuthIdentityProvider` gains `strip_bearer_scheme` to read the opaque token directly from the `Authorization` header.
- `oidc/looker_introspection.py` (new) — `LookerUserIntrospector` (the `GET /user` verifier) + `LookerOAuthAuthMiddleware` (ASGI gate mirroring public-mode HTTP contract, swapping JWT validation for opaque-token introspection).
- `server.py` — selects the no-credential `OAuthIdentityProvider` in `looker_oauth` mode; PRM advertises Looker as the AS; `build_looker_oauth_mode_middleware` helper.
- `main.py` — threads the `looker_oauth` auth gate into the HTTP middleware chain.
- Tests + README + CHANGELOG; version `0.19.0` -> `0.20.0`.

## Testing
`ruff check`, `ruff format --check`, `pyright`, and `pytest tests/` all pass (462 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * v0.20.0: Added LOOKER_MCP_MODE=looker_oauth to validate opaque per-user Looker tokens via Looker introspection and forward them so Looker enforces per-user permissions; HTTP auth accepts Authorization: Bearer tokens (optional bearer-scheme stripping).

* **Configuration**
  * Stricter startup validation: require LOOKER_BASE_URL and LOOKER_MCP_RESOURCE_URI as absolute https URLs; disallow static MCP auth token for this mode; PRM/resource discovery served for both public and looker_oauth modes.

* **Documentation & Tests**
  * Changelog/README updated and comprehensive tests added for the new posture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultrathink-Solutions/looker-mcp-server/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->