### PR TITLE
feat(tools): exclude hidden LookML content from discovery tools by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Discovery tools now exclude LookML `hidden` content by default, with a
+  per-call `include_hidden` escape hatch.** `list_models`, `get_model`,
+  `get_explore`, `list_dimensions`, `list_measures`, and `search_content`
+  all gain an `include_hidden: bool = false` argument. By default, hidden
+  explores are filtered out of `list_models`/`get_model` (previously they
+  leaked through), hidden filter and parameter fields are filtered out of
+  `get_explore` (previously only dimensions and measures were filtered), and
+  `search_content` drops results carrying a truthy `hidden` flag. Passing
+  `include_hidden=true` returns everything, with each item's `hidden` flag
+  visible (`list_models` now surfaces the flag per explore). LookML `hidden`
+  is a curation signal, not a security boundary — the API serves hidden items
+  to any caller regardless; this only aligns the MCP discovery surface with
+  the model author's curation.
+
 ## [0.20.0] - 2026-05-28
 
 Adds a third MCP-level authentication posture, `LOOKER_MCP_MODE=looker_oauth`,

--- a/src/looker_mcp_server/tools/_helpers.py
+++ b/src/looker_mcp_server/tools/_helpers.py
@@ -52,6 +52,28 @@ ACT_AS_USER_DESCRIPTION = (
 ActAsUser = Annotated[str | None, ACT_AS_USER_DESCRIPTION]
 
 
+# Per-call hidden-content toggle shared across discovery tools (explore,
+# query). LookML ``hidden: yes`` is a curation signal — model authors hide
+# fields and explores they don't want surfaced in the field picker — so
+# discovery tools honor it by default and expose this escape hatch.
+INCLUDE_HIDDEN_DESCRIPTION = (
+    "Include items marked hidden in LookML (hidden explores, fields, or "
+    "content). Hidden items are excluded by default."
+)
+IncludeHidden = Annotated[bool, INCLUDE_HIDDEN_DESCRIPTION]
+
+
+def _filter_hidden(items: list[dict[str, Any]], include_hidden: bool) -> list[dict[str, Any]]:
+    """Drop items whose ``hidden`` flag is truthy unless ``include_hidden``.
+
+    Items without a ``hidden`` key are always kept — not every Looker
+    payload carries the flag, and absence means "not hidden".
+    """
+    if include_hidden:
+        return items
+    return [item for item in items if not item.get("hidden")]
+
+
 def _validate_branch_args(branch: str | None, project_id: str | None) -> None:
     """Branch swap requires a non-empty project ID and branch name.
 

--- a/src/looker_mcp_server/tools/explore.py
+++ b/src/looker_mcp_server/tools/explore.py
@@ -13,16 +13,18 @@ from typing import Annotated
 from fastmcp import FastMCP
 
 from ..client import LookerClient, format_api_error
+from ._helpers import IncludeHidden, _filter_hidden
 
 
 def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "List all LookML models accessible to the current user. "
-            "Returns model names, labels, associated projects, and their explores."
+            "Returns model names, labels, associated projects, and their explores. "
+            "Hidden explores are excluded unless include_hidden=true."
         ),
     )
-    async def list_models() -> str:
+    async def list_models(include_hidden: IncludeHidden = False) -> str:
         ctx = client.build_context("list_models", "explore")
         try:
             async with client.session(ctx) as session:
@@ -34,8 +36,12 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                         "project_name": m.get("project_name"),
                         "has_content": m.get("has_content"),
                         "explores": [
-                            {"name": e.get("name"), "label": e.get("label")}
-                            for e in (m.get("explores") or [])
+                            {
+                                "name": e.get("name"),
+                                "label": e.get("label"),
+                                "hidden": e.get("hidden"),
+                            }
+                            for e in _filter_hidden(m.get("explores") or [], include_hidden)
                         ],
                     }
                     for m in (models or [])
@@ -47,11 +53,13 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "Get detailed information about a specific LookML model, "
-            "including all its explores and their descriptions."
+            "including all its explores and their descriptions. "
+            "Hidden explores are excluded unless include_hidden=true."
         ),
     )
     async def get_model(
         model_name: Annotated[str, "Name of the LookML model"],
+        include_hidden: IncludeHidden = False,
     ) -> str:
         ctx = client.build_context("get_model", "explore", {"model_name": model_name})
         try:
@@ -69,7 +77,7 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                             "group_label": e.get("group_label"),
                             "hidden": e.get("hidden"),
                         }
-                        for e in (model.get("explores") or [])
+                        for e in _filter_hidden(model.get("explores") or [], include_hidden)
                     ],
                 }
                 return json.dumps(result, indent=2)
@@ -80,12 +88,14 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
         description=(
             "Get full details of an explore including all its dimensions, measures, "
             "filters, and parameters. This is the primary tool for understanding "
-            "what fields are available for querying."
+            "what fields are available for querying. "
+            "Hidden fields are excluded unless include_hidden=true."
         ),
     )
     async def get_explore(
         model_name: Annotated[str, "Name of the LookML model"],
         explore_name: Annotated[str, "Name of the explore within the model"],
+        include_hidden: IncludeHidden = False,
     ) -> str:
         ctx = client.build_context(
             "get_explore", "explore", {"model_name": model_name, "explore_name": explore_name}
@@ -106,8 +116,9 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                             "sql": d.get("sql"),
                             "hidden": d.get("hidden"),
                         }
-                        for d in (explore.get("fields", {}).get("dimensions") or [])
-                        if not d.get("hidden")
+                        for d in _filter_hidden(
+                            explore.get("fields", {}).get("dimensions") or [], include_hidden
+                        )
                     ],
                     "measures": [
                         {
@@ -118,8 +129,9 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                             "sql": m.get("sql"),
                             "hidden": m.get("hidden"),
                         }
-                        for m in (explore.get("fields", {}).get("measures") or [])
-                        if not m.get("hidden")
+                        for m in _filter_hidden(
+                            explore.get("fields", {}).get("measures") or [], include_hidden
+                        )
                     ],
                     "filters": [
                         {
@@ -127,8 +139,11 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                             "label": f.get("label"),
                             "type": f.get("type"),
                             "description": f.get("description"),
+                            "hidden": f.get("hidden"),
                         }
-                        for f in (explore.get("fields", {}).get("filters") or [])
+                        for f in _filter_hidden(
+                            explore.get("fields", {}).get("filters") or [], include_hidden
+                        )
                     ],
                     "parameters": [
                         {
@@ -136,8 +151,11 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                             "label": p.get("label"),
                             "type": p.get("type"),
                             "description": p.get("description"),
+                            "hidden": p.get("hidden"),
                         }
-                        for p in (explore.get("fields", {}).get("parameters") or [])
+                        for p in _filter_hidden(
+                            explore.get("fields", {}).get("parameters") or [], include_hidden
+                        )
                     ],
                 }
                 return json.dumps(result, indent=2)
@@ -147,12 +165,14 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "List dimensions in an explore. Convenience tool that returns "
-            "only the dimension fields (name, label, type, description)."
+            "only the dimension fields (name, label, type, description, hidden). "
+            "Hidden dimensions are excluded unless include_hidden=true."
         ),
     )
     async def list_dimensions(
         model_name: Annotated[str, "Name of the LookML model"],
         explore_name: Annotated[str, "Name of the explore"],
+        include_hidden: IncludeHidden = False,
     ) -> str:
         ctx = client.build_context(
             "list_dimensions", "explore", {"model_name": model_name, "explore_name": explore_name}
@@ -169,9 +189,11 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                         "label": d.get("label"),
                         "type": d.get("type"),
                         "description": d.get("description"),
+                        "hidden": d.get("hidden"),
                     }
-                    for d in (explore.get("fields", {}).get("dimensions") or [])
-                    if not d.get("hidden")
+                    for d in _filter_hidden(
+                        explore.get("fields", {}).get("dimensions") or [], include_hidden
+                    )
                 ]
                 return json.dumps(dims, indent=2)
         except Exception as e:
@@ -180,12 +202,14 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "List measures in an explore. Convenience tool that returns "
-            "only the measure fields (name, label, type, description)."
+            "only the measure fields (name, label, type, description, hidden). "
+            "Hidden measures are excluded unless include_hidden=true."
         ),
     )
     async def list_measures(
         model_name: Annotated[str, "Name of the LookML model"],
         explore_name: Annotated[str, "Name of the explore"],
+        include_hidden: IncludeHidden = False,
     ) -> str:
         ctx = client.build_context(
             "list_measures", "explore", {"model_name": model_name, "explore_name": explore_name}
@@ -202,9 +226,11 @@ def register_explore_tools(server: FastMCP, client: LookerClient) -> None:
                         "label": m.get("label"),
                         "type": m.get("type"),
                         "description": m.get("description"),
+                        "hidden": m.get("hidden"),
                     }
-                    for m in (explore.get("fields", {}).get("measures") or [])
-                    if not m.get("hidden")
+                    for m in _filter_hidden(
+                        explore.get("fields", {}).get("measures") or [], include_hidden
+                    )
                 ]
                 return json.dumps(measures, indent=2)
         except Exception as e:

--- a/src/looker_mcp_server/tools/query.py
+++ b/src/looker_mcp_server/tools/query.py
@@ -12,7 +12,13 @@ from typing import Annotated, Any
 from fastmcp import FastMCP
 
 from ..client import LookerClient, LookerSession, format_api_error
-from ._helpers import ActAsUser, _maybe_use_branch, _validate_branch_args
+from ._helpers import (
+    ActAsUser,
+    IncludeHidden,
+    _filter_hidden,
+    _maybe_use_branch,
+    _validate_branch_args,
+)
 
 # Looker returns these formats as ``text/plain`` rather than JSON; calling
 # ``session.get`` on them would raise ``Expecting value`` from the JSON
@@ -477,7 +483,8 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
     @server.tool(
         description=(
             "Search across all Looker content — dashboards, looks, explores, "
-            "and more. Returns matching items with titles, descriptions, and IDs."
+            "and more. Returns matching items with titles, descriptions, and IDs. "
+            "Hidden items are excluded unless include_hidden=true."
         ),
     )
     async def search_content(
@@ -487,6 +494,7 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
             "Content types to search: 'dashboard', 'look', 'folder', etc.",
         ] = None,
         limit: Annotated[int, "Maximum results to return"] = 20,
+        include_hidden: IncludeHidden = False,
     ) -> str:
         ctx = client.build_context("search_content", "query", {"query_string": query_string})
         try:
@@ -495,6 +503,8 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
                 if types:
                     params["types"] = ",".join(types)
                 results = await session.get("/content_metadata_access", params=params)
+                if isinstance(results, list):
+                    results = _filter_hidden(results, include_hidden)
                 return json.dumps(results, indent=2)
         except Exception as e:
             return format_api_error("search_content", e)

--- a/tests/test_explore_tools.py
+++ b/tests/test_explore_tools.py
@@ -1,0 +1,235 @@
+"""Tests for explore tool group — hidden-content filtering.
+
+LookML ``hidden: yes`` is a curation signal: hidden explores and fields
+are excluded from discovery tools by default, with a per-call
+``include_hidden`` escape hatch.
+"""
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from fastmcp import Client
+from mcp.types import TextContent
+
+from looker_mcp_server.config import LookerConfig
+from looker_mcp_server.server import create_server
+
+
+@pytest.fixture
+def config():
+    return LookerConfig(
+        base_url="https://test.looker.com",
+        client_id="test-id",
+        client_secret="test-secret",
+        sudo_as_user=False,
+        _env_file=None,  # type: ignore[call-arg]
+    )
+
+
+API_URL = "https://test.looker.com/api/4.0"
+
+
+def _mock_login_logout() -> None:
+    respx.post(f"{API_URL}/login").mock(
+        return_value=httpx.Response(200, json={"access_token": "sess-token"})
+    )
+    respx.delete(f"{API_URL}/logout").mock(return_value=httpx.Response(204))
+
+
+async def _call(config, tool: str, args: dict) -> Any:
+    mcp, looker_client = create_server(config, enabled_groups={"explore"})
+    try:
+        async with Client(mcp) as mcp_client:
+            result = await mcp_client.call_tool(tool, args)
+            content = result.content[0]
+            assert isinstance(content, TextContent)
+            return json.loads(content.text)
+    finally:
+        await looker_client.close()
+
+
+MODELS_PAYLOAD = [
+    {
+        "name": "ecommerce",
+        "label": "Ecommerce",
+        "project_name": "proj1",
+        "has_content": True,
+        "explores": [
+            {"name": "orders", "label": "Orders", "hidden": False},
+            {"name": "staging_orders", "label": "Staging Orders", "hidden": True},
+        ],
+    }
+]
+
+EXPLORE_PAYLOAD = {
+    "name": "orders",
+    "label": "Orders",
+    "description": "Order facts",
+    "fields": {
+        "dimensions": [
+            {"name": "orders.region", "label": "Region", "type": "string", "hidden": False},
+            {"name": "orders.pk", "label": "PK", "type": "number", "hidden": True},
+        ],
+        "measures": [
+            {"name": "orders.count", "label": "Count", "type": "count", "hidden": False},
+            {"name": "orders.raw_sum", "label": "Raw Sum", "type": "sum", "hidden": True},
+        ],
+        "filters": [
+            {"name": "orders.date_filter", "label": "Date Filter", "type": "date"},
+            {"name": "orders.secret_filter", "label": "Secret", "type": "string", "hidden": True},
+        ],
+        "parameters": [
+            {"name": "orders.tz", "label": "Timezone", "type": "string"},
+            {"name": "orders.debug", "label": "Debug", "type": "string", "hidden": True},
+        ],
+    },
+}
+
+
+class TestListModelsHiddenFiltering:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_hidden_explores_excluded_by_default(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models").mock(
+            return_value=httpx.Response(200, json=MODELS_PAYLOAD)
+        )
+        payload = await _call(config, "list_models", {})
+        explores = payload[0]["explores"]
+        assert [e["name"] for e in explores] == ["orders"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_include_hidden_returns_all_with_flag(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models").mock(
+            return_value=httpx.Response(200, json=MODELS_PAYLOAD)
+        )
+        payload = await _call(config, "list_models", {"include_hidden": True})
+        explores = payload[0]["explores"]
+        assert [e["name"] for e in explores] == ["orders", "staging_orders"]
+        assert explores[1]["hidden"] is True
+
+
+class TestGetModelHiddenFiltering:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_hidden_explores_excluded_by_default(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce").mock(
+            return_value=httpx.Response(200, json=MODELS_PAYLOAD[0])
+        )
+        payload = await _call(config, "get_model", {"model_name": "ecommerce"})
+        assert [e["name"] for e in payload["explores"]] == ["orders"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_include_hidden_returns_all(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce").mock(
+            return_value=httpx.Response(200, json=MODELS_PAYLOAD[0])
+        )
+        payload = await _call(
+            config, "get_model", {"model_name": "ecommerce", "include_hidden": True}
+        )
+        assert [e["name"] for e in payload["explores"]] == ["orders", "staging_orders"]
+
+
+class TestGetExploreHiddenFiltering:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_hidden_fields_excluded_by_default(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce/explores/orders").mock(
+            return_value=httpx.Response(200, json=EXPLORE_PAYLOAD)
+        )
+        payload = await _call(
+            config, "get_explore", {"model_name": "ecommerce", "explore_name": "orders"}
+        )
+        assert [d["name"] for d in payload["dimensions"]] == ["orders.region"]
+        assert [m["name"] for m in payload["measures"]] == ["orders.count"]
+        assert [f["name"] for f in payload["filters"]] == ["orders.date_filter"]
+        assert [p["name"] for p in payload["parameters"]] == ["orders.tz"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_include_hidden_returns_all_fields(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce/explores/orders").mock(
+            return_value=httpx.Response(200, json=EXPLORE_PAYLOAD)
+        )
+        payload = await _call(
+            config,
+            "get_explore",
+            {"model_name": "ecommerce", "explore_name": "orders", "include_hidden": True},
+        )
+        assert [d["name"] for d in payload["dimensions"]] == ["orders.region", "orders.pk"]
+        assert [m["name"] for m in payload["measures"]] == ["orders.count", "orders.raw_sum"]
+        assert [f["name"] for f in payload["filters"]] == [
+            "orders.date_filter",
+            "orders.secret_filter",
+        ]
+        assert [f["hidden"] for f in payload["filters"]] == [None, True]
+        assert [p["name"] for p in payload["parameters"]] == ["orders.tz", "orders.debug"]
+        assert [p["hidden"] for p in payload["parameters"]] == [None, True]
+
+
+class TestListDimensionsHiddenFiltering:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_hidden_dimensions_excluded_by_default(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce/explores/orders").mock(
+            return_value=httpx.Response(200, json=EXPLORE_PAYLOAD)
+        )
+        payload = await _call(
+            config, "list_dimensions", {"model_name": "ecommerce", "explore_name": "orders"}
+        )
+        assert [d["name"] for d in payload] == ["orders.region"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_include_hidden_returns_all(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce/explores/orders").mock(
+            return_value=httpx.Response(200, json=EXPLORE_PAYLOAD)
+        )
+        payload = await _call(
+            config,
+            "list_dimensions",
+            {"model_name": "ecommerce", "explore_name": "orders", "include_hidden": True},
+        )
+        assert [d["name"] for d in payload] == ["orders.region", "orders.pk"]
+        assert [d["hidden"] for d in payload] == [False, True]
+
+
+class TestListMeasuresHiddenFiltering:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_hidden_measures_excluded_by_default(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce/explores/orders").mock(
+            return_value=httpx.Response(200, json=EXPLORE_PAYLOAD)
+        )
+        payload = await _call(
+            config, "list_measures", {"model_name": "ecommerce", "explore_name": "orders"}
+        )
+        assert [m["name"] for m in payload] == ["orders.count"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_include_hidden_returns_all(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/lookml_models/ecommerce/explores/orders").mock(
+            return_value=httpx.Response(200, json=EXPLORE_PAYLOAD)
+        )
+        payload = await _call(
+            config,
+            "list_measures",
+            {"model_name": "ecommerce", "explore_name": "orders", "include_hidden": True},
+        )
+        assert [m["name"] for m in payload] == ["orders.count", "orders.raw_sum"]
+        assert [m["hidden"] for m in payload] == [False, True]

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -517,3 +517,54 @@ class TestRunDashboardSharesRunQueryPath:
             "run_dashboard must route its per-tile run through the shared "
             "saved-query helper that backs run_query."
         )
+
+
+class TestSearchContentHiddenFiltering:
+    """``search_content`` drops results carrying a truthy ``hidden`` flag by
+    default; ``include_hidden=True`` passes the raw result set through.
+    Items with no ``hidden`` key are always kept (most content types do not
+    carry the flag)."""
+
+    SEARCH_PAYLOAD = [
+        {"name": "Sales Dashboard", "type": "dashboard"},
+        {"name": "Staging Explore", "type": "explore", "hidden": True},
+        {"name": "Orders Explore", "type": "explore", "hidden": False},
+    ]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_hidden_results_excluded_by_default(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/content_metadata_access").mock(
+            return_value=httpx.Response(200, json=self.SEARCH_PAYLOAD)
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("search_content", {"query_string": "orders"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        assert [r["name"] for r in payload] == ["Sales Dashboard", "Orders Explore"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_include_hidden_returns_all(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/content_metadata_access").mock(
+            return_value=httpx.Response(200, json=self.SEARCH_PAYLOAD)
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "search_content", {"query_string": "orders", "include_hidden": True}
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        assert len(payload) == 3


### PR DESCRIPTION
## Summary

LookML `hidden: yes` is a curation signal — model authors hide fields and explores they don't want surfaced in the field picker. The discovery tools were inconsistent about honoring it: `get_explore`/`list_dimensions`/`list_measures` hard-filtered hidden dimensions and measures with no override, while `list_models`/`get_model` leaked hidden explores, `get_explore` leaked hidden filter/parameter fields, and `search_content` passed raw results through untouched.

This PR makes one consistent policy: **hidden content is excluded by default, and every discovery tool accepts `include_hidden=true` to opt back in.**

## Changes

- Shared `_filter_hidden` helper and `IncludeHidden` annotated argument in `tools/_helpers.py`
- `list_models` / `get_model`: hidden explores filtered by default; `list_models` now surfaces the `hidden` flag per explore
- `get_explore`: existing dimension/measure filtering becomes conditional and is extended to filter and parameter fields
- `list_dimensions` / `list_measures`: existing filtering becomes conditional
- `search_content`: results with a truthy `hidden` flag are dropped by default; items without the key always pass through
- Tool descriptions document the default behavior

## Tests

- New `tests/test_explore_tools.py` — first test coverage for the explore group; pins both default-filtered and `include_hidden=true` paths for all five tools
- `search_content` hidden-filtering cases added to `tests/test_query_tools.py`
- `ruff format`, `ruff check`, `pyright`, and the full suite (483 tests) are green

## Notes

`hidden` is not a security boundary — the Looker API serves hidden items to any caller regardless of this flag. This change only aligns the MCP discovery surface with the model author's curation, with a per-call escape hatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery and search tools now exclude LookML/content items marked hidden by default; an optional include_hidden flag returns hidden items when requested
* **Tests**
  * Added test suites validating default hidden-item filtering and include_hidden behavior across discovery and search tools
* **Documentation**
  * Changelog updated to document hidden-content filtering and the include_hidden option
<!-- end of auto-generated comment: release notes by coderabbit.ai -->