### PR TITLE
chore(release): prepare v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-06-11
+
+Two themes: git-recovery primitives for per-user dev workspaces (the
+operations needed to repair a developer's clone after a force-push rewrites
+shared-branch history), and hidden-content curation across the discovery
+tools (LookML `hidden: yes` is now honored by default, with a per-call
+`include_hidden` escape hatch).
+
 ### Added
 
 - **`reset_git_branch_to_remote` — force-push recovery primitive for
@@ -1034,7 +1042,8 @@ infrastructure / deployment-posture release, not a tool surface expansion.
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
-[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.21.0...HEAD
+[0.21.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.17.0...v0.18.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.20.0"
+version = "0.21.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/src/looker_mcp_server/__init__.py
+++ b/src/looker_mcp_server/__init__.py
@@ -1,3 +1,9 @@
 """Looker MCP Server — Full-featured MCP server for the Looker API."""
 
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("looker-mcp-server")
+except PackageNotFoundError:
+    # Running from a source tree without an installed distribution.
+    __version__ = "0.0.0+unknown"

--- a/src/looker_mcp_server/server.py
+++ b/src/looker_mcp_server/server.py
@@ -184,18 +184,13 @@ def create_server(
     # guidance. ``stdio`` transport doesn't need this route (no gateway,
     # no discovery flow).
     if config.is_http():
-        from importlib import metadata
-
+        from . import __version__
         from .introspect import register_introspect_endpoint
 
-        try:
-            pkg_version = metadata.version("looker-mcp-server")
-        except metadata.PackageNotFoundError:
-            pkg_version = "0.0.0"
         register_introspect_endpoint(
             mcp,
             server_name="looker-mcp-server",
-            server_version=pkg_version,
+            server_version=__version__,
         )
 
     # ── Register tool groups ─────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Cut v0.21.0.

## Highlights

**Added** — git-recovery primitives for per-user dev workspaces:
- `reset_git_branch_to_remote`: fetch + hard reset of the current dev branch to its remote HEAD; the force-push recovery primitive. `confirm=True` guard, before/after branch state in the response.
- `update_git_branch`: hard-pin a branch to a specific ref via `PUT /git_branch` with `{name, ref}`; deterministic CI sync. Same confirm guard.

**Changed** — discovery tools (`list_models`, `get_model`, `get_explore`, `list_dimensions`, `list_measures`, `search_content`) now exclude LookML `hidden` content by default, with a per-call `include_hidden` escape hatch.

See the `[0.21.0]` CHANGELOG section for full detail.

## Release mechanics

After merge, tagging the merge commit `v0.21.0` triggers the release workflow (test matrix → PyPI publish).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Version 0.21.0 Release

* **New Features**
  * Added git recovery and branch-repair primitives for force-push scenarios
  * Discovery tooling now respects hidden items by default, with an escape hatch to include them

* **Chores**
  * Package updated to v0.21.0 and release notes added

* **Bug Fixes**
  * Runtime now reports package version dynamically with a safe fallback when metadata is unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->