### PR TITLE
feat(git): add reset_git_branch_to_remote and update_git_branch tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`reset_git_branch_to_remote` — force-push recovery primitive for
+  per-user dev workspaces.** Wraps `POST /projects/{id}/reset_to_remote`
+  (fetch + hard reset of the current dev branch to its remote HEAD) in a
+  dev-mode session. This is the only operation that recovers a dev
+  workspace after a force-push has rewritten branch history: the IDE's
+  "Pull Remote Changes" merges the stale local commit with the new remote
+  and mass-conflicts, `reset_to_production` resets to the wrong base, and
+  `switch_git_branch` checks out the cached local ref without fetching.
+  Requires `confirm=True` (the target user's uncommitted IDE edits are
+  discarded) and returns before/after `{name, ref, remote_ref}` for
+  verification. Combine with `act_as_user` to repair another developer's
+  clone — Looker dev workspaces are per-user, so resetting one user's
+  clone does nothing for any other user's.
+- **`update_git_branch` — hard-pin a branch to a specific ref.** Wraps
+  `PUT /projects/{id}/git_branch` with `{name, ref}`; the deterministic
+  primitive for CI sync (pin a dev workspace to the exact SHA of a push
+  event). Carries the same `confirm=True` guard since the target user's
+  local branch position is discarded.
+
 ### Changed
 
 - **Discovery tools now exclude LookML `hidden` content by default, with a

--- a/src/looker_mcp_server/tools/git.py
+++ b/src/looker_mcp_server/tools/git.py
@@ -292,6 +292,131 @@ def register_git_tools(server: FastMCP, client: LookerClient) -> None:
         except Exception as e:
             return format_api_error("reset_to_production", e)
 
