### PR TITLE
feat(query): surface explore link and full Query/Look metadata

### DIFF
--- a/src/looker_mcp_server/tools/query.py
+++ b/src/looker_mcp_server/tools/query.py
@@ -27,6 +27,25 @@ from ._helpers import (
 _TEXT_PLAIN_FORMATS = frozenset({"csv", "txt", "sql"})
 
 
+async def _run_path(
+    session: LookerSession,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    result_format: str = "json",
+) -> Any:
+    """Execute a Looker ``/run`` request, routing text/plain formats correctly.
+
+    Looker returns ``text/plain`` for the ``_TEXT_PLAIN_FORMATS`` (csv, txt,
+    sql); calling ``session.get`` on those routes through ``response.json()``
+    and raises ``Expecting value``. JSON formats go through ``session.get``.
+    Single source of truth for every ``/run`` caller so the routing can't drift.
+    """
+    if result_format in _TEXT_PLAIN_FORMATS:
+        return await session.get_text(path, params=params)
+    return await session.get(path, params=params)
+
+
 async def _execute_saved_query(
     session: LookerSession,
     query_id: str,
@@ -61,11 +80,28 @@ async def _execute_saved_query(
         if value is not None:
             params[key] = "true" if value else "false"
 
-    path = f"/queries/{query_id}/run/{result_format}"
-    request_params = params or None
-    if result_format in _TEXT_PLAIN_FORMATS:
-        return await session.get_text(path, params=request_params)
-    return await session.get(path, params=request_params)
+    return await _run_path(
+        session,
+        f"/queries/{query_id}/run/{result_format}",
+        params=params or None,
+        result_format=result_format,
+    )
+
+
+def _run_payload(result: Any, result_format: str = "json") -> dict[str, Any]:
+    """Build the data portion of a run response from a ``/run`` result.
+
+    Shared by every run tool so the data envelope can't drift: JSON list
+    results carry a ``row_count``; text/plain results (csv, txt) carry the
+    ``format`` they were requested in; ``json_detail`` dicts pass straight
+    through under ``data``. The metadata block (``query`` / ``look``) is merged
+    in by each tool on top of this.
+    """
+    if isinstance(result, list):
+        return {"row_count": len(result), "data": result}
+    if isinstance(result, str):
+        return {"format": result_format, "data": result}
+    return {"data": result}
 
 
 def register_query_tools(server: FastMCP, client: LookerClient) -> None:
@@ -146,13 +182,18 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
                     query_def = await session.post("/queries", body=body)
                     query_id = query_def["id"]
 
-                    result = await session.get(f"/queries/{query_id}/run/{result_format}")
-                    if isinstance(result, list):
-                        return json.dumps(
-                            {"row_count": len(result), "data": result},
-                            indent=2,
-                        )
-                    return json.dumps(result, indent=2)
+                    result = await _run_path(
+                        session,
+                        f"/queries/{query_id}/run/{result_format}",
+                        result_format=result_format,
+                    )
+                    # ``query_def`` is the full Query object Looker returns from
+                    # POST /queries — it carries share_url / expanded_share_url /
+                    # url (the explore link). Surface it instead of dropping it.
+                    return json.dumps(
+                        {"query": query_def, **_run_payload(result, result_format)},
+                        indent=2,
+                    )
         except Exception as e:
             return format_api_error("query", e)
 
@@ -217,7 +258,9 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
                     # ``Expecting value: line 1 column 1 (char 0)``. Mirrors the
                     # pattern used by the git deploy-key tools.
                     result = await session.get_text(f"/queries/{query_id}/run/sql")
-                    return json.dumps({"sql": result}, indent=2)
+                    # Surface the Query object (explore link + slug) alongside
+                    # the compiled SQL rather than dropping it.
+                    return json.dumps({"query": query_def, "sql": result}, indent=2)
         except Exception as e:
             return format_api_error("query_sql", e)
 
@@ -262,16 +305,20 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
             effective_dev_mode = dev_mode or branch is not None
             async with client.session(ctx, dev_mode=effective_dev_mode) as session:
                 async with _maybe_use_branch(session, project_id, branch):
-                    result = await session.get(
+                    # The /run endpoint returns only rows; fetch the Look object
+                    # for its metadata (short_url / public_url + the embedded
+                    # Query's explore link).
+                    look_def = await session.get(f"/looks/{look_id}")
+                    result = await _run_path(
+                        session,
                         f"/looks/{look_id}/run/{result_format}",
                         params={"limit": limit},
+                        result_format=result_format,
                     )
-                    if isinstance(result, list):
-                        return json.dumps(
-                            {"row_count": len(result), "data": result},
-                            indent=2,
-                        )
-                    return json.dumps(result, indent=2)
+                    return json.dumps(
+                        {"look": look_def, **_run_payload(result, result_format)},
+                        indent=2,
+                    )
         except Exception as e:
             return format_api_error("run_look", e)
 
@@ -349,6 +396,10 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
             effective_dev_mode = dev_mode or branch is not None
             async with client.session(ctx, dev_mode=effective_dev_mode) as session:
                 async with _maybe_use_branch(session, project_id, branch):
+                    # run_query is given an existing id, so the explore link
+                    # isn't in hand — fetch the Query object to recover it.
+                    # The /run endpoint returns only data rows.
+                    query_def = await session.get(f"/queries/{query_id}")
                     result = await _execute_saved_query(
                         session,
                         query_id,
@@ -359,19 +410,10 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
                         server_table_calcs=server_table_calcs,
                         cache=cache,
                     )
-                    if isinstance(result, list):
-                        return json.dumps(
-                            {"row_count": len(result), "data": result},
-                            indent=2,
-                        )
-                    if isinstance(result, str):
-                        # text/plain formats (csv, txt) — wrap so the
-                        # response shape is always JSON for MCP transport.
-                        return json.dumps(
-                            {"format": result_format, "data": result},
-                            indent=2,
-                        )
-                    return json.dumps(result, indent=2)
+                    return json.dumps(
+                        {"query": query_def, **_run_payload(result, result_format)},
+                        indent=2,
+                    )
         except Exception as e:
             return format_api_error("run_query", e)
 
@@ -396,6 +438,10 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
                         "title": elem.get("title") or elem.get("title_text"),
                         "type": elem.get("type"),
                     }
+                    # The tile's embedded Query carries its explore link
+                    # (share_url) — surface it instead of dropping it.
+                    if elem.get("query"):
+                        elem_info["query"] = elem["query"]
                     query_id = (elem.get("query") or {}).get("id") if elem.get("query") else None
                     result_maker = elem.get("result_maker")
                     if result_maker:
@@ -410,10 +456,14 @@ def register_query_tools(server: FastMCP, client: LookerClient) -> None:
                             elem_info["error"] = "Failed to execute element query"
                     results.append(elem_info)
 
+                # Pass the dashboard's own metadata through (minus the elements,
+                # which are returned enriched above) so it isn't dropped.
+                dashboard_meta = {k: v for k, v in dashboard.items() if k != "dashboard_elements"}
                 return json.dumps(
                     {
                         "title": dashboard.get("title"),
                         "description": dashboard.get("description"),
+                        "dashboard": dashboard_meta,
                         "element_count": len(results),
                         "elements": results,
                     },

--- a/tests/test_query_tools.py
+++ b/tests/test_query_tools.py
@@ -241,6 +241,12 @@ class TestRunQuery:
     @respx.mock
     async def test_runs_existing_query_by_id_returning_rows(self, config):
         _mock_login_logout()
+        # run_query now fetches the Query object for its explore-link metadata.
+        meta_route = respx.get(f"{API_URL}/queries/q1").mock(
+            return_value=httpx.Response(
+                200, json={"id": "q1", "share_url": "https://test.looker.com/x/q1"}
+            )
+        )
         run_route = respx.get(f"{API_URL}/queries/q1/run/json").mock(
             return_value=httpx.Response(
                 200,
@@ -269,6 +275,8 @@ class TestRunQuery:
 
         assert run_route.called, "must GET the run endpoint by ID"
         assert not create_route.called, "must NOT re-create the query via POST /queries"
+        assert meta_route.called, "must GET the Query object for its explore-link metadata"
+        assert payload["query"]["share_url"] == "https://test.looker.com/x/q1"
 
     @pytest.mark.asyncio
     @respx.mock
@@ -276,6 +284,7 @@ class TestRunQuery:
         """``result_format='csv'`` returns text/plain — must use get_text and
         wrap the raw payload in a JSON envelope."""
         _mock_login_logout()
+        respx.get(f"{API_URL}/queries/q1").mock(return_value=httpx.Response(200, json={"id": "q1"}))
         csv_body = "orders.region,orders.total\nwest,42\neast,17\n"
         respx.get(f"{API_URL}/queries/q1/run/csv").mock(
             return_value=httpx.Response(
@@ -308,6 +317,7 @@ class TestRunQuery:
         explicitly. This test pins that — a regression to httpx's default
         would silently make ``apply_formatting`` etc. no-ops."""
         _mock_login_logout()
+        respx.get(f"{API_URL}/queries/q1").mock(return_value=httpx.Response(200, json={"id": "q1"}))
         run_route = respx.get(f"{API_URL}/queries/q1/run/json").mock(
             return_value=httpx.Response(200, json=[])
         )
@@ -356,6 +366,7 @@ class TestRunQuery:
         param, so it deliberately doesn't appear here; ``limit`` is
         ``None`` by default so it's correctly omitted."""
         _mock_login_logout()
+        respx.get(f"{API_URL}/queries/q1").mock(return_value=httpx.Response(200, json={"id": "q1"}))
         run_route = respx.get(f"{API_URL}/queries/q1/run/json").mock(
             return_value=httpx.Response(200, json=[])
         )
@@ -392,6 +403,7 @@ class TestRunQuery:
         put_branch = respx.put(f"{API_URL}/projects/proj1/git_branch").mock(
             return_value=httpx.Response(200, json={"name": "feature-x"})
         )
+        respx.get(f"{API_URL}/queries/q1").mock(return_value=httpx.Response(200, json={"id": "q1"}))
         respx.get(f"{API_URL}/queries/q1/run/json").mock(
             return_value=httpx.Response(200, json=[{"orders.region": "west"}])
         )
@@ -568,3 +580,241 @@ class TestSearchContentHiddenFiltering:
         finally:
             await looker_client.close()
         assert len(payload) == 3
+
+
+class TestExploreLinkPassthrough:
+    """The query-group tools must surface the explore link — and the rest of
+    the ``Query`` / ``Look`` object Looker returns — instead of dropping it.
+
+    Looker hands back ``share_url`` / ``expanded_share_url`` / ``url`` on every
+    created ``Query``; the ``/run`` endpoints return only data rows, so the
+    metadata is read from the ``Query`` / ``Look`` object and merged into the
+    response envelope alongside the data. Existing keys (``row_count``,
+    ``data``, ``format``, ``sql``) are preserved — the metadata is additive.
+    """
+
+    QUERY_OBJ = {
+        "id": "q1",
+        "slug": "abc123def456789012345x",
+        "share_url": "https://test.looker.com/x/abc123def456789012345x",
+        "expanded_share_url": (
+            "https://test.looker.com/explore/ecommerce/orders?fields=orders.region&limit=500"
+        ),
+        "url": "/explore/ecommerce/orders?qid=abc123def456789012345x",
+        # Opaque fields are passed through verbatim too — "don't drop stuff".
+        "vis_config": {"type": "looker_grid"},
+        "can": {"run": True},
+    }
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_query_surfaces_full_query_object_with_explore_link(self, config):
+        _mock_login_logout()
+        respx.post(f"{API_URL}/queries").mock(return_value=httpx.Response(201, json=self.QUERY_OBJ))
+        respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "query",
+                    {"model": "ecommerce", "view": "orders", "fields": ["orders.region"]},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        # The full Query object is passed through verbatim — nothing dropped.
+        assert payload["query"] == self.QUERY_OBJ
+        assert payload["query"]["share_url"] == "https://test.looker.com/x/abc123def456789012345x"
+        # Data envelope preserved.
+        assert payload["row_count"] == 1
+        assert payload["data"] == [{"orders.region": "west"}]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_query_sql_surfaces_query_object_alongside_sql(self, config):
+        _mock_login_logout()
+        compiled_sql = "SELECT region FROM orders"
+        respx.post(f"{API_URL}/queries").mock(return_value=httpx.Response(201, json=self.QUERY_OBJ))
+        respx.get(f"{API_URL}/queries/q1/run/sql").mock(
+            return_value=httpx.Response(
+                200, text=compiled_sql, headers={"content-type": "text/plain"}
+            )
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "query_sql",
+                    {"model": "ecommerce", "view": "orders", "fields": ["orders.region"]},
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        assert payload["sql"] == compiled_sql
+        assert payload["query"] == self.QUERY_OBJ
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_query_fetches_and_surfaces_query_metadata(self, config):
+        _mock_login_logout()
+        # run_query takes an existing id, so it must GET the Query object to
+        # recover the explore link the run endpoint doesn't return.
+        meta_route = respx.get(f"{API_URL}/queries/q1").mock(
+            return_value=httpx.Response(200, json=self.QUERY_OBJ)
+        )
+        respx.get(f"{API_URL}/queries/q1/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("run_query", {"query_id": "q1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        assert meta_route.called, "run_query must fetch the Query object for its metadata"
+        assert payload["query"] == self.QUERY_OBJ
+        assert payload["row_count"] == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_look_surfaces_full_look_object(self, config):
+        _mock_login_logout()
+        look_obj = {
+            "id": "55",
+            "title": "Top regions",
+            "short_url": "/looks/55",
+            "public_url": "https://test.looker.com/public/look55",
+            # The Look embeds its own Query, which carries the explore link.
+            "query": {"id": "q9", "share_url": "https://test.looker.com/x/look55query"},
+        }
+        meta_route = respx.get(f"{API_URL}/looks/55").mock(
+            return_value=httpx.Response(200, json=look_obj)
+        )
+        respx.get(f"{API_URL}/looks/55/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("run_look", {"look_id": "55"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        assert meta_route.called, "run_look must fetch the Look object for its metadata"
+        assert payload["look"] == look_obj
+        assert payload["look"]["query"]["share_url"] == "https://test.looker.com/x/look55query"
+        assert payload["row_count"] == 1
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_dashboard_surfaces_per_tile_explore_link(self, config):
+        _mock_login_logout()
+        respx.get(f"{API_URL}/dashboards/d1").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "title": "Ops",
+                    "description": None,
+                    "slug": "ops-dash",
+                    "dashboard_elements": [
+                        {
+                            "title": "Top regions",
+                            "type": "vis",
+                            "query": {
+                                "id": "qA",
+                                "share_url": "https://test.looker.com/x/tileA",
+                            },
+                        }
+                    ],
+                },
+            )
+        )
+        respx.get(f"{API_URL}/queries/qA/run/json").mock(
+            return_value=httpx.Response(200, json=[{"orders.region": "west"}])
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool("run_dashboard", {"dashboard_id": "d1"})
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        elem = payload["elements"][0]
+        # The tile's embedded Query (with its explore link) is no longer dropped.
+        assert elem["query"]["share_url"] == "https://test.looker.com/x/tileA"
+        assert elem["row_count"] == 1
+        # Dashboard-level metadata is surfaced, minus the re-nested elements.
+        assert payload["dashboard"]["slug"] == "ops-dash"
+        assert "dashboard_elements" not in payload["dashboard"]
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_query_csv_routes_through_text_plain(self, config):
+        """``query`` advertises csv/txt; Looker returns those as text/plain, so
+        the run must route through get_text — session.get would JSON-decode the
+        body and fail. The metadata block is still surfaced alongside the text."""
+        _mock_login_logout()
+        respx.post(f"{API_URL}/queries").mock(return_value=httpx.Response(201, json=self.QUERY_OBJ))
+        csv_body = "orders.region\nwest\n"
+        respx.get(f"{API_URL}/queries/q1/run/csv").mock(
+            return_value=httpx.Response(200, text=csv_body, headers={"content-type": "text/plain"})
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "query",
+                    {
+                        "model": "ecommerce",
+                        "view": "orders",
+                        "fields": ["orders.region"],
+                        "result_format": "csv",
+                    },
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        assert payload["format"] == "csv"
+        assert payload["data"] == csv_body
+        assert payload["query"] == self.QUERY_OBJ
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_run_look_csv_routes_through_text_plain(self, config):
+        """``run_look`` advertises csv/txt — same text/plain routing as query."""
+        _mock_login_logout()
+        look_obj = {"id": "55", "short_url": "/looks/55"}
+        respx.get(f"{API_URL}/looks/55").mock(return_value=httpx.Response(200, json=look_obj))
+        csv_body = "orders.region\nwest\n"
+        respx.get(f"{API_URL}/looks/55/run/csv").mock(
+            return_value=httpx.Response(200, text=csv_body, headers={"content-type": "text/plain"})
+        )
+        mcp, looker_client = create_server(config, enabled_groups={"query"})
+        try:
+            async with Client(mcp) as mcp_client:
+                result = await mcp_client.call_tool(
+                    "run_look", {"look_id": "55", "result_format": "csv"}
+                )
+                content = result.content[0]
+                assert isinstance(content, TextContent)
+                payload = json.loads(content.text)
+        finally:
+            await looker_client.close()
+        assert payload["format"] == "csv"
+        assert payload["data"] == csv_body
+        assert payload["look"] == look_obj


### PR DESCRIPTION
The query-group tools discarded the Query/Look object Looker returns,
dropping the explore link (share_url / expanded_share_url / url) that
comes back with every created query.

- query / query_sql: return the full Query object (already fetched from
  POST /queries) alongside the data / compiled SQL
- run_query / run_look: fetch the Query / Look object (GET /queries/{id},
  GET /looks/{id}) to recover the metadata the /run endpoints omit
- run_dashboard: surface each tile's embedded Query (its share_url) and
  the dashboard's own metadata

Add a shared _run_payload() helper so the data envelope (row_count /
format / data) stays consistent across the run tools. Changes are
additive — existing keys (row_count, data, format, sql) are preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Query and look execution now returns enriched metadata alongside results, including full Query/Look details (with share links).
  * Dashboard execution preserves per-tile query information and surfaces dashboard-level metadata in a cleaner top-level payload.
* **Improvements**
  * Result output is standardized across supported formats, including consistent structure for plain-text (CSV/TXT/SQL) responses.
* **Tests**
  * Expanded coverage to validate enriched metadata and standardized formatting across query, run, look, and dashboard scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->