### PR TITLE
chore(release): prepare v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-23
+
+Surface the Looker explore link — and the rest of the `Query`/`Look` object
+Looker returns — across the query-group tools instead of discarding it, plus a
+text/plain routing fix for `csv`/`txt` output.
+
+### Added
+
+- **The query-group tools now return the explore link and full Query/Look
+  metadata alongside the data.** Looker hands back `share_url`,
+  `expanded_share_url`, and `url` on every created query, but the run tools
+  previously returned only data rows and dropped the rest. Now `query` and
+  `query_sql` include the full `Query` object they already create from
+  `POST /queries`; `run_query` and `run_look` fetch the `Query`/`Look` object
+  (`GET /queries/{id}`, `GET /looks/{id}`) to recover the metadata the `/run`
+  endpoints omit; and `run_dashboard` surfaces each tile's embedded `Query`
+  (with its `share_url`) plus the dashboard's own metadata. Existing response
+  keys (`row_count`, `data`, `format`, `sql`) are preserved — the metadata is
+  additive.
+
+### Fixed
+
+- **`query` and `run_look` now route `csv`/`txt` output through `get_text`.**
+  Both tools advertised `csv`/`txt` but always called `session.get`, which
+  decodes the response as JSON and fails on Looker's `text/plain` payload. The
+  format-aware routing is now a shared `_run_path` helper (also adopted by
+  `_execute_saved_query`) so it can't drift between call sites.
+
 ## [0.21.0] - 2026-06-11
 
 Two themes: git-recovery primitives for per-user dev workspaces (the
@@ -1042,7 +1070,8 @@ infrastructure / deployment-posture release, not a tool surface expansion.
 - MCP-level bearer token authentication
 - ASGI header capture middleware for per-request identity
 
-[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/ultrathink-solutions/looker-mcp-server/compare/v0.18.0...v0.19.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "looker-mcp-server"
-version = "0.21.0"
+version = "0.22.0"
 description = "A Model Context Protocol (MCP) server for the Looker API with full tool coverage, OAuth pass-through, and user impersonation support."
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ wheels = [
 
 [[package]]
 name = "looker-mcp-server"
-version = "0.21.0"
+version = "0.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Prepares the **v0.22.0** release.

Bumps `0.21.0 → 0.22.0` (`pyproject.toml` + `uv.lock`) and adds the CHANGELOG entry for the only change merged since v0.21.0: #54 — surface the Looker explore link / full `Query`/`Look` metadata across the query-group tools, plus the `csv`/`txt` text/plain routing fix.

**After merge:** tag `v0.22.0` on the merge commit and push it to trigger the PyPI publish — `.github/workflows/release.yml` fires on `v*` tags (`uv build` + `uv publish`).

Verified: `uv lock --check` clean, `uv sync --locked --dev` succeeds, 494 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query-group tools now return Looker explore links and complete query/look metadata alongside results.

* **Bug Fixes**
  * Fixed CSV/TXT output routing for query and run_look endpoints to use correct text handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->