+    @server.tool(
+        description=(
+            "Hard-reset the current dev branch to its remote HEAD (fetch + "
+            "reset). This is the recovery primitive after a force-push has "
+            "rewritten the branch's history: the IDE's 'Pull Remote Changes' "
+            "merges and conflicts, while this discards the local ref and "
+            "uncommitted edits and makes the dev workspace match origin. "
+            "Operates on the calling user's per-user dev workspace — pass "
+            "act_as_user to repair another developer's clone. Requires "
+            "confirm=True because uncommitted IDE edits are lost. Returns "
+            "before/after branch state for verification."
+        ),
+    )
+    async def reset_git_branch_to_remote(
+        project_id: Annotated[str, "LookML project ID"],
+        confirm: Annotated[
+            bool, "Must be True; prevents accidental data loss from stale tool calls"
+        ] = False,
+        act_as_user: ActAsUser = None,
+    ) -> str:
+        if not confirm:
+            return json.dumps(
+                {
+                    "error": "Confirmation required.",
+                    "hint": (
+                        "This operation discards the target user's local ref "
+                        "and uncommitted dev-workspace edits on the currently "
+                        "checked-out branch, resetting it to the remote HEAD. "
+                        "Re-issue with confirm=True to proceed."
+                    ),
+                },
+                indent=2,
+            )
+
+        ctx = client.build_context(
+            "reset_git_branch_to_remote",
+            "git",
+            {"project_id": project_id, "act_as_user": act_as_user},
+        )
+
+        def _branch_state(branch: Any) -> dict[str, Any]:
+            return {
+                "name": branch.get("name"),
+                "ref": branch.get("ref"),
+                "remote_ref": branch.get("remote_ref"),
+            }
+
+        try:
+            async with client.session(ctx, dev_mode=True) as session:
+                before = await session.get(f"/projects/{_path_seg(project_id)}/git_branch")
+                await session.post(f"/projects/{_path_seg(project_id)}/reset_to_remote")
+                after = await session.get(f"/projects/{_path_seg(project_id)}/git_branch")
+                return json.dumps(
+                    {
+                        "reset": True,
+                        "project_id": project_id,
+                        "before": _branch_state(before),
+                        "after": _branch_state(after),
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("reset_git_branch_to_remote", e)
+
+    @server.tool(
+        description=(
+            "Update a Git branch in a LookML project to point at a specific "
+            "ref (branch name + commit SHA or ref). This is a hard pin — the "
+            "deterministic-sync primitive for CI (e.g. pin the dev workspace "
+            "to the exact SHA of a push event) and for repairing a branch "
+            "whose local ref has diverged from where it should be. Operates "
+            "on the calling user's per-user dev workspace — pass act_as_user "
+            "to target another developer's clone. Requires confirm=True "
+            "because the target user's local branch position (and any "
+            "commits not reachable from the new ref) is discarded."
+        ),
+    )
+    async def update_git_branch(
+        project_id: Annotated[str, "LookML project ID"],
+        branch_name: Annotated[str, "Name of the branch to update"],
+        ref: Annotated[str, "Git ref or commit SHA to point the branch at"],
+        confirm: Annotated[
+            bool, "Must be True; prevents accidental data loss from stale tool calls"
+        ] = False,
+        act_as_user: ActAsUser = None,
+    ) -> str:
+        if not confirm:
+            return json.dumps(
+                {
+                    "error": "Confirmation required.",
+                    "hint": (
+                        "This operation hard-pins the branch to the given ref, "
+                        "discarding the target user's current local branch "
+                        "position. Re-issue with confirm=True to proceed."
+                    ),
+                },
+                indent=2,
+            )
+
+        ctx = client.build_context(
+            "update_git_branch",
+            "git",
+            {
+                "project_id": project_id,
+                "branch_name": branch_name,
+                "act_as_user": act_as_user,
+            },
+        )
+        try:
+            async with client.session(ctx, dev_mode=True) as session:
+                branch = await session.put(
+                    f"/projects/{_path_seg(project_id)}/git_branch",
+                    body={"name": branch_name, "ref": ref},
+                )
+                return json.dumps(
+                    {
+                        "name": branch.get("name") if branch else branch_name,
+                        "ref": branch.get("ref") if branch else ref,
+                        "remote_ref": branch.get("remote_ref") if branch else None,
+                    },
+                    indent=2,
+                )
+        except Exception as e:
+            return format_api_error("update_git_branch", e)
+
     # ── Deploy keys ──────────────────────────────────────────────────
 
     @server.tool(

--- a/tests/test_git_tools.py
+++ b/tests/test_git_tools.py
@@ -90,6 +90,8 @@ EXPECTED_GIT_TOOLS = {
     "delete_git_branch",
     "deploy_to_production",
     "reset_to_production",
+    "reset_git_branch_to_remote",
+    "update_git_branch",
     "get_git_deploy_key",
     "create_git_deploy_key",
     "list_git_connection_tests",
@@ -670,3 +672,148 @@ class TestProjectIdPathEncoding:
             assert "my%20project" in captured["raw_path"]
         finally:
             await looker_client.close()
+
+
+class TestResetGitBranchToRemote:
+    """``reset_git_branch_to_remote`` is the force-push recovery primitive:
+    hard-reset the current dev branch to its remote HEAD (fetch + reset).
+    It discards the target user's uncommitted IDE edits, so it requires
+    ``confirm=True`` and reports before/after branch state for verification."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unconfirmed_returns_refusal_without_api_calls(self, config):
+        _mock_login_logout()
+        reset_route = respx.post(f"{API_URL}/projects/proj1/reset_to_remote").mock(
+            return_value=httpx.Response(204)
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp, "reset_git_branch_to_remote", {"project_id": "proj1"}
+            )()
+            assert "error" in payload
+            assert not reset_route.called, "refusal must short-circuit before any API call"
+            assert not respx.calls, (
+                "refusal must short-circuit before ANY API traffic — "
+                "including login and the dev-mode session PATCH"
+            )
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_confirmed_resets_and_returns_before_after(self, config):
+        _mock_login_logout()
+        stale = {"name": "feature-x", "ref": "a592f91", "remote_ref": "f60eb12"}
+        fresh = {"name": "feature-x", "ref": "f60eb12", "remote_ref": "f60eb12"}
+        branch_route = respx.get(f"{API_URL}/projects/proj1/git_branch").mock(
+            side_effect=[httpx.Response(200, json=stale), httpx.Response(200, json=fresh)]
+        )
+        reset_route = respx.post(f"{API_URL}/projects/proj1/reset_to_remote").mock(
+            return_value=httpx.Response(204)
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "reset_git_branch_to_remote",
+                {"project_id": "proj1", "confirm": True},
+            )()
+        finally:
+            await looker_client.close()
+
+        assert reset_route.called
+        assert branch_route.call_count == 2, "must capture branch state before AND after"
+        assert payload["reset"] is True
+        assert payload["before"] == {
+            "name": "feature-x",
+            "ref": "a592f91",
+            "remote_ref": "f60eb12",
+        }
+        assert payload["after"] == {
+            "name": "feature-x",
+            "ref": "f60eb12",
+            "remote_ref": "f60eb12",
+        }
+
+        # The reset must run in the dev workspace — without the session
+        # PATCH it would target production and 422.
+        patched = [
+            c
+            for c in respx.calls
+            if c.request.method == "PATCH" and "/session" in str(c.request.url)
+        ]
+        assert patched, "reset_git_branch_to_remote must switch the session to dev mode"
+
+
+class TestUpdateGitBranch:
+    """``update_git_branch`` pins a branch to a specific ref via
+    ``PUT /projects/{id}/git_branch`` with ``{name, ref}`` — the
+    deterministic-sync primitive (e.g. CI pinning to an event SHA).
+    Equally destructive to the target user's local branch position, so it
+    carries the same ``confirm=True`` guard."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_unconfirmed_returns_refusal_without_api_calls(self, config):
+        _mock_login_logout()
+        put_route = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(200, json={"name": "feature-x", "ref": "f60eb12"})
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "update_git_branch",
+                {"project_id": "proj1", "branch_name": "feature-x", "ref": "f60eb12"},
+            )()
+            assert "error" in payload
+            assert not put_route.called, "refusal must short-circuit before any API call"
+            assert not respx.calls, (
+                "refusal must short-circuit before ANY API traffic — "
+                "including login and the dev-mode session PATCH"
+            )
+        finally:
+            await looker_client.close()
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_confirmed_puts_name_and_ref(self, config):
+        _mock_login_logout()
+        put_route = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
+            return_value=httpx.Response(
+                200, json={"name": "feature-x", "ref": "f60eb12", "remote_ref": "f60eb12"}
+            )
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"git"})
+        try:
+            payload = await _invoke_tool(
+                mcp,
+                "update_git_branch",
+                {
+                    "project_id": "proj1",
+                    "branch_name": "feature-x",
+                    "ref": "f60eb12",
+                    "confirm": True,
+                },
+            )()
+        finally:
+            await looker_client.close()
+
+        assert put_route.called
+        body = json.loads(put_route.calls[0].request.content.decode())
+        assert body == {"name": "feature-x", "ref": "f60eb12"}
+        assert payload["name"] == "feature-x"
+        assert payload["ref"] == "f60eb12"
+
+        # The pin must run in the dev workspace — without the session PATCH
+        # it would target production and 422.
+        session_patches = [
+            c
+            for c in respx.calls
+            if c.request.method == "PATCH" and "/session" in str(c.request.url)
+        ]
+        assert session_patches, "update_git_branch must switch the session to dev mode"
+        patch_body = json.loads(session_patches[0].request.content.decode())
+        assert patch_body == {"workspace_id": "dev"}


### PR DESCRIPTION
## Summary

Looker dev workspaces are per-user clones of the LookML project repo. After a force-push rewrites a shared branch's history, an affected developer's dev workspace cannot be recovered with the existing tool set:

- The IDE's **"Pull Remote Changes" is a merge, not a reset** — against rewritten history it merges the stale local commit with the new remote and mass-conflicts on every file changed in both histories.
- `reset_to_production` clears the dirty working tree but resets to **production**, not the branch's remote — the stale branch ref survives.
- `switch_git_branch` checks out the **cached local ref with no fetch** — it cannot see the new remote HEAD.
- `delete_git_branch` + recreate propagates the delete to origin and auto-closes the associated PR.

The only operation that recovers the workspace is Looker's `reset_to_remote` (fetch + hard reset to remote HEAD), which the server did not expose — remediation required a hand-rolled `login` → `login/{user_id}` → `PATCH /session` → `POST /projects/{id}/reset_to_remote` REST sequence. With a one-commit-per-PR amend+force-push convention this failure mode triggers on every PR iteration, for every developer with the branch checked out.

## Changes

- **`reset_git_branch_to_remote(project_id, confirm=False, act_as_user=None)`** — wraps `POST /projects/{id}/reset_to_remote` in a dev-mode session. Requires `confirm=True` (same guard pattern as `rollback_to_production`) since the target user's uncommitted IDE edits are discarded, and returns before/after `{name, ref, remote_ref}` so the caller can verify `ref == remote_ref`. Combine with `act_as_user` to repair another developer's clone.
- **`update_git_branch(project_id, branch_name, ref, confirm=False, act_as_user=None)`** — wraps `PUT /projects/{id}/git_branch` with `{name, ref}`; hard-pins a branch to a specific SHA (the deterministic primitive for CI sync). Carries the same `confirm` guard, since the target user's local branch position is discarded.

## Tests

- Registration regression set extended to require both new tools
- Unconfirmed calls return a structured refusal and are proven to short-circuit before any API call
- Confirmed reset pins the GET → POST reset → GET sequence, the before/after payload, and the dev-mode session PATCH
- Confirmed update pins the exact `{name, ref}` PUT body
- `ruff format`, `ruff check`, `pyright`, full suite (475 tests) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two git tools: recover a dev workspace branch to its remote and pin a branch to a specific ref/commit — both require explicit confirmation and return before/after branch verification data.
* **Documentation**
  * Updated changelog with usage, confirmation guard, and verification behavior for the new operations.
* **Tests**
  * Added tests validating confirmation guards, no-op on missing confirm, and before/after verification flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